### PR TITLE
[WIP] Implement PEP 503

### DIFF
--- a/packaging/repositories/__init__.py
+++ b/packaging/repositories/__init__.py
@@ -1,0 +1,15 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+from __future__ import absolute_import, division, print_function
+
+from .filters import ProjectFilter, FormatFilter
+from .legacy import FlatHTMLRepository, SimpleRepository
+from .wrappers import FilteredRepository, MultiRepository
+
+
+__all__ = [
+    "ProjectFilter", "FormatFilter",
+    "FlatHTMLRepository", "SimpleRepository",
+    "FilteredRepository", "MultiRepository",
+]

--- a/packaging/repositories/base.py
+++ b/packaging/repositories/base.py
@@ -4,12 +4,9 @@
 from __future__ import absolute_import, division, print_function
 
 import abc
-import cgi
 
 import attr
 import six
-
-from six.moves import urllib_parse
 
 
 @attr.s(cmp=False, frozen=True, slots=True)
@@ -35,61 +32,3 @@ class BaseRepository(six.with_metaclass(abc.ABCMeta, object)):
         Find all available distributions in the repository for a project named
         `project`.
         """
-
-
-@attr.s(cmp=False, frozen=True, slots=True)
-class Response(object):
-
-    url = attr.ib()
-    data = attr.ib(repr=False)
-    encoding = attr.ib(repr=False)
-
-
-class BaseTransport(six.with_metaclass(abc.ABCMeta, object)):
-
-    @abc.abstractmethod
-    def get(self, url):
-        """
-        Gets the data represented by a specific URL, returning the content as
-        a tuple of
-        """
-
-
-class RequestsTransport(BaseTransport):
-
-    def __init__(self, session=None):
-        if session is None:
-            import requests
-            session = requests.session()
-
-        self._session = session
-
-    def get(self, url):
-        try:
-            resp = self._session.get(url)
-            resp.raise_for_status()
-        except Exception:  # TODO: Better Exception
-            # TODO: How should we signal to the caller that there wasn't an
-            #       item (either because of connection issues, 404, or
-            #       whatever). As an extended bit, do we want to treat things
-            #       like 404 errors differently then 500 errors or connection
-            #       errors?
-            return None
-
-        # Detect what the character set of the transport is.
-        _, params = cgi.parse_header(resp.headers.get("Content-Type", ""))
-        encoding = params.get("charset")
-
-        return Response(url=url, data=resp.content, encoding=encoding)
-
-
-@attr.s(cmp=False, frozen=True, slots=True)
-class Transports(BaseTransport):
-
-    schemes = attr.ib()
-
-    def _transport_for_url(self, url):
-        return self.schemes[urllib_parse.urlparse(url).scheme]
-
-    def get(self, url):
-        return self._transport_for_url(url).get(url)

--- a/packaging/repositories/base.py
+++ b/packaging/repositories/base.py
@@ -1,0 +1,95 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+from __future__ import absolute_import, division, print_function
+
+import abc
+import cgi
+
+import attr
+import six
+
+from six.moves import urllib_parse
+
+
+@attr.s(cmp=False, frozen=True, slots=True)
+class AvailableFile(object):
+
+    # TODO: What is the appropiate data structure for this? We need to
+    #       correctly support the case where the only things we really know
+    #       about the project is the items available in the old legacy/simple
+    #       repository API, however we also need to think about the future when
+    #       we have more information than that available to us.
+
+    project = attr.ib()
+    version = attr.ib()
+    location = attr.ib()
+    hashes = attr.ib(default=attr.Factory(dict), repr=False, hash=False)
+
+
+class BaseRepository(six.with_metaclass(abc.ABCMeta, object)):
+
+    @abc.abstractmethod
+    def fetch(self, project):
+        """
+        Find all available distributions in the repository for a project named
+        `project`.
+        """
+
+
+@attr.s(cmp=False, frozen=True, slots=True)
+class Response(object):
+
+    url = attr.ib()
+    data = attr.ib(repr=False)
+    encoding = attr.ib(repr=False)
+
+
+class BaseTransport(six.with_metaclass(abc.ABCMeta, object)):
+
+    @abc.abstractmethod
+    def get(self, url):
+        """
+        Gets the data represented by a specific URL, returning the content as
+        a tuple of
+        """
+
+
+class RequestsTransport(BaseTransport):
+
+    def __init__(self, session=None):
+        if session is None:
+            import requests
+            session = requests.session()
+
+        self._session = session
+
+    def get(self, url):
+        try:
+            resp = self._session.get(url)
+            resp.raise_for_status()
+        except Exception:  # TODO: Better Exception
+            # TODO: How should we signal to the caller that there wasn't an
+            #       item (either because of connection issues, 404, or
+            #       whatever). As an extended bit, do we want to treat things
+            #       like 404 errors differently then 500 errors or connection
+            #       errors?
+            return None
+
+        # Detect what the character set of the transport is.
+        _, params = cgi.parse_header(resp.headers.get("Content-Type", ""))
+        encoding = params.get("charset")
+
+        return Response(url=url, data=resp.content, encoding=encoding)
+
+
+@attr.s(cmp=False, frozen=True, slots=True)
+class Transports(BaseTransport):
+
+    schemes = attr.ib()
+
+    def _transport_for_url(self, url):
+        return self.schemes[urllib_parse.urlparse(url).scheme]
+
+    def get(self, url):
+        return self._transport_for_url(url).get(url)

--- a/packaging/repositories/filters.py
+++ b/packaging/repositories/filters.py
@@ -1,0 +1,74 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+from __future__ import absolute_import, division, print_function
+
+import attr
+
+
+@attr.s(cmp=False, frozen=True, init=False)
+class ProjectFilter:
+
+    projects = attr.ib(default=attr.Factory(list))
+
+    def __init__(self, *projects):
+        self.__dict__["projects"] = list(projects)
+
+    @property
+    def blacklist(self):
+        if not hasattr(self, "_blacklist"):
+            self.__dict__["_blacklist"] = [
+                p[1:] for p in self.projects if p.startswith("!")
+            ]
+
+        return self._blacklist
+
+    @property
+    def whitelist(self):
+        if not hasattr(self, "_whitelist"):
+            self.__dict__["_whitelist"] = [
+                p for p in self.projects if not p.startswith("!")
+            ]
+
+        return self._whitelist
+
+    def __call__(self, item):
+        # If the project is in our blacklist, then we can go ahead and reject
+        # it up front because no matter what if it appears here then it is
+        # rejected.
+        if item.project in self.blacklist:
+            return False
+        # If the project is in our whitelist, then we can go ahead and allow it
+        # now. If it is in both the whitelist and the blacklist, the first
+        # conditional will have already rejected it.
+        elif item.project in self.whitelist:
+            return True
+        # If we have any whitelisted projects at all, then we can just blindly
+        # reject anything else at this point because we've already checked for
+        # the project to exist in our whitelist and it did not pass that.
+        elif self.whitelist:
+            return False
+        # If we do not have a whitelist (e.g. this is a blacklist only filter)
+        # and we've gotten to this point, then our first conditional would have
+        # ensured that any blacklisted items are already rejected and the
+        # check for a whitelist would have ensured we are not filtering to only
+        # specific projects, so we can just go ahead and blindly allow.
+        else:
+            return True
+
+
+@attr.s(cmp=False, frozen=True, slots=True)
+class FormatFilter:
+
+    wheel = attr.ib(default=True)
+    sdist = attr.ib(default=True)
+
+    def __call__(self, item):
+        # TODO: This should ideally be a lot smarter, but this is good enough
+        #       for now.
+        if item.location.endswith(".whl"):
+            return self.wheel
+        elif item.location.endswith((".zip", ".tar.gz")):
+            return self.sdist
+
+        return False

--- a/packaging/repositories/legacy.py
+++ b/packaging/repositories/legacy.py
@@ -3,6 +3,7 @@
 # for complete details.
 from __future__ import absolute_import, division, print_function
 
+import cgi
 import functools
 
 import attr
@@ -48,10 +49,13 @@ class _HTMLRepository(BaseRepository):
         #         file. This will work better when we combine multiple
         #         repositories into a single stream of files.
 
+        _, params = cgi.parse_header(resp.headers.get("Content-Type", ""))
+        encoding = params.get("charset")
+
         html = html5lib.parse(
-            resp.data,
+            resp.content,
             namespaceHTMLElements=False,
-            transport_encoding=resp.encoding,
+            transport_encoding=encoding,
         )
 
         result = []

--- a/packaging/repositories/legacy.py
+++ b/packaging/repositories/legacy.py
@@ -1,0 +1,96 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+from __future__ import absolute_import, division, print_function
+
+import attr
+import html5lib
+
+from six.moves import urllib_parse
+
+from .base import AvailableFile, BaseRepository
+from ..utils import canonicalize_name
+
+
+@attr.s(cmp=False, frozen=True, slots=True)
+class _HTMLRepository(BaseRepository):
+
+    # TODO: Determine how we should actually set thse values.
+    _ALLOWED_HASHES = frozenset(["md5", "sha256"])
+
+    url = attr.ib()
+    transport = attr.ib(hash=False, repr=False)
+
+    def _get_project_url(self, project):
+        raise NotImplementedError
+
+    def _get_base_url(self, html):
+        bases = [
+            x for x in html.findall(".//base")
+            if x.get("href") is not None
+        ]
+
+        if bases and bases[0].get("href"):
+            return bases[0].get("href")
+        else:
+            return self.url
+
+    def fetch(self, project):
+        # TODO: Is there an order that we should be returning from this? Is
+        #       that meaningful? Perhaps order of priority?
+        # TODO: Do we want this to yield one item per file? One item per
+        #       version with multiple files attached to it? what's most
+        #       important here?
+        #       - I think that we're likely to want to use a single item per
+        #         file. This will work better when we combine multiple
+        #         repositories into a single stream of files.
+
+        # Fetch the data from the repository
+        resp = self.transport.get(self._get_project_url(project))
+
+        # Actually parse the HTML we've gotten now.
+        html = html5lib.parse(
+            resp.data,
+            namespaceHTMLElements=False,
+            transport_encoding=resp.encoding,
+        )
+
+        for anchor in html.findall(".//a"):
+            # TODO: Should we filter out anything that isn't a valid file for
+            #       this project? Or should we assume the repository is giving
+            #       us correct information.
+            href = anchor.get("href")
+            if href:
+                location = urllib_parse.urljoin(self._get_base_url(html), href)
+                hashes = {}
+
+                parsed_location = urllib_parse.urlparse(location)
+                if parsed_location.fragment:
+                    fragment = urllib_parse.parse_qs(parsed_location.fragment)
+                    for key, value in fragment.items():
+                        if key.lower() in self._ALLOWED_HASHES and value:
+                            # We only support a single value for each type of
+                            # hash, this makes sense because the same file
+                            # should *always* hash to the same thing.
+                            hashes[key.lower()] = value[0]
+
+                yield AvailableFile(
+                    project=project,
+                    version=None,
+                    location=urllib_parse.urldefrag(location).url,
+                    hashes=hashes,
+                )
+
+
+class SimpleRepository(_HTMLRepository):
+
+    def _get_project_url(self, project):
+        return urllib_parse.urldefrag(
+            urllib_parse.urljoin(self.url, canonicalize_name(project) + "/")
+        ).url
+
+
+class FlatHTMLRepository(_HTMLRepository):
+
+    def _get_project_url(self, project):
+        return urllib_parse.urldefrag(self.url).url

--- a/packaging/repositories/wrappers.py
+++ b/packaging/repositories/wrappers.py
@@ -1,0 +1,30 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+from __future__ import absolute_import, division, print_function
+
+import attr
+
+from .base import BaseRepository
+
+
+@attr.s(cmp=False, frozen=True, slots=True)
+class FilteredRepository(BaseRepository):
+
+    repository = attr.ib()
+    _predicate = attr.ib(repr=False, hash=False)
+
+    def fetch(self, project):
+        for item in filter(self._predicate, self.repository.fetch(project)):
+            yield item
+
+
+@attr.s(cmp=False, frozen=True, slots=True)
+class MultiRepository(BaseRepository):
+
+    repositories = attr.ib()
+
+    def fetch(self, project):
+        for repository in self.repositories:
+            for item in repository.fetch(project):
+                yield item

--- a/packaging/transports/__init__.py
+++ b/packaging/transports/__init__.py
@@ -1,0 +1,12 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+from __future__ import absolute_import, division, print_function
+
+
+from .wrappers import Transports  # noqa
+
+try:
+    from .requests import RequestsTransport  # noqa
+except ImportError:
+    pass

--- a/packaging/transports/base.py
+++ b/packaging/transports/base.py
@@ -1,0 +1,26 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+from __future__ import absolute_import, division, print_function
+
+import abc
+
+import attr
+import six
+
+
+@attr.s(cmp=False, frozen=True, slots=True)
+class Response(object):
+
+    url = attr.ib()
+    content = attr.ib(repr=False)
+    headers = attr.ib(default=attr.Factory(dict), repr=False)
+
+
+class BaseTransport(six.with_metaclass(abc.ABCMeta, object)):
+
+    @abc.abstractmethod
+    def get(self, url):
+        """
+        Gets the data represented by a specific URL.
+        """

--- a/packaging/transports/requests.py
+++ b/packaging/transports/requests.py
@@ -1,0 +1,29 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+from __future__ import absolute_import, division, print_function
+
+import attr
+import requests
+
+from .base import BaseTransport, Response
+
+
+@attr.s(cmp=False, frozen=True, slots=True)
+class RequestsTransport(BaseTransport):
+
+    _session = attr.ib(default=attr.Factory(requests.session), repr=False)
+
+    def get(self, url):
+        try:
+            resp = self._session.get(url)
+            resp.raise_for_status()
+        except Exception:  # TODO: Better Exception
+            # TODO: How should we signal to the caller that there wasn't an
+            #       item (either because of connection issues, 404, or
+            #       whatever). As an extended bit, do we want to treat things
+            #       like 404 errors differently then 500 errors or connection
+            #       errors?
+            raise
+
+        return Response(url=url, headers=resp.headers, content=resp.content)

--- a/packaging/transports/wrappers.py
+++ b/packaging/transports/wrappers.py
@@ -1,0 +1,22 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+from __future__ import absolute_import, division, print_function
+
+import attr
+
+from six.moves import urllib_parse
+
+from .base import BaseTransport
+
+
+@attr.s(cmp=False, frozen=True, slots=True)
+class Transports(BaseTransport):
+
+    schemes = attr.ib()
+
+    def _transport_for_url(self, url):
+        return self.schemes[urllib_parse.urlparse(url).scheme]
+
+    def get(self, url):
+        return self._transport_for_url(url).get(url)


### PR DESCRIPTION
This is a start of what it would look like for packaging to implement PEP 503. This interface features a composition driven interface that lets you easily do things like filter a particular repository (or all repositories) and then combine multiple repositories so that they act as one single repository.

Using this PR, you can write some code that looks like:

```python
from packaging.repositories import (
    ProjectFilter, FormatFilter,
    FilteredRepository, MultiRepository,
    SimpleRepository,
)
from packaging.repositories.base import RequestsTransport, Transports


transports = Transports(schemes={
    "https": RequestsTransport(),
    "http": RequestsTransport(),
})


repo = FilteredRepository(
    MultiRepository(repositories=[
        # SimpleRepository("https://pypi.example.com/", transport=transports),
        FilteredRepository(
            SimpleRepository("https://pypi.org/simple/", transport=transports),
            ProjectFilter("!myinternallibrary"),
        ),
    ]),
    FormatFilter(wheel=True, sdist=False),
)

files = list(repo.fetch("pip"))
```

This is still heavily a work in progress, and there are a number of open questions like:

* How exactly should we handle transports? Right now there is a class that implements the very basics of what we need, but is that the right way of doing it? We can't just simply bake in ``requests`` here because we want to be able to handle more than HTTP(S) and ideally even something that will integrate reasonably well with Twisted or asyncio. This is the least fleshed out part of this PR currently.
* Does it make sense to have ``Repository().fetch()`` return a single object per file it finds? Personally I think it does because it makes things like filtering on file type much easier to do in an immutable way as well as making it so ``MultiRepository`` doesn't need to buffer the entire stream in memory so that it can collapse multiple entries from multiple repositories into a single entry.
* What data structure do we actually want to return from ``Repository().fetch()``? This needs to be something that can deal with the fact that our API currently provides very little information but that can extend out to a much more fleshed out metadata (including possibly the *entire* set of metadata).
* How should transports treat network errors? What about errors like HTTP 404? Should they just skip that repository? Raise an exception? If we raise an exception we could add another Filter that silences network errors (or logs them) and turns them into empty iterables but that makes constructing a repository even more ugly.
* We need to know what values can be Hashes, but how should we set those? Is pulling the data out of ``hashlib`` enough? What if we start to support blake or something?
* Does this make sense to live in packaging at all? Currently we're largely only core data types and utilities but this would be our first real bit of network code.
* Typically in the past we've waited until we had a new API designed and encoded in a PEP before we implemented the API for it in packaging, should we wait for that to happen here too?

There is also more work to be done in actually extracting information from the legacy repository types.

I'm curious what folks think about the API and if anyone has any opinions on the questions above.