### PR TITLE
Add `operator` and `version` properties to `Specifier`

### DIFF
--- a/docs/specifiers.rst
+++ b/docs/specifiers.rst
@@ -147,9 +147,13 @@ Reference
 
         The string value of the operator part of this specifier.
 
-    .. attribute:: version
+    .. attribute:: version_string
 
         The string version of the version part of this specifier.
+
+    .. attribute:: version
+
+        The (parsed) :class:`Version` of this specifier.
 
     .. attribute:: prereleases
 
@@ -187,9 +191,13 @@ Reference
 
         The string value of the operator part of this specifier.
 
-    .. attribute:: version
+    .. attribute:: version_string
 
         The string version of the version part of this specifier.
+
+    .. attribute:: version
+
+        The (parsed) :class:`Version` of this specifier.
 
     .. attribute:: prereleases
 

--- a/docs/specifiers.rst
+++ b/docs/specifiers.rst
@@ -147,13 +147,9 @@ Reference
 
         The string value of the operator part of this specifier.
 
-    .. attribute:: version_string
-
-        The string version of the version part of this specifier.
-
     .. attribute:: version
 
-        The (parsed) :class:`Version` of this specifier.
+        The string version of the version part of this specifier.
 
     .. attribute:: prereleases
 
@@ -191,13 +187,9 @@ Reference
 
         The string value of the operator part of this specifier.
 
-    .. attribute:: version_string
-
-        The string version of the version part of this specifier.
-
     .. attribute:: version
 
-        The (parsed) :class:`Version` of this specifier.
+        The string version of the version part of this specifier.
 
     .. attribute:: prereleases
 

--- a/docs/specifiers.rst
+++ b/docs/specifiers.rst
@@ -32,12 +32,12 @@ Usage
     >>> v1 = Version("1.0a5")
     >>> v2 = Version("1.0")
     >>> # We can check a version object to see if it falls within a specifier
-    >>> combined_spec.contains(v1)
+    >>> v1 in combined_spec
     False
-    >>> combined_spec.contains(v2)
+    >>> v2 in combined_spec
     True
     >>> # We can even do the same with a string based version
-    >>> combined_spec.contains("1.4")
+    >>> "1.4" in combined_spec
     True
     >>> # Finally we can filter a list of versions to get only those which are
     >>> # contained within our specifier.
@@ -79,6 +79,14 @@ Reference
         prereleases or it can be set to ``None`` (the default) to enable
         autodetection.
 
+    .. method:: __contains__(version)
+
+        This is the more Pythonic version of :meth:`contains()`, but does
+        not allow you to override the ``prereleases`` argument.  If you
+        need that, use :meth:`contains()`.
+
+        See :meth:`contains()`.
+
     .. method:: contains(version, prereleases=None)
 
         Determines if ``version``, which can be either a version string, a
@@ -90,6 +98,15 @@ Reference
         (the default) it will use the ``Specifier().prereleases`` attribute to
         determine if to allow them. Otherwise it will use the boolean value of
         the passed in value to determine if to allow them or not.
+
+    .. method:: __len__()
+
+        Returns the number of specifiers in this specifier set.
+
+    .. method:: __iter__()
+
+        Returns an iterator over all the underlying :class:`Specifier`
+        (or :class:`LegacySpecifier`) instances in this specifier set.
 
     .. method:: filter(iterable, prereleases=None)
 
@@ -126,9 +143,21 @@ Reference
     :raises InvalidSpecifier: If the ``specifier`` does not conform to PEP 440
                               in any way then this exception will be raised.
 
+    .. attribute:: operator
+
+        The string value of the operator part of this specifier.
+
+    .. attribute:: version
+
+        The string version of the version part of this specifier.
+
     .. attribute:: prereleases
 
         See :attr:`SpecifierSet.prereleases`.
+
+    .. method:: __contains__(version)
+
+        See :meth:`SpecifierSet.__contains__()`.
 
     .. method:: contains(version, prereleases=None)
 
@@ -154,13 +183,33 @@ Reference
     :raises InvalidSpecifier: If the ``specifier`` is not parseable than this
                               will be raised.
 
+    .. attribute:: operator
+
+        The string value of the operator part of this specifier.
+
+    .. attribute:: version
+
+        The string version of the version part of this specifier.
+
     .. attribute:: prereleases
 
         See :attr:`SpecifierSet.prereleases`.
 
+    .. method:: __contains__(version)
+
+        See :meth:`SpecifierSet.__contains__()`.
+
     .. method:: contains(version, prereleases=None)
 
         See :meth:`SpecifierSet.contains()`.
+
+    .. method:: __len__()
+
+        See :meth:`SpecifierSet.__len__()`.
+
+    .. method:: __iter__()
+
+        See :meth:`SpecifierSet.__iter__()`.
 
     .. method:: filter(iterable, prereleases=None)
 

--- a/packaging/specifiers.py
+++ b/packaging/specifiers.py
@@ -156,12 +156,8 @@ class _IndividualSpecifier(BaseSpecifier):
         return self._spec[0]
 
     @property
-    def version_string(self):
-        return self._spec[1]
-
-    @property
     def version(self):
-        return parse(self.version_string)
+        return self._spec[1]
 
     @property
     def prereleases(self):
@@ -191,7 +187,7 @@ class _IndividualSpecifier(BaseSpecifier):
 
         # Actually do the comparison to determine if this item is contained
         # within this Specifier or not.
-        return self._get_operator(self.operator)(item, self.version_string)
+        return self._get_operator(self.operator)(item, self.version)
 
     def filter(self, iterable, prereleases=None):
         yielded = False

--- a/packaging/specifiers.py
+++ b/packaging/specifiers.py
@@ -677,6 +677,12 @@ class SpecifierSet(BaseSpecifier):
 
         return self._specs != other._specs
 
+    def __len__(self):
+        return len(self._specs)
+
+    def __iter__(self):
+        return iter(self._specs)
+
     @property
     def prereleases(self):
         # If we have been given an explicit prerelease modifier, then we'll

--- a/packaging/specifiers.py
+++ b/packaging/specifiers.py
@@ -156,8 +156,12 @@ class _IndividualSpecifier(BaseSpecifier):
         return self._spec[0]
 
     @property
-    def version(self):
+    def version_string(self):
         return self._spec[1]
+
+    @property
+    def version(self):
+        return parse(self.version_string)
 
     @property
     def prereleases(self):
@@ -187,7 +191,7 @@ class _IndividualSpecifier(BaseSpecifier):
 
         # Actually do the comparison to determine if this item is contained
         # within this Specifier or not.
-        return self._get_operator(self.operator)(item, self.version)
+        return self._get_operator(self.operator)(item, self.version_string)
 
     def filter(self, iterable, prereleases=None):
         yielded = False

--- a/packaging/specifiers.py
+++ b/packaging/specifiers.py
@@ -167,6 +167,9 @@ class _IndividualSpecifier(BaseSpecifier):
     def prereleases(self, value):
         self._prereleases = value
 
+    def __contains__(self, item):
+        return self.contains(item)
+
     def contains(self, item, prereleases=None):
         # Determine if prereleases are to be allowed or not.
         if prereleases is None:
@@ -690,6 +693,9 @@ class SpecifierSet(BaseSpecifier):
     @prereleases.setter
     def prereleases(self, value):
         self._prereleases = value
+
+    def __contains__(self, item):
+        return self.contains(item)
 
     def contains(self, item, prereleases=None):
         # Ensure that our item is a Version or LegacyVersion instance.

--- a/packaging/specifiers.py
+++ b/packaging/specifiers.py
@@ -152,6 +152,14 @@ class _IndividualSpecifier(BaseSpecifier):
         return version
 
     @property
+    def operator(self):
+        return self._spec[0]
+
+    @property
+    def version(self):
+        return self._spec[1]
+
+    @property
     def prereleases(self):
         return self._prereleases
 
@@ -176,7 +184,7 @@ class _IndividualSpecifier(BaseSpecifier):
 
         # Actually do the comparison to determine if this item is contained
         # within this Specifier or not.
-        return self._get_operator(self._spec[0])(item, self._spec[1])
+        return self._get_operator(self.operator)(item, self.version)
 
     def filter(self, iterable, prereleases=None):
         yielded = False

--- a/tests/test_specifiers.py
+++ b/tests/test_specifiers.py
@@ -641,8 +641,10 @@ class TestSpecifier:
             ('===lolwat', 'lolwat'),
         ]
     )
-    def test_specifier_version_property(self, spec, version):
-        assert Specifier(spec).version == version
+    def test_specifier_version_properties(self, spec, version):
+        parsed_version = parse(version)
+        assert Specifier(spec).version_string == version
+        assert Specifier(spec).version == parsed_version
 
     @pytest.mark.parametrize(
         ("spec", "expected_length"),

--- a/tests/test_specifiers.py
+++ b/tests/test_specifiers.py
@@ -641,10 +641,8 @@ class TestSpecifier:
             ('===lolwat', 'lolwat'),
         ]
     )
-    def test_specifier_version_properties(self, spec, version):
-        parsed_version = parse(version)
-        assert Specifier(spec).version_string == version
-        assert Specifier(spec).version == parsed_version
+    def test_specifier_version_property(self, spec, version):
+        assert Specifier(spec).version == version
 
     @pytest.mark.parametrize(
         ("spec", "expected_length"),

--- a/tests/test_specifiers.py
+++ b/tests/test_specifiers.py
@@ -508,15 +508,19 @@ class TestSpecifier:
 
         if expected:
             # Test that the plain string form works
+            assert version in spec
             assert spec.contains(version)
 
             # Test that the version instance form works
+            assert Version(version) in spec
             assert spec.contains(Version(version))
         else:
             # Test that the plain string form works
+            assert version not in spec
             assert not spec.contains(version)
 
             # Test that the version instance form works
+            assert Version(version) not in spec
             assert not spec.contains(Version(version))
 
     @pytest.mark.parametrize(
@@ -535,10 +539,10 @@ class TestSpecifier:
 
         if expected:
             # Identity comparisons only support the plain string form
-            assert spec.contains(version)
+            assert version in spec
         else:
             # Identity comparisons only support the plain string form
-            assert not spec.contains(version)
+            assert version not in spec
 
     @pytest.mark.parametrize(
         ("specifier", "expected"),
@@ -576,13 +580,13 @@ class TestSpecifier:
         spec = Specifier(specifier)
 
         if expected:
-            assert spec.contains(version)
+            assert version in spec
             spec.prereleases = False
-            assert not spec.contains(version)
+            assert version not in spec
         else:
-            assert not spec.contains(version)
+            assert version not in spec
             spec.prereleases = True
-            assert spec.contains(version)
+            assert version in spec
 
     @pytest.mark.parametrize(
         ("specifier", "prereleases", "input", "expected"),
@@ -743,15 +747,19 @@ class TestLegacySpecifier:
 
         if expected:
             # Test that the plain string form works
+            assert version in spec
             assert spec.contains(version)
 
             # Test that the version instance form works
+            assert LegacyVersion(version) in spec
             assert spec.contains(LegacyVersion(version))
         else:
             # Test that the plain string form works
+            assert version not in spec
             assert not spec.contains(version)
 
             # Test that the version instance form works
+            assert LegacyVersion(version) not in spec
             assert not spec.contains(LegacyVersion(version))
 
     def test_specifier_explicit_prereleases(self):
@@ -785,29 +793,37 @@ class TestSpecifierSet:
     def test_empty_specifier(self, version):
         spec = SpecifierSet(prereleases=True)
 
+        assert version in spec
         assert spec.contains(version)
+        assert parse(version) in spec
         assert spec.contains(parse(version))
 
     def test_specifier_prereleases_explicit(self):
         spec = SpecifierSet()
         assert not spec.prereleases
+        assert "1.0.dev1" not in spec
         assert not spec.contains("1.0.dev1")
         spec.prereleases = True
         assert spec.prereleases
+        assert "1.0.dev1" in spec
         assert spec.contains("1.0.dev1")
 
         spec = SpecifierSet(prereleases=True)
         assert spec.prereleases
+        assert "1.0.dev1" in spec
         assert spec.contains("1.0.dev1")
         spec.prereleases = False
         assert not spec.prereleases
+        assert "1.0.dev1" not in spec
         assert not spec.contains("1.0.dev1")
 
         spec = SpecifierSet(prereleases=True)
         assert spec.prereleases
+        assert "1.0.dev1" in spec
         assert spec.contains("1.0.dev1")
         spec.prereleases = None
         assert not spec.prereleases
+        assert "1.0.dev1" not in spec
         assert not spec.contains("1.0.dev1")
 
     @pytest.mark.parametrize(
@@ -852,7 +868,7 @@ class TestSpecifierSet:
 
     def test_legacy_specifiers_combined(self):
         spec = SpecifierSet("<3,>1-1-1")
-        assert spec.contains("2.0")
+        assert "2.0" in spec
 
     @pytest.mark.parametrize(
         ("specifier", "expected"),

--- a/tests/test_specifiers.py
+++ b/tests/test_specifiers.py
@@ -604,6 +604,42 @@ class TestSpecifier:
     def test_specifier_explicit_leacy(self):
         Specifier("==1.0").contains(LegacyVersion("1.0"))
 
+    @pytest.mark.parametrize(
+        ('spec', 'op'),
+        [
+            ('~=2.0', '~='),
+            ('==2.1.*', '=='),
+            ('==2.1.0.3', '=='),
+            ('!=2.2.*', '!='),
+            ('!=2.2.0.5', '!='),
+            ('<=5', '<='),
+            ('>=7.9a1', '>='),
+            ('<1.0.dev1', '<'),
+            ('>2.0.post1', '>'),
+            ('===lolwat', '==='),
+        ]
+    )
+    def test_specifier_operator_property(self, spec, op):
+        assert Specifier(spec).operator == op
+
+    @pytest.mark.parametrize(
+        ('spec', 'version'),
+        [
+            ('~=2.0', '2.0'),
+            ('==2.1.*', '2.1.*'),
+            ('==2.1.0.3', '2.1.0.3'),
+            ('!=2.2.*', '2.2.*'),
+            ('!=2.2.0.5', '2.2.0.5'),
+            ('<=5', '5'),
+            ('>=7.9a1', '7.9a1'),
+            ('<1.0.dev1', '1.0.dev1'),
+            ('>2.0.post1', '2.0.post1'),
+            ('===lolwat', 'lolwat'),
+        ]
+    )
+    def test_specifier_version_property(self, spec, version):
+        assert Specifier(spec).version == version
+
 
 class TestLegacySpecifier:
 

--- a/tests/test_specifiers.py
+++ b/tests/test_specifiers.py
@@ -644,6 +644,35 @@ class TestSpecifier:
     def test_specifier_version_property(self, spec, version):
         assert Specifier(spec).version == version
 
+    @pytest.mark.parametrize(
+        ("spec", "expected_length"),
+        [
+            ("", 0),
+            ("==2.0", 1),
+            (">=2.0", 1),
+            (">=2.0,<3", 2),
+            (">=2.0,<3,==2.4", 3),
+        ],
+    )
+    def test_length(self, spec, expected_length):
+        spec = SpecifierSet(spec)
+        assert len(spec) == expected_length
+
+    @pytest.mark.parametrize(
+        ("spec", "expected_items"),
+        [
+            ("", []),
+            ("==2.0", ["==2.0"]),
+            (">=2.0", [">=2.0"]),
+            (">=2.0,<3", [">=2.0", "<3"]),
+            (">=2.0,<3,==2.4", [">=2.0", "<3", "==2.4"]),
+        ],
+    )
+    def test_iteration(self, spec, expected_items):
+        spec = SpecifierSet(spec)
+        items = set(str(item) for item in spec)
+        assert items == set(expected_items)
+
 
 class TestLegacySpecifier:
 


### PR DESCRIPTION
This adds the `operator` and `version` properties, to provide a public way of accessing the underpinnings of the Specifier (and LegacySpecifier) class.

In a nutshell:

```python
>>> s = Specifier('~=2.*')
>>> s.operator
'~='
>>> s.version
'2.*'
```