### PR TITLE
Parse multiple specifiers containing whitespace

### DIFF
--- a/packaging/requirements.py
+++ b/packaging/requirements.py
@@ -49,7 +49,7 @@ VERSION_LEGACY = Regex(LegacySpecifier._regex_str, re.VERBOSE | re.IGNORECASE)
 
 VERSION_ONE = VERSION_PEP440 ^ VERSION_LEGACY
 VERSION_MANY = Combine(VERSION_ONE + ZeroOrMore(COMMA + VERSION_ONE),
-                       joinString=",")("_raw_spec")
+                       joinString=",", adjacent=False)("_raw_spec")
 _VERSION_SPEC = Optional(((LPAREN + VERSION_MANY + RPAREN) | VERSION_MANY))
 _VERSION_SPEC.setParseAction(lambda s, l, t: t._raw_spec or '')
 

--- a/packaging/specifiers.py
+++ b/packaging/specifiers.py
@@ -218,11 +218,11 @@ class LegacySpecifier(_IndividualSpecifier):
         (?P<operator>(==|!=|<=|>=|<|>))
         \s*
         (?P<version>
-            [^;\s)]* # We just match everything, except for whitespace,
-                     # a semi-colon for marker support, and closing paren
-                     # since versions can be enclosed in them. Since this is
-                     # a "legacy" specifier and the version string can be
-                     # just about anything.
+            [^,;\s)]* # Since this is a "legacy" specifier, and the version
+                      # string can be just about anything, we match everything
+                      # except for whitespace, a semi-colon for marker support,
+                      # a closing paren since versions can be enclosed in
+                      # them, and a comma since it's a version separator.
         )
         """
     )

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -73,6 +73,10 @@ class TestRequirements:
         req = Requirement("name>=3,<2")
         self._assert_requirement(req, "name", specifier="<2,>=3")
 
+    def test_name_with_multiple_versions_and_whitespace(self):
+        req = Requirement("name >=2, <3")
+        self._assert_requirement(req, "name", specifier="<3,>=2")
+
     def test_extras(self):
         req = Requirement("foobar [quux,bar]")
         self._assert_requirement(req, "foobar", extras=["bar", "quux"])


### PR DESCRIPTION
Firstly, drop comma from the acceptable character list by excluding it in LegacySpecifier's regex. To be honest, I feel this should have been added from the start, since any PEP has specified using commas to separate multiple specifiers. Secondly, I've reflowed the comment so it should scan better.

I've added ajdacent=False to the Combine() constructor, since it by default will not accept tokens that have whitespace between them.