### PR TITLE
Fix #72: Add support for python_implementation marker

### DIFF
--- a/packaging/markers.py
+++ b/packaging/markers.py
@@ -78,9 +78,14 @@ VARIABLE = (
     L("platform.version") |  # PEP-345
     L("platform.machine") |  # PEP-345
     L("platform.python_implementation") |  # PEP-345
+    L("python_implementation") |  # undocumented setuptools legacy
     L("extra")
 )
-VARIABLE.setParseAction(lambda s, l, t: Variable(t[0].replace('.', '_')))
+ALIASES = {
+    'python_implementation': 'platform_python_implementation'
+}
+VARIABLE.setParseAction(lambda s, l, t:
+                        Variable(ALIASES.get(t[0], t[0].replace('.', '_'))))
 
 VERSION_CMP = (
     L("===") |

--- a/packaging/markers.py
+++ b/packaging/markers.py
@@ -82,10 +82,14 @@ VARIABLE = (
     L("extra")
 )
 ALIASES = {
+    'os.name': 'os_name',
+    'sys.platform': 'sys_platform',
+    'platform.version': 'platform_version',
+    'platform.machine': 'platform_machine',
+    'platform.python_implementation': 'platform_python_implementation',
     'python_implementation': 'platform_python_implementation'
 }
-VARIABLE.setParseAction(lambda s, l, t:
-                        Variable(ALIASES.get(t[0], t[0].replace('.', '_'))))
+VARIABLE.setParseAction(lambda s, l, t: Variable(ALIASES.get(t[0], t[0])))
 
 VERSION_CMP = (
     L("===") |

--- a/tests/test_markers.py
+++ b/tests/test_markers.py
@@ -30,6 +30,10 @@ PEP_345_VARIABLES = [
     "platform.python_implementation",
 ]
 
+SETUPTOOLS_VARIABLES = [
+    "python_implementation",
+]
+
 OPERATORS = [
     "===", "==", ">=", "<=", "!=", "~=", ">", "<", "in", "not in",
 ]
@@ -346,3 +350,21 @@ class TestMarker:
                                      expected):
         args = [] if environment is None else [environment]
         assert Marker(marker_string).evaluate(*args) == expected
+
+    @pytest.mark.parametrize(
+        "marker_string",
+        [
+            "{0} {1} {2!r}".format(*i)
+            for i in itertools.product(SETUPTOOLS_VARIABLES, OPERATORS, VALUES)
+        ] + [
+            "{2!r} {1} {0}".format(*i)
+            for i in itertools.product(SETUPTOOLS_VARIABLES, OPERATORS, VALUES)
+        ],
+    )
+    def test_parses_setuptools_legacy_valid(self, marker_string):
+        Marker(marker_string)
+
+    def test_evaluate_setuptools_legacy_markers(self):
+        marker_string = "python_implementation=='Jython'"
+        args = [{"platform_python_implementation": "CPython"}]
+        assert Marker(marker_string).evaluate(*args) is False


### PR DESCRIPTION
This is legacy from setuptools, supported from 0.7 to 20.1.1 (inclusive). The #72 bug report has all the detail you could ever want about its history.
