### PR TITLE
Fix to parse requirements that use legacy versions

### DIFF
--- a/packaging/requirements.py
+++ b/packaging/requirements.py
@@ -47,7 +47,7 @@ EXTRAS = (LBRACKET + Optional(EXTRAS_LIST) + RBRACKET)("extras")
 VERSION_PEP440 = Regex(Specifier._regex_str, re.VERBOSE | re.IGNORECASE)
 VERSION_LEGACY = Regex(LegacySpecifier._regex_str, re.VERBOSE | re.IGNORECASE)
 
-VERSION_ONE = VERSION_PEP440 | VERSION_LEGACY
+VERSION_ONE = VERSION_LEGACY | VERSION_PEP440
 VERSION_MANY = Combine(VERSION_ONE + ZeroOrMore(COMMA + VERSION_ONE),
                        joinString=",")("_raw_spec")
 _VERSION_SPEC = Optional(((LPAREN + VERSION_MANY + RPAREN) | VERSION_MANY))

--- a/packaging/specifiers.py
+++ b/packaging/specifiers.py
@@ -218,9 +218,10 @@ class LegacySpecifier(_IndividualSpecifier):
         (?P<operator>(==|!=|<=|>=|<|>))
         \s*
         (?P<version>
-            [^\s]* # We just match everything, except for whitespace since this
-                   # is a "legacy" specifier and the version string can be just
-                   # about anything.
+            [^;\s]* # We just match everything, except for whitespace, and
+                    # a semi-colon (for markers), since this is a "legacy"
+                    # specifier and the version string can be just about
+                    # anything.
         )
         """
     )

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -56,6 +56,15 @@ class TestRequirements:
         req = Requirement("name>=3")
         self._assert_requirement(req, "name", specifier=">=3")
 
+    def test_with_legacy_version(self):
+        req = Requirement("name==1.0.org1")
+        self._assert_requirement(req, "name", specifier="==1.0.org1")
+
+    def test_with_legacy_version_and_marker(self):
+        req = Requirement("name>=1.x.y;python_version=='2.6'")
+        self._assert_requirement(req, "name", specifier=">=1.x.y",
+                                 marker='python_version == "2.6"')
+
     def test_name_with_multiple_versions(self):
         req = Requirement("name>=3,<2")
         self._assert_requirement(req, "name", specifier="<2,>=3")


### PR DESCRIPTION
When we added support for requirements parsing, we didn't test non PEP 440 compliant versions, so of course it was broken. :-(