### PR TITLE
Fix regression in parsing requirements with whitespace

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,8 @@ Changelog
 
 .. note:: This version is not yet released and is under active development.
 
+* Fix a regression in parsing requirements with multiple versions and
+  whitespace, like ``foo>=2.0, !=2.1``. (:issue:`65`).
 
 16.4 - 2016-02-22
 ~~~~~~~~~~~~~~~~~

--- a/packaging/specifiers.py
+++ b/packaging/specifiers.py
@@ -215,20 +215,22 @@ class LegacySpecifier(_IndividualSpecifier):
 
     _regex_str = (
         r"""
+        \s*
         (?P<operator>(==|!=|<=|>=|<|>))
         \s*
         (?P<version>
-            [^;\s)]* # We just match everything, except for whitespace,
-                     # a semi-colon for marker support, and closing paren
-                     # since versions can be enclosed in them. Since this is
-                     # a "legacy" specifier and the version string can be
-                     # just about anything.
+            [^;\s),]* # We just match everything, except for whitespace,
+                      # a comma for multiple version support, a semi-colon for
+                      # marker support, and closing paren since versions can be
+                      # enclosed in them. Since this is a "legacy" specifier
+                      # and the version string can be just about anything.
         )
+        \s*
         """
     )
 
     _regex = re.compile(
-        r"^\s*" + _regex_str + r"\s*$", re.VERBOSE | re.IGNORECASE)
+        r"^" + _regex_str + r"$", re.VERBOSE | re.IGNORECASE)
 
     _operators = {
         "==": "equal",
@@ -276,6 +278,7 @@ class Specifier(_IndividualSpecifier):
 
     _regex_str = (
         r"""
+        \s*
         (?P<operator>(~=|==|!=|<=|>=|<|>|===))
         (?P<version>
             (?:
@@ -366,11 +369,12 @@ class Specifier(_IndividualSpecifier):
                 (?:[-_\.]?dev[-_\.]?[0-9]*)?          # dev release
             )
         )
+        \s*
         """
     )
 
     _regex = re.compile(
-        r"^\s*" + _regex_str + r"\s*$", re.VERBOSE | re.IGNORECASE)
+        r"^" + _regex_str + r"$", re.VERBOSE | re.IGNORECASE)
 
     _operators = {
         "~=": "compatible",

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -73,6 +73,22 @@ class TestRequirements:
         req = Requirement("name>=3,<2")
         self._assert_requirement(req, "name", specifier="<2,>=3")
 
+    def test_name_with_multiple_versions_and_right_pre_whitespace(self):
+        req = Requirement("name>=3, <2")
+        self._assert_requirement(req, "name", specifier="<2,>=3")
+
+    def test_name_with_multiple_versions_and_right_post_whitespace(self):
+        req = Requirement("name>=3,<2 ")
+        self._assert_requirement(req, "name", specifier="<2,>=3")
+
+    def test_name_with_multiple_versions_and_right_pre_post_whitespace(self):
+        req = Requirement("name>=3, <2 ")
+        self._assert_requirement(req, "name", specifier="<2,>=3")
+
+    def test_name_with_multiple_versions_and_all_whitespace(self):
+        req = Requirement("name >= 3 , <2 ")
+        self._assert_requirement(req, "name", specifier="<2,>=3")
+
     def test_extras(self):
         req = Requirement("foobar [quux,bar]")
         self._assert_requirement(req, "foobar", extras=["bar", "quux"])


### PR DESCRIPTION
Fixes #65. This was introduced in 3e1be47f6903c53d08a50a7b57c838d1a90cdece, there were just no tests covering it.