### PR TITLE
In Markers, use PEP 440 version comparison only if both sides are valid version specifier.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,8 @@ Changelog
 
 .. note:: This version is not yet released and is under active development.
 
+* Fix a bug where ``packaging.markers.Marker.evaluate`` used PEP 440
+  version comparison when the left side is not a valid version specifier.
 * Drop support for python 2.6 and 3.2
 
 

--- a/packaging/markers.py
+++ b/packaging/markers.py
@@ -14,6 +14,7 @@ from pyparsing import Literal as L  # noqa
 
 from ._compat import string_types
 from .specifiers import Specifier, InvalidSpecifier
+from .version import Version, InvalidVersion
 
 
 __all__ = [
@@ -182,8 +183,11 @@ _operators = {
 
 def _eval_op(lhs, op, rhs):
     try:
+        # PEP 508: Use the PEP-440 version comparison rules
+        # when both sides have a valid version specifier.
         spec = Specifier("".join([op.serialize(), rhs]))
-    except InvalidSpecifier:
+        lhs = Version(lhs)
+    except (InvalidSpecifier, InvalidVersion):
         pass
     else:
         return spec.contains(lhs)

--- a/packaging/version.py
+++ b/packaging/version.py
@@ -33,7 +33,7 @@ def parse(version):
         return LegacyVersion(version)
 
 
-class InvalidVersion(ValueError):
+class InvalidVersion(Exception):
     """
     An invalid version was found, users should refer to PEP 440.
     """
@@ -198,7 +198,14 @@ class Version(_BaseVersion):
 
     def __init__(self, version):
         # Validate the version and parse it into pieces
-        match = self._regex.search(str(version))
+        try:
+            match = self._regex.search(version)
+        except TypeError:
+            raise InvalidVersion(
+                "Invalid type: '{0}' of type '{1}' is not a string".format(
+                    version, type(version)
+                )
+            )
         if not match:
             raise InvalidVersion("Invalid version: '{0}'".format(version))
 

--- a/packaging/version.py
+++ b/packaging/version.py
@@ -198,7 +198,7 @@ class Version(_BaseVersion):
 
     def __init__(self, version):
         # Validate the version and parse it into pieces
-        match = self._regex.search(version)
+        match = self._regex.search(str(version))
         if not match:
             raise InvalidVersion("Invalid version: '{0}'".format(version))
 

--- a/tests/test_markers.py
+++ b/tests/test_markers.py
@@ -303,6 +303,46 @@ class TestMarker:
                 {"extra": "security"},
                 True,
             ),
+            (
+                "extra == 'security'",
+                {"extra": None},
+                False,
+            ),
+            (
+                "extra == '3.7.0'",
+                {"extra": None},
+                False,
+            ),
+            (
+                "extra == '3.7.0'",
+                {"extra": "foobar"},
+                False,
+            ),
+            (
+                "extra == '3.7.0'",
+                {"extra": "3.7.0"},
+                True,
+            ),
+            (
+                "extra == '3.7.0'",
+                {"extra": "3.7"},
+                True,
+            ),
+            (
+                "extra == '3.7.0'",
+                {"extra": "3.7.0.0"},
+                True,
+            ),
+            (
+                "extra == '3.7.0'",
+                {"extra": "3.7.0+youaregreat"},
+                True,
+            ),
+            (
+                "extra == '3.7.0'",
+                {"extra": "3.7.1"},
+                False,
+            ),
         ],
     )
     def test_evaluates(self, marker_string, environment, expected):

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -57,6 +57,20 @@ class TestVersion:
             # None is not a valid version
             None,
 
+            # Numbers (not strings) are not valid versions
+            0,
+            1,
+            1.0,
+            1.1,
+
+            # Object that are not string are not valid versions
+            [],
+            [1],
+            {},
+            {'1': 1},
+            tuple(),
+            (1, 2),
+
             # Non sensical versions should be invalid
             "french toast",
 

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -17,6 +17,7 @@ from packaging.version import Version, LegacyVersion, InvalidVersion, parse
     [
         ("1.0", Version),
         ("1-1-1", LegacyVersion),
+        (None, LegacyVersion),
     ],
 )
 def test_parse(version, klass):
@@ -53,6 +54,9 @@ class TestVersion:
     @pytest.mark.parametrize(
         "version",
         [
+            # None is not a valid version
+            None,
+
             # Non sensical versions should be invalid
             "french toast",
 


### PR DESCRIPTION
This adresses the bug mentionned here: pypa/pip#4356.

This parses the `lhs` to make sure it's a valid PEP 440 version specifier before attempting to use PEP 440 version comparison.
Do to so, the behaviour of `Version(None)` (or rather `Version(<not a string>)`) was changed: It now raises an `InvalidVersion` exception instead of relying on the regex raising a `TypeError`.