### PR TITLE
Drop Python 2.6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ python: 3.4
 sudo: false
 
 env:
-  - TOXENV=py26
   - TOXENV=py27
   - TOXENV=py32
   - TOXENV=py33

--- a/docs/development/getting-started.rst
+++ b/docs/development/getting-started.rst
@@ -37,7 +37,6 @@ each supported Python version and run the tests. For example:
 
     $ tox
     ...
-    ERROR:   py26: InterpreterNotFound: python2.6
      py27: commands succeeded
     ERROR:   pypy: InterpreterNotFound: pypy
     ERROR:   py32: InterpreterNotFound: python3.2

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,6 @@ setup(
 
         "Programming Language :: Python",
         "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.6",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.2",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,pypy,py32,py33,py34,docs,pep8,py2pep8
+envlist = py27,pypy,py32,py33,py34,docs,pep8,py2pep8
 
 [testenv]
 deps =
@@ -11,12 +11,6 @@ commands =
     python -m coverage report -m --fail-under 100
 install_command =
     pip install --find-links https://wheels.caremad.io/ {opts} {packages}
-
-# Python 2.6 doesn't support python -m on a package.
-[testenv:py26]
-commands =
-    python -m coverage.__main__ run --source packaging/ -m pytest --strict {posargs}
-    python -m coverage.__main__ report -m --fail-under 100
 
 # coverage.py doesn't support Python 3.2 anymore.
 [testenv:py32]
@@ -44,7 +38,7 @@ deps =
 commands = flake8 .
 
 [testenv:py2pep8]
-basepython = python2.6
+basepython = python2.7
 deps =
     flake8
     pep8-naming


### PR DESCRIPTION
Yesterday marks 3 years since the last release of Python 2.6! 🎉

To celebrate, I'm attempting to drop support for it from 156 prominent Python packages (one for every week it's past end-of-life)--including this one!

I've tried my best to remove as much 2.6-specific cruft as I can, but at the very least, this PR will remove the `'Programming Language :: Python :: 2.6'` trove classifier from this projects `setup.py`.
