### PR TITLE
README.rst: Add link to docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,6 +7,8 @@ Core utilities for Python packages
 Discussion
 ----------
 
+Check out the `documentation`_. 
+
 If you run into bugs, you can file them in our `issue tracker`_.
 
 You can also join ``#pypa`` on Freenode to ask questions or get involved.


### PR DESCRIPTION
I believe that this will fix #23 since:

```
[marca@marca-mac2 packaging]$ rst2html.py README.rst --strict
README.rst:15: (INFO/1) Hyperlink target "documentation" is not referenced.
Exiting due to level-1 (INFO) system message.
```
