### PR TITLE
Be more forgiving about invalid versions

### DIFF
--- a/docs/version.rst
+++ b/docs/version.rst
@@ -86,8 +86,11 @@ Reference
 
     This class abstracts handling of a project's versions if they are not
     compatible with the scheme defined in `PEP 440`_. It implements a similar
-    interface to that of :class:`Version` however it is considered unorderable
-    and many of the comparison types are not implemented.
+    interface to that of :class:`Version`.
+
+    This class implements the previous de facto sorting algorithm used by
+    setuptools, however it will always sort as less than a :class:`Version`
+    instance.
 
     :param str version: The string representation of a version which will be
                         used as is.

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -454,8 +454,12 @@ class TestVersion:
 
         assert getattr(operator, op)(Version("1"), other) is expected
 
+    def test_compare_legacyversion_version(self):
+        result = sorted([Version("0"), LegacyVersion("1")])
+        assert result == [LegacyVersion("1"), Version("0")]
 
-LEGACY_VERSIONS = ["foobar", "a cat is fine too", "lolwut", "1-0"]
+
+LEGACY_VERSIONS = ["foobar", "a cat is fine too", "lolwut", "1-0", "2.0-a1"]
 
 
 class TestLegacyVersion:
@@ -1125,3 +1129,12 @@ class TestSpecifier:
         else:
             # Identity comparisons only support the plain string form
             assert version not in spec
+
+    @pytest.mark.parametrize(
+        "version",
+        VERSIONS + LEGACY_VERSIONS,
+    )
+    def test_empty_specifier(self, version):
+        spec = Specifier()
+
+        assert version in spec


### PR DESCRIPTION
- Allow sorting `LegacyVersion` and `Version` instances.
- Allow `Specifier()` to match anything, even `LegacyVersion`s

This PR stems from real world experience trying to integrate with setuptools. While being strict like this works really well when you're attempting to pick a version to install it does not however work when you're trying to apply them to a list of things which are already installed on the filesystem or when you _need_ to sort a list of versions and you cannot filter (such as PyPI).

In this PR a `LegacyVersion` will _always_ sort as less than a `Version`, no matter what their values are. This will ensure that `pip install foo` does not get a non PEP 440 version unless no other options are available.

If someone wishes to filter out instances of `LegacyVersion` which previously this library required, they can still do by simply doing:

``` python
from packaging.version import Version, LegacyVersion, InvalidVersion

def parse(version):
    try:
        return Version(version)
    except InvalidVersion:
        return LegacyVersion(version)

versions = [
    v for v in (parse(v) for v in ["dog", "cat", "1.0", "2.0"])
    if isinstance(v, Version)
]
```
