### PR TITLE
Ensure normalized versions uses in less than and greater than

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,9 @@ Changelog
 
 .. note:: This version is not yet released and is under active development.
 
+* Ensure that versions are normalized before comparison when used in a
+  specifier with a less than (``<``) or greater than (``>``) operator.
+
 
 14.3 - 2014-11-19
 ~~~~~~~~~~~~~~~~~

--- a/packaging/specifiers.py
+++ b/packaging/specifiers.py
@@ -461,16 +461,18 @@ class Specifier(_IndividualSpecifier):
         # Less than are defined as exclusive operators, this implies that
         # pre-releases do not match for the same series as the spec. This is
         # implemented by making <V imply !=V.*.
-        return (prospective < Version(spec)
-                and self._get_operator("!=")(prospective, spec + ".*"))
+        spec = Version(spec)
+        return (prospective < spec
+                and self._get_operator("!=")(prospective, str(spec) + ".*"))
 
     @_require_version_compare
     def _compare_greater_than(self, prospective, spec):
         # Greater than are defined as exclusive operators, this implies that
         # pre-releases do not match for the same series as the spec. This is
         # implemented by making >V imply !=V.*.
-        return (prospective > Version(spec)
-                and self._get_operator("!=")(prospective, spec + ".*"))
+        spec = Version(spec)
+        return (prospective > spec
+                and self._get_operator("!=")(prospective, str(spec) + ".*"))
 
     def _compare_arbitrary(self, prospective, spec):
         return str(prospective).lower() == str(spec).lower()

--- a/tests/test_specifiers.py
+++ b/tests/test_specifiers.py
@@ -392,6 +392,9 @@ class TestSpecifier:
                 ("2!1.0", ">=2.0"),
                 ("1.0", "<2!0.1"),
                 ("2!1.0", ">2.0"),
+
+                # Test some normalization rules
+                ("2.0.5", ">2.0dev"),
             ]
         ]
         +


### PR DESCRIPTION
The less than and greater than operators of `Specifier` were not correctly ensuring that they normalized the version before doing any comparisons. This caused things like `2.0.5` to not be included as part of `2.0dev` while it was included in `2.0.dev`.
