### PR TITLE
Simplfy the rules for > and <

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,9 @@ Changelog
 * Add ``Version().is_postrelease`` and ``LegacyVersion().is_postrelease`` to
   make it easy to determine if a release is a post release.
 
+* Add ``Version().base_version`` and ``LegacyVersion().base_version`` to make
+  it easy to get the public version without any pre or post release markers.
+
 
 14.5 - 2014-12-17
 ~~~~~~~~~~~~~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,9 @@ Changelog
 
 .. note:: This version is not yet released and is under active development.
 
+* Add ``Version().is_postrelease`` and ``LegacyVersion().is_postrelease`` to
+  make it easy to determine if a release is a post release.
+
 
 14.5 - 2014-12-17
 ~~~~~~~~~~~~~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,10 @@ Changelog
 * Add ``Version().base_version`` and ``LegacyVersion().base_version`` to make
   it easy to get the public version without any pre or post release markers.
 
+* Support the update to PEP 440 which removed the implied ``!=V.*`` when using
+  either ``>V`` or ``<V`` and which instead special cased the handling of
+  pre-releases, post-releases, and local versions when using ``>V`` or ``<V``.
+
 
 14.5 - 2014-12-17
 ~~~~~~~~~~~~~~~~~

--- a/docs/version.rst
+++ b/docs/version.rst
@@ -60,6 +60,12 @@ Reference
 
         A string representing the public version portion of this ``Version()``.
 
+    .. attribute:: base_version
+
+        A string representing the base version of this :class:`Version`
+        instance. The base version is the public version of the project without
+        any pre or post release markers.
+
     .. attribute:: local
 
         A string representing the local version portion of this ``Version()``
@@ -93,6 +99,12 @@ Reference
 
         A string representing the public version portion of this
         :class:`LegacyVersion`. This will always be the entire version string.
+
+    .. attribute:: base_version
+
+        A string representing the base version portion of this
+        :class:`LegacyVersion` instance. This will always be the entire version
+        string.
 
     .. attribute:: local
 

--- a/docs/version.rst
+++ b/docs/version.rst
@@ -29,6 +29,10 @@ Usage
     Traceback (most recent call last):
         ...
     InvalidVersion: Invalid version: 'french toast'
+    >>> Version("1.0").is_postrelease
+    False
+    >>> Version("1.0.post0").is_postrelease
+    True
 
 
 Reference
@@ -66,6 +70,11 @@ Reference
         A boolean value indicating whether this :class:`Version` instance
         represents a prerelease or a final release.
 
+    .. attribute:: is_postrelease
+
+        A boolean value indicating whether this :class:`Version` instance
+        represents a post-release.
+
 
 .. class:: LegacyVersion(version)
 
@@ -97,6 +106,13 @@ Reference
         represents a prerelease or a final release. Since without `PEP 440`_
         there is no concept of pre or final releases this will always be
         `False` and exists for compatibility with :class:`Version`.
+
+    .. attribute:: is_postrelease
+
+        A boolean value indicating whether this :class:`LegacyVersion`
+        represents a post-release. Since without `PEP 440`_ there is no concept
+        of post-releases this will always be ``False`` and exists for
+        compatibility with :class:`Version`.
 
 
 .. exception:: InvalidVersion

--- a/packaging/version.py
+++ b/packaging/version.py
@@ -96,6 +96,10 @@ class LegacyVersion(_BaseVersion):
         return self._version
 
     @property
+    def base_version(self):
+        return self._version
+
+    @property
     def local(self):
         return None
 
@@ -272,6 +276,19 @@ class Version(_BaseVersion):
     @property
     def public(self):
         return str(self).split("+", 1)[0]
+
+    @property
+    def base_version(self):
+        parts = []
+
+        # Epoch
+        if self._version.epoch != 0:
+            parts.append("{0}!".format(self._version.epoch))
+
+        # Release segment
+        parts.append(".".join(str(x) for x in self._version.release))
+
+        return "".join(parts)
 
     @property
     def local(self):

--- a/packaging/version.py
+++ b/packaging/version.py
@@ -103,6 +103,10 @@ class LegacyVersion(_BaseVersion):
     def is_prerelease(self):
         return False
 
+    @property
+    def is_postrelease(self):
+        return False
+
 
 _legacy_version_component_re = re.compile(
     r"(\d+ | [a-z]+ | \.| -)", re.VERBOSE,
@@ -278,6 +282,10 @@ class Version(_BaseVersion):
     @property
     def is_prerelease(self):
         return bool(self._version.dev or self._version.pre)
+
+    @property
+    def is_postrelease(self):
+        return bool(self._version.post)
 
 
 def _parse_letter_version(letter, number):

--- a/tests/test_specifiers.py
+++ b/tests/test_specifiers.py
@@ -371,10 +371,14 @@ class TestSpecifier:
                 # Test the greater than operation
                 ("3", ">2"),
                 ("2.1", ">2.0"),
+                ("2.0.1", ">2"),
+                ("2.1.post1", ">2"),
+                ("2.1+local.version", ">2"),
 
                 # Test the less than operation
                 ("1", "<2"),
                 ("2.0", "<2.1"),
+                ("2.0.dev0", "<2.1"),
 
                 # Test the compatibility operation
                 ("1", "~=1.0"),
@@ -467,7 +471,7 @@ class TestSpecifier:
                 ("2.0", ">2"),
                 ("2.0.post1", ">2"),
                 ("2.0.post1.dev1", ">2"),
-                ("2.0.1", ">2"),
+                ("2.0+local.version", ">2"),
 
                 # Test the less than operation
                 ("2.0.dev1", "<2"),

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -300,6 +300,42 @@ class TestVersion:
         assert Version(version).public == public
 
     @pytest.mark.parametrize(
+        ("version", "base_version"),
+        [
+            ("1.0", "1.0"),
+            ("1.0.dev6", "1.0"),
+            ("1.0a1", "1.0"),
+            ("1.0a1.post5", "1.0"),
+            ("1.0a1.post5.dev6", "1.0"),
+            ("1.0rc4", "1.0"),
+            ("1.0.post5", "1.0"),
+            ("1!1.0", "1!1.0"),
+            ("1!1.0.dev6", "1!1.0"),
+            ("1!1.0a1", "1!1.0"),
+            ("1!1.0a1.post5", "1!1.0"),
+            ("1!1.0a1.post5.dev6", "1!1.0"),
+            ("1!1.0rc4", "1!1.0"),
+            ("1!1.0.post5", "1!1.0"),
+            ("1.0+deadbeef", "1.0"),
+            ("1.0.dev6+deadbeef", "1.0"),
+            ("1.0a1+deadbeef", "1.0"),
+            ("1.0a1.post5+deadbeef", "1.0"),
+            ("1.0a1.post5.dev6+deadbeef", "1.0"),
+            ("1.0rc4+deadbeef", "1.0"),
+            ("1.0.post5+deadbeef", "1.0"),
+            ("1!1.0+deadbeef", "1!1.0"),
+            ("1!1.0.dev6+deadbeef", "1!1.0"),
+            ("1!1.0a1+deadbeef", "1!1.0"),
+            ("1!1.0a1.post5+deadbeef", "1!1.0"),
+            ("1!1.0a1.post5.dev6+deadbeef", "1!1.0"),
+            ("1!1.0rc4+deadbeef", "1!1.0"),
+            ("1!1.0.post5+deadbeef", "1!1.0"),
+        ],
+    )
+    def test_version_base_version(self, version, base_version):
+        assert Version(version).base_version == base_version
+
+    @pytest.mark.parametrize(
         ("version", "local"),
         [
             ("1.0", None),
@@ -502,6 +538,10 @@ class TestLegacyVersion:
     @pytest.mark.parametrize("version", VERSIONS + LEGACY_VERSIONS)
     def test_legacy_version_public(self, version):
         assert LegacyVersion(version).public == version
+
+    @pytest.mark.parametrize("version", VERSIONS + LEGACY_VERSIONS)
+    def test_legacy_version_base_version(self, version):
+        assert LegacyVersion(version).base_version == version
 
     @pytest.mark.parametrize("version", VERSIONS + LEGACY_VERSIONS)
     def test_legacy_version_local(self, version):

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -365,6 +365,19 @@ class TestVersion:
         assert Version(version).is_prerelease is expected
 
     @pytest.mark.parametrize(
+        ("version", "expected"),
+        [
+            ("1.0.dev1", False),
+            ("1.0", False),
+            ("1.0+foo", False),
+            ("1.0.post1.dev1", True),
+            ("1.0.post1", True)
+        ],
+    )
+    def test_version_is_postrelease(self, version, expected):
+        assert Version(version).is_postrelease is expected
+
+    @pytest.mark.parametrize(
         ("left", "right", "op"),
         # Below we'll generate every possible combination of VERSIONS that
         # should be True for the given operator
@@ -497,6 +510,10 @@ class TestLegacyVersion:
     @pytest.mark.parametrize("version", VERSIONS + LEGACY_VERSIONS)
     def test_legacy_version_is_prerelease(self, version):
         assert not LegacyVersion(version).is_prerelease
+
+    @pytest.mark.parametrize("version", VERSIONS + LEGACY_VERSIONS)
+    def test_legacy_version_is_postrelease(self, version):
+        assert not LegacyVersion(version).is_postrelease
 
     @pytest.mark.parametrize(
         ("left", "right", "op"),


### PR DESCRIPTION
Instead of having these operators imply a ``!=V.*`` this will instead have them more-or-less simply check if the prospective version is greater than or less than the specifier version. They will not however match a post or pre-release of the version mentioned in the specifier unless the specifier itself contains a post or a pre-release. In addition, we will ensure that ``>V`` does not match ``V+local.version`` even though it is technically greater than ``V``.

In particular that means that something like ``>1.7`` will match ``1.7.1`` but will not match ``1.7.post1`` while ``>1.7.post0`` would. Likewise ``<3.0`` would not match ``3.0.dev0`` while ``<3.0rc1`` would.

This PR also includes two new attributes on ``Version`` instances: ``is_postrelease`` to determine is a particular release is a post release and ``base_version`` which will return just the part of the version which shows the "base" version (e.g. ``1.0`` is the base version of ``1.0.dev0`` and ``1.0.post0`` and ``2!1.0`` is the base version of ``2!1.0.dev0`` and ``2!1.0.post0``).

This requires https://github.com/pypa/interoperability-peps/pull/3 to land before this can be merged.