### PR TITLE
Add missing `assert`

### DIFF
--- a/tests/test_specifiers.py
+++ b/tests/test_specifiers.py
@@ -601,8 +601,9 @@ class TestSpecifier:
 
         assert list(spec.filter(input, **kwargs)) == expected
 
-    def test_specifier_explicit_leacy(self):
-        Specifier("==1.0").contains(LegacyVersion("1.0"))
+    @pytest.mark.xfail
+    def test_specifier_explicit_legacy(self):
+        assert Specifier("==1.0").contains(LegacyVersion("1.0"))
 
 
 class TestLegacySpecifier:


### PR DESCRIPTION
Also mark the now-failing test as expected failing (xfail).  Not sure what we semantics should be wrt legacy versions, but this at least does not make the test silently fail.
