### PR TITLE
Implement PEP 508 Marker support

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -22,6 +22,7 @@ API
 
     version
     specifiers
+    markers
 
 
 Project

--- a/docs/markers.rst
+++ b/docs/markers.rst
@@ -1,0 +1,77 @@
+Markers
+=======
+
+.. currentmodule:: packaging.markers
+
+One extra requirement of dealing with dependencies is the ability to specify
+if it is required depending on the operating system or Python version in use.
+`PEP 508`_ defines the scheme which has been implemented by this module.
+
+Usage
+-----
+
+.. doctest::
+
+    >>> from packaging.markers import Marker
+    >>> marker = Marker("python_version>'2'")
+    >>> marker
+    <Marker('python_version > "2"')>
+    >>> # We can evaluate a marker to see if the dependency is required
+    >>> marker.evaluate()
+    True
+    >>> # We can also override the environment
+    >>> env = {'python_version': '1.5.4'}
+    >>> marker.evaluate(environment=env)
+    False
+    >>> # Multiple markers can be ANDed
+    >>> and_marker = Marker("os_name=='a' and os_name=='b'")
+    >>> and_marker
+    <Marker('os_name == "a" and os_name == "b"')>
+    >>> # Multiple markers can be ORed
+    >>> or_marker = Marker("os_name=='a' or os_name=='b'")
+    >>> or_marker
+    <Marker('os_name == "a" or os_name == "b"')>
+    >>> # Markers can be also used with extras, to pull in dependencies if
+    >>> # a certain extra is being installed
+    >>> extra = Marker('extra == "bar"')
+    >>> # Evaluating an extra marker with no environment is an error
+    >>> try:
+    ...     extra.evaluate()
+    ... except ValueError:
+    ...     pass
+    >>> extra_environment = {'extra': ''}
+    >>> extra.evaluate(environment=extra_environment)
+    False
+    >>> extra_environment['extra'] = 'bar'
+    >>> extra.evaluate(environment=extra_environment)
+    True
+
+
+Reference
+---------
+
+.. class:: Marker(markers)
+
+    This class abstracts handling markers for dependencies of a project. It can
+    be passed a single marker or multiple markers that are ANDed or ORed
+    together. Each marker will be parsed according to PEP 508.
+
+    :param str markers: The string representation of a marker or markers.
+    :raises InvalidMarker: If the given ``markers`` are not parseable, then
+                           this exception will be raised.
+
+    .. method:: evaluate(environment=None)
+
+    Evaluate the marker given the context of the current Python process.
+
+    :param dict environment: A dictionary containing keys and values to
+                             override the detected environment.
+    :raises ValueError: If the marker contains 'extra', and 'extra' isn't
+                        defined in the environment.
+
+.. exception:: InvalidMarker
+
+    Raised when attempting to create a :class:`Marker` with a string that
+    does not conform to PEP 508.
+
+.. _`PEP 508`: https://www.python.org/dev/peps/pep-0508/

--- a/packaging/markers.py
+++ b/packaging/markers.py
@@ -1,0 +1,251 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+from __future__ import absolute_import, division, print_function
+
+import operator
+import os
+import platform
+import sys
+
+from pyparsing import ParseException, ParseResults, stringStart, stringEnd
+from pyparsing import ZeroOrMore, Group, Forward, QuotedString
+from pyparsing import Literal as L  # noqa
+
+from ._compat import string_types
+from .specifiers import Specifier, InvalidSpecifier
+
+
+__all__ = [
+    "InvalidMarker", "UndefinedComparison", "Marker", "default_environment",
+]
+
+
+class InvalidMarker(ValueError):
+    """
+    An invalid marker was found, users should refer to PEP 508.
+    """
+
+
+class UndefinedComparison(ValueError):
+    """
+    An invalid operation was attempted on a value that doesn't support it.
+    """
+
+
+class Node(object):
+
+    def __init__(self, value):
+        self.value = value
+
+    def __str__(self):
+        return str(self.value)
+
+    def __repr__(self):
+        return "<{0}({1!r})>".format(self.__class__.__name__, str(self))
+
+
+class Variable(Node):
+    pass
+
+
+class Value(Node):
+    pass
+
+
+VARIABLE = (
+    L("implementation_version") |
+    L("platform_python_implementation") |
+    L("implementation_name") |
+    L("python_full_version") |
+    L("platform_release") |
+    L("platform_version") |
+    L("platform_machine") |
+    L("platform_system") |
+    L("python_version") |
+    L("sys_platform") |
+    L("os_name") |
+    L("extra")
+)
+VARIABLE.setParseAction(lambda s, l, t: Variable(t[0]))
+
+VERSION_CMP = (
+    L("===") |
+    L("==") |
+    L(">=") |
+    L("<=") |
+    L("!=") |
+    L("~=") |
+    L(">") |
+    L("<")
+)
+
+MARKER_OP = VERSION_CMP | L("not in") | L("in")
+
+MARKER_VALUE = QuotedString("'") | QuotedString('"')
+MARKER_VALUE.setParseAction(lambda s, l, t: Value(t[0]))
+
+BOOLOP = L("and") | L("or")
+
+MARKER_VAR = VARIABLE | MARKER_VALUE
+
+MARKER_ITEM = Group(MARKER_VAR + MARKER_OP + MARKER_VAR)
+MARKER_ITEM.setParseAction(lambda s, l, t: tuple(t[0]))
+
+LPAREN = L("(").suppress()
+RPAREN = L(")").suppress()
+
+MARKER_EXPR = Forward()
+MARKER_ATOM = MARKER_ITEM | Group(LPAREN + MARKER_EXPR + RPAREN)
+MARKER_EXPR << MARKER_ATOM + ZeroOrMore(BOOLOP + MARKER_EXPR)
+
+MARKER = stringStart + MARKER_EXPR + stringEnd
+
+
+def _coerce_parse_result(results):
+    if isinstance(results, ParseResults):
+        return [_coerce_parse_result(i) for i in results]
+    else:
+        return results
+
+
+def _format_marker(marker, first=True):
+    assert isinstance(marker, (list, tuple, string_types))
+
+    # Sometimes we have a structure like [[...]] which is a single item list
+    # where the single item is itself it's own list. In that case we want skip
+    # the rest of this function so that we don't get extraneous () on the
+    # outside.
+    if (isinstance(marker, list) and len(marker) == 1 and
+            isinstance(marker[0], (list, tuple))):
+        return _format_marker(marker[0])
+
+    if isinstance(marker, list):
+        inner = (_format_marker(m, first=False) for m in marker)
+        if first:
+            return " ".join(inner)
+        else:
+            return "(" + " ".join(inner) + ")"
+    elif isinstance(marker, tuple):
+        return '{0} {1} "{2}"'.format(*marker)
+    else:
+        return marker
+
+
+_operators = {
+    "in": lambda lhs, rhs: lhs in rhs,
+    "not in": lambda lhs, rhs: lhs not in rhs,
+    "<": operator.lt,
+    "<=": operator.le,
+    "==": operator.eq,
+    "!=": operator.ne,
+    ">=": operator.ge,
+    ">": operator.gt,
+}
+
+
+def _eval_op(lhs, op, rhs):
+    try:
+        spec = Specifier("".join([op, rhs]))
+    except InvalidSpecifier:
+        pass
+    else:
+        return spec.contains(lhs)
+
+    oper = _operators.get(op)
+    if oper is None:
+        raise UndefinedComparison(
+            "Undefined {0!r} on {1!r} and {2!r}.".format(op, lhs, rhs)
+        )
+
+    return oper(lhs, rhs)
+
+
+def _evaluate_markers(markers, environment):
+    groups = [[]]
+
+    for marker in markers:
+        assert isinstance(marker, (list, tuple, string_types))
+
+        if isinstance(marker, list):
+            groups[-1].append(_evaluate_markers(marker, environment))
+        elif isinstance(marker, tuple):
+            lhs, op, rhs = marker
+            if ((lhs.value == 'extra' or rhs.value == 'extra') and
+               'extra' not in environment):
+                raise ValueError("can not evaluate extra marker without "
+                                 "environment override")
+            if isinstance(lhs, Variable):
+                value = _eval_op(environment[lhs.value], op, rhs.value)
+            else:
+                value = _eval_op(lhs.value, op, environment[rhs.value])
+            groups[-1].append(value)
+        else:
+            assert marker in ["and", "or"]
+            if marker == "or":
+                groups.append([])
+
+    return any(all(item) for item in groups)
+
+
+def format_full_version(info):
+    version = '{0.major}.{0.minor}.{0.micro}'.format(info)
+    kind = info.releaselevel
+    if kind != 'final':
+        version += kind[0] + str(info.serial)
+    return version
+
+
+def default_environment():
+    if hasattr(sys, 'implementation'):
+        iver = format_full_version(sys.implementation.version)
+        implementation_name = sys.implementation.name
+    else:
+        iver = '0'
+        implementation_name = ''
+
+    return {
+        "implementation_name": implementation_name,
+        "implementation_version": iver,
+        "os_name": os.name,
+        "platform_machine": platform.machine(),
+        "platform_release": platform.release(),
+        "platform_system": platform.system(),
+        "platform_version": platform.version(),
+        "python_full_version": platform.python_version(),
+        "platform_python_implementation": platform.python_implementation(),
+        "python_version": platform.python_version()[:3],
+        "sys_platform": sys.platform,
+    }
+
+
+class Marker(object):
+
+    def __init__(self, marker):
+        try:
+            self._markers = _coerce_parse_result(MARKER.parseString(marker))
+        except ParseException as e:
+            err_str = "Invalid marker: {0!r}, parse error at {1!r}".format(
+                marker, marker[e.loc:e.loc + 8])
+            raise InvalidMarker(err_str)
+
+    def __str__(self):
+        return _format_marker(self._markers)
+
+    def __repr__(self):
+        return "<Marker({0!r})>".format(str(self))
+
+    def evaluate(self, environment=None):
+        """Evaluate a marker.
+
+        Return the boolean from evaluating the given marker against the
+        environment. environment is an optional argument to override all or
+        part of the determined environment.
+
+        The environment is determined from the current Python process.
+        """
+        current_environment = default_environment()
+        if environment is not None:
+            current_environment.update(environment)
+
+        return _evaluate_markers(self._markers, current_environment)

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,8 @@ setup(
     author=about["__author__"],
     author_email=about["__email__"],
 
+    install_requires=["pyparsing"],
+
     classifiers=[
         "Intended Audience :: Developers",
 

--- a/tests/test_markers.py
+++ b/tests/test_markers.py
@@ -1,0 +1,297 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+from __future__ import absolute_import, division, print_function
+
+import collections
+import itertools
+import os
+import platform
+import sys
+
+import pretend
+import pytest
+
+from packaging.markers import (
+    Node, InvalidMarker, UndefinedComparison, Marker, _eval_op,
+    default_environment, format_full_version,
+)
+
+
+VARIABLES = [
+    "extra", "implementation_version", "implementation_version", "os_name",
+    "platform_machine", "platform_release", "platform_system",
+    "platform_version", "python_full_version", "python_version",
+    "platform_python_implementation", "sys_platform",
+]
+
+OPERATORS = [
+    "===", "==", ">=", "<=", "!=", "~=", ">", "<", "in", "not in",
+]
+
+VALUES = [
+    "1.0", "5.6a0", "dog", "freebsd", "literally any string can go here",
+    "things @#4 dsfd (((",
+]
+
+
+class TestNode:
+
+    @pytest.mark.parametrize("value", ["one", "two", None, 3, 5, []])
+    def test_accepts_value(self, value):
+        assert Node(value).value == value
+
+    @pytest.mark.parametrize("value", ["one", "two", None, 3, 5, []])
+    def test_str(self, value):
+        assert str(Node(value)) == str(value)
+
+    @pytest.mark.parametrize("value", ["one", "two", None, 3, 5, []])
+    def test_repr(self, value):
+        assert repr(Node(value)) == "<Node({0!r})>".format(str(value))
+
+
+class TestOperatorEvaluation:
+
+    def test_prefers_pep440(self):
+        assert _eval_op("2.7.10", ">", "2.7.9")
+
+    def test_falls_back_to_python(self):
+        assert _eval_op("b", ">", "a")
+
+    def test_fails_when_undefined(self):
+        with pytest.raises(UndefinedComparison):
+            _eval_op("2.7.0", "~=", "invalid")
+
+
+FakeVersionInfo = collections.namedtuple(
+    "FakeVersionInfo",
+    ["major", "minor", "micro", "releaselevel", "serial"],
+)
+
+
+class TestDefaultEnvironment:
+
+    @pytest.mark.skipif(hasattr(sys, 'implementation'),
+                        reason='sys.implementation does exist')
+    def test_matches_expected_no_sys_implementation(self):
+        environment = default_environment()
+
+        assert environment == {
+            "implementation_name": "",
+            "implementation_version": "0",
+            "os_name": os.name,
+            "platform_machine": platform.machine(),
+            "platform_release": platform.release(),
+            "platform_system": platform.system(),
+            "platform_version": platform.version(),
+            "python_full_version": platform.python_version(),
+            "platform_python_implementation": platform.python_implementation(),
+            "python_version": platform.python_version()[:3],
+            "sys_platform": sys.platform,
+        }
+
+    @pytest.mark.skipif(not hasattr(sys, 'implementation'),
+                        reason='sys.implementation does not exist')
+    def test_matches_expected_deleted_sys_implementation(self, monkeypatch):
+        monkeypatch.delattr(sys, "implementation")
+
+        environment = default_environment()
+
+        assert environment == {
+            "implementation_name": "",
+            "implementation_version": "0",
+            "os_name": os.name,
+            "platform_machine": platform.machine(),
+            "platform_release": platform.release(),
+            "platform_system": platform.system(),
+            "platform_version": platform.version(),
+            "python_full_version": platform.python_version(),
+            "platform_python_implementation": platform.python_implementation(),
+            "python_version": platform.python_version()[:3],
+            "sys_platform": sys.platform,
+        }
+
+    @pytest.mark.skipif(not hasattr(sys, 'implementation'),
+                        reason='sys.implementation does not exist')
+    def test_matches_expected(self):
+        environment = default_environment()
+
+        iver = "{0.major}.{0.minor}.{0.micro}".format(
+            sys.implementation.version
+        )
+        if sys.implementation.version.releaselevel != "final":
+            iver = "{0}{1}[0]{2}".format(
+                iver,
+                sys.implementation.version.releaselevel,
+                sys.implementation.version.serial,
+            )
+
+        assert environment == {
+            "implementation_name": sys.implementation.name,
+            "implementation_version": iver,
+            "os_name": os.name,
+            "platform_machine": platform.machine(),
+            "platform_release": platform.release(),
+            "platform_system": platform.system(),
+            "platform_version": platform.version(),
+            "python_full_version": platform.python_version(),
+            "platform_python_implementation": platform.python_implementation(),
+            "python_version": platform.python_version()[:3],
+            "sys_platform": sys.platform,
+        }
+
+    @pytest.mark.skipif(hasattr(sys, 'implementation'),
+                        reason='sys.implementation does exist')
+    def test_monkeypatch_sys_implementation(self, monkeypatch):
+        monkeypatch.setattr(
+            sys, "implementation",
+            pretend.stub(version=FakeVersionInfo(3, 4, 2, "final", 0),
+                         name="linux"),
+            raising=False)
+
+        environment = default_environment()
+        assert environment == {
+            "implementation_name": "linux",
+            "implementation_version": "3.4.2",
+            "os_name": os.name,
+            "platform_machine": platform.machine(),
+            "platform_release": platform.release(),
+            "platform_system": platform.system(),
+            "platform_version": platform.version(),
+            "python_full_version": platform.python_version(),
+            "platform_python_implementation": platform.python_implementation(),
+            "python_version": platform.python_version()[:3],
+            "sys_platform": sys.platform,
+        }
+
+    def tests_when_releaselevel_final(self):
+        v = FakeVersionInfo(3, 4, 2, "final", 0)
+        assert format_full_version(v) == '3.4.2'
+
+    def tests_when_releaselevel_not_final(self):
+        v = FakeVersionInfo(3, 4, 2, "beta", 4)
+        assert format_full_version(v) == '3.4.2b4'
+
+
+class TestMarker:
+
+    @pytest.mark.parametrize(
+        "marker_string",
+        [
+            "{0} {1} {2!r}".format(*i)
+            for i in itertools.product(VARIABLES, OPERATORS, VALUES)
+        ] + [
+            "{2!r} {1} {0}".format(*i)
+            for i in itertools.product(VARIABLES, OPERATORS, VALUES)
+        ],
+    )
+    def test_parses_valid(self, marker_string):
+        Marker(marker_string)
+
+    @pytest.mark.parametrize(
+        "marker_string",
+        [
+            "this_isnt_a_real_variable >= '1.0'",
+            "python_version",
+            "(python_version)",
+            "python_version >= 1.0 and (python_version)",
+        ],
+    )
+    def test_parses_invalid(self, marker_string):
+        with pytest.raises(InvalidMarker):
+            Marker(marker_string)
+
+    @pytest.mark.parametrize(
+        ("marker_string", "expected"),
+        [
+            # Test the different quoting rules
+            ("python_version == '2.7'", 'python_version == "2.7"'),
+            ('python_version == "2.7"', 'python_version == "2.7"'),
+
+            # Test and/or expressions
+            (
+                'python_version == "2.7" and os_name == "linux"',
+                'python_version == "2.7" and os_name == "linux"',
+            ),
+            (
+                'python_version == "2.7" or os_name == "linux"',
+                'python_version == "2.7" or os_name == "linux"',
+            ),
+            (
+                'python_version == "2.7" and os_name == "linux" or '
+                'sys_platform == "win32"',
+                'python_version == "2.7" and os_name == "linux" or '
+                'sys_platform == "win32"',
+            ),
+
+            # Test nested expressions and grouping with ()
+            ('(python_version == "2.7")', 'python_version == "2.7"'),
+            (
+                '(python_version == "2.7" and sys_platform == "win32")',
+                'python_version == "2.7" and sys_platform == "win32"',
+            ),
+            (
+                'python_version == "2.7" and (sys_platform == "win32" or '
+                'sys_platform == "linux")',
+                'python_version == "2.7" and (sys_platform == "win32" or '
+                'sys_platform == "linux")',
+            ),
+        ],
+    )
+    def test_str_and_repr(self, marker_string, expected):
+        m = Marker(marker_string)
+        assert str(m) == expected
+        assert repr(m) == "<Marker({0!r})>".format(str(m))
+
+    def test_extra_with_no_extra_in_environment(self):
+        # We can't evaluate an extra if no extra is passed into the environment
+        m = Marker("extra == 'security'")
+        with pytest.raises(ValueError):
+            m.evaluate()
+
+    @pytest.mark.parametrize(
+        ("marker_string", "environment", "expected"),
+        [
+            ("os_name == '{0}'".format(os.name), None, True),
+            ("os_name == 'foo'", {"os_name": "foo"}, True),
+            ("os_name == 'foo'", {"os_name": "bar"}, False),
+            ("'2.7' in python_version", {"python_version": "2.7.5"}, True),
+            ("'2.7' not in python_version", {"python_version": "2.7"}, False),
+            (
+                "os_name == 'foo' and python_version ~= '2.7.0'",
+                {"os_name": "foo", "python_version": "2.7.6"},
+                True,
+            ),
+            (
+                "python_version ~= '2.7.0' and (os_name == 'foo' or "
+                "os_name == 'bar')",
+                {"os_name": "foo", "python_version": "2.7.4"},
+                True,
+            ),
+            (
+                "python_version ~= '2.7.0' and (os_name == 'foo' or "
+                "os_name == 'bar')",
+                {"os_name": "bar", "python_version": "2.7.4"},
+                True,
+            ),
+            (
+                "python_version ~= '2.7.0' and (os_name == 'foo' or "
+                "os_name == 'bar')",
+                {"os_name": "other", "python_version": "2.7.4"},
+                False,
+            ),
+            (
+                "extra == 'security'",
+                {"extra": "quux"},
+                False,
+            ),
+            (
+                "extra == 'security'",
+                {"extra": "security"},
+                True,
+            ),
+        ],
+    )
+    def test_evaluates(self, marker_string, environment, expected):
+        args = [] if environment is None else [environment]
+        assert Marker(marker_string).evaluate(*args) == expected


### PR DESCRIPTION
This builds on the work that Donald already did in his branch. All I've done on top is rip out the vendoring and make the tests pass on both Python 2 and 3.