### PR TITLE
Allowing prereleases for one SpecifierSet allows for all.

### DIFF
--- a/packaging/specifiers.py
+++ b/packaging/specifiers.py
@@ -673,10 +673,14 @@ class SpecifierSet(BaseSpecifier):
         if self._prereleases is not None:
             return self._prereleases
 
+        # If we don't have any specifiers, and we don't have a forced value,
+        # then we'll just return None since we don't know if this should have
+        # pre-releases or not.
+        if not self._specs:
+            return None
+
         # Otherwise we'll see if any of the given specifiers accept
         # prereleases, if any of them do we'll return True, otherwise False.
-        # Note: The use of any() here means that an empty set of specifiers
-        #       will always return False, this is an explicit design decision.
         return any(s.prereleases for s in self._specs)
 
     @prereleases.setter
@@ -688,26 +692,20 @@ class SpecifierSet(BaseSpecifier):
         if not isinstance(item, (LegacyVersion, Version)):
             item = parse(item)
 
+        # Determine if we're forcing a prerelease or not, if we're not forcing
+        # one for this particular filter call, then we'll use whatever the
+        # SpecifierSet thinks for whether or not we should support prereleases.
+        if prereleases is None:
+            prereleases = self.prereleases
+
         # We can determine if we're going to allow pre-releases by looking to
         # see if any of the underlying items supports them. If none of them do
         # and this item is a pre-release then we do not allow it and we can
         # short circuit that here.
         # Note: This means that 1.0.dev1 would not be contained in something
         #       like >=1.0.devabc however it would be in >=1.0.debabc,>0.0.dev0
-        if (not (self.prereleases or prereleases)) and item.is_prerelease:
+        if not prereleases and item.is_prerelease:
             return False
-
-        # Determine if we're forcing a prerelease or not, we bypass
-        # self.prereleases here and use self._prereleases because we want to
-        # only take into consideration actual *forced* values. The underlying
-        # specifiers will handle the other logic.
-        # The logic here is: If prereleases is anything but None, we'll just
-        #                    go aheand and continue to use that. However if
-        #                    prereleases is None, then we'll use whatever the
-        #                    value of self._prereleases is as long as it is not
-        #                    None itself.
-        if prereleases is None and self._prereleases is not None:
-            prereleases = self._prereleases
 
         # We simply dispatch to the underlying specs here to make sure that the
         # given version is contained within all of them.
@@ -719,24 +717,18 @@ class SpecifierSet(BaseSpecifier):
         )
 
     def filter(self, iterable, prereleases=None):
-        # Determine if we're forcing a prerelease or not, we bypass
-        # self.prereleases here and use self._prereleases because we want to
-        # only take into consideration actual *forced* values. The underlying
-        # specifiers will handle the other logic.
-        # The logic here is: If prereleases is anything but None, we'll just
-        #                    go aheand and continue to use that. However if
-        #                    prereleases is None, then we'll use whatever the
-        #                    value of self._prereleases is as long as it is not
-        #                    None itself.
-        if prereleases is None and self._prereleases is not None:
-            prereleases = self._prereleases
+        # Determine if we're forcing a prerelease or not, if we're not forcing
+        # one for this particular filter call, then we'll use whatever the
+        # SpecifierSet thinks for whether or not we should support prereleases.
+        if prereleases is None:
+            prereleases = self.prereleases
 
         # If we have any specifiers, then we want to wrap our iterable in the
         # filter method for each one, this will act as a logical AND amongst
         # each specifier.
         if self._specs:
             for spec in self._specs:
-                iterable = spec.filter(iterable, prereleases=prereleases)
+                iterable = spec.filter(iterable, prereleases=bool(prereleases))
             return iterable
         # If we do not have any specifiers, then we need to have a rough filter
         # which will filter out any pre-releases, unless there are no final

--- a/tests/test_specifiers.py
+++ b/tests/test_specifiers.py
@@ -774,6 +774,17 @@ class TestSpecifierSet:
         assert not spec.prereleases
         assert not spec.contains("1.0.dev1")
 
+    def test_specifier_contains_prereleases(self):
+        spec = SpecifierSet()
+        assert spec.prereleases is None
+        assert not spec.contains("1.0.dev1")
+        assert spec.contains("1.0.dev1", prereleases=True)
+
+        spec = SpecifierSet(prereleases=True)
+        assert spec.prereleases
+        assert spec.contains("1.0.dev1")
+        assert not spec.contains("1.0.dev1", prereleases=False)
+
     @pytest.mark.parametrize(
         (
             "specifier", "specifier_prereleases", "prereleases", "input",


### PR DESCRIPTION
We erronously tried to let the underlying Specifiers handle the choice about if we are accepting pre-releases or not, however within a single SpecifierSet we need to consistently either allow pre-releases or not. This will cause any pre-release allowing specifier to cause the whole specifier set to allow pre-releases.

Fixes #28