### PR TITLE
Re-add support for deprecated PEP-345 markers

### DIFF
--- a/packaging/markers.py
+++ b/packaging/markers.py
@@ -73,9 +73,14 @@ VARIABLE = (
     L("python_version") |
     L("sys_platform") |
     L("os_name") |
+    L("os.name") |  # PEP-345
+    L("sys.platform") |  # PEP-345
+    L("platform.version") |  # PEP-345
+    L("platform.machine") |  # PEP-345
+    L("platform.python_implementation") |  # PEP-345
     L("extra")
 )
-VARIABLE.setParseAction(lambda s, l, t: Variable(t[0]))
+VARIABLE.setParseAction(lambda s, l, t: Variable(t[0].replace('.', '_')))
 
 VERSION_CMP = (
     L("===") |


### PR DESCRIPTION
packaging.markers did not support the same environment markers that
PEP 345 specified, and they are still in use.

Closes #70 

A release when this merges would be lovely.