### PR TITLE
Correctly parse versions with parens too

### DIFF
--- a/packaging/requirements.py
+++ b/packaging/requirements.py
@@ -47,7 +47,7 @@ EXTRAS = (LBRACKET + Optional(EXTRAS_LIST) + RBRACKET)("extras")
 VERSION_PEP440 = Regex(Specifier._regex_str, re.VERBOSE | re.IGNORECASE)
 VERSION_LEGACY = Regex(LegacySpecifier._regex_str, re.VERBOSE | re.IGNORECASE)
 
-VERSION_ONE = VERSION_LEGACY | VERSION_PEP440
+VERSION_ONE = VERSION_PEP440 ^ VERSION_LEGACY
 VERSION_MANY = Combine(VERSION_ONE + ZeroOrMore(COMMA + VERSION_ONE),
                        joinString=",")("_raw_spec")
 _VERSION_SPEC = Optional(((LPAREN + VERSION_MANY + RPAREN) | VERSION_MANY))

--- a/packaging/specifiers.py
+++ b/packaging/specifiers.py
@@ -218,10 +218,11 @@ class LegacySpecifier(_IndividualSpecifier):
         (?P<operator>(==|!=|<=|>=|<|>))
         \s*
         (?P<version>
-            [^;\s]* # We just match everything, except for whitespace, and
-                    # a semi-colon (for markers), since this is a "legacy"
-                    # specifier and the version string can be just about
-                    # anything.
+            [^;\s)]* # We just match everything, except for whitespace,
+                     # a semi-colon for marker support, and closing paren
+                     # since versions can be enclosed in them. Since this is
+                     # a "legacy" specifier and the version string can be
+                     # just about anything.
         )
         """
     )

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -65,6 +65,10 @@ class TestRequirements:
         self._assert_requirement(req, "name", specifier=">=1.x.y",
                                  marker='python_version == "2.6"')
 
+    def test_version_with_parens_and_whitespace(self):
+        req = Requirement("name (==4)")
+        self._assert_requirement(req, "name", specifier="==4")
+
     def test_name_with_multiple_versions(self):
         req = Requirement("name>=3,<2")
         self._assert_requirement(req, "name", specifier="<2,>=3")


### PR DESCRIPTION
It turns out that the 16.3 release broke requirement parsing if the version was encased in a paren. Furthermore, having VERSION_LEGACY first was actually the wrong solution. | in pyparsing is not or, it is MatchFirst(), which means if the left most expression matches (or partially matches), then the rest of the expression will be skipped, which is why 16.1 and 16.2 couldn't parse legacy versions.

The solution there is to use ^ which is Or(), which will compute both, and use the one that matched more characters. In the case of a tie, the left most expression wins, so VERSION_PEP440 should be back in use almost all the time.

Adding ) to LegacySpecifier regex's exclusion is so we can deal with requirements enclosed in parens.

A 16.4 release when this lands would be lovely.