### PR TITLE
Fix tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ python: 3.4
 sudo: false
 
 env:
-  - TOXENV=py26
   - TOXENV=py27
   - TOXENV=py32
   - TOXENV=py33

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,30 @@
 language: python
-python: 3.4
 
-sudo: false
 
-env:
-  - TOXENV=py27
-  - TOXENV=py33
-  - TOXENV=py34
-  - TOXENV=pypy
-  - TOXENV=pep8
-  - TOXENV=py2pep8
-  - TOXENV=docs
-  - TOXENV=packaging
+matrix:
+  include:
+    - python: 2.7
+      env: TOXENV=py27
+    - python: 3.3
+      env: TOXENV=py33
+    - python: 3.4
+      env: TOXENV=py34
+    - python: 3.5
+      env: TOXENV=py35
+    - python: 3.6
+      env: TOXENV=py36
+    - python: nightly
+      env: TOXENV=py37
+    - python: pypy
+      env: TOXENV=pypy
+    - env: TOXENV=pep8
+    - env: TOXENV=py2pep8
+    - python: 3.6
+      env: TOXENV=docs
+    - env: TOXENV=packaging
+
+  allow_failures:
+    - python: nightly
 
 install:
   - pip install tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ sudo: false
 
 env:
   - TOXENV=py27
-  - TOXENV=py32
   - TOXENV=py33
   - TOXENV=py34
   - TOXENV=pypy
@@ -16,7 +15,6 @@ env:
 
 install:
   - pip install tox
-  - if [[ $TOXENV == 'pep8' || $TOXENV == 'py32' ]]; then pip install "virtualenv<14" ; fi
 
 script:
   - tox

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,8 @@ Changelog
 
 .. note:: This version is not yet released and is under active development.
 
+* Drop support for python 2.6
+
 
 16.8 - 2016-10-29
 ~~~~~~~~~~~~~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ Changelog
 
 .. note:: This version is not yet released and is under active development.
 
-* Drop support for python 2.6
+* Drop support for python 2.6 and 3.2
 
 
 16.8 - 2016-10-29

--- a/packaging/_structures.py
+++ b/packaging/_structures.py
@@ -33,6 +33,7 @@ class Infinity(object):
     def __neg__(self):
         return NegativeInfinity
 
+
 Infinity = Infinity()
 
 
@@ -64,5 +65,6 @@ class NegativeInfinity(object):
 
     def __neg__(self):
         return Infinity
+
 
 NegativeInfinity = NegativeInfinity()

--- a/packaging/version.py
+++ b/packaging/version.py
@@ -154,6 +154,7 @@ def _legacy_cmpkey(version):
 
     return epoch, parts
 
+
 # Deliberately not anchored to the start and end of the string, to make it
 # easier for 3rd party code to reuse
 VERSION_PATTERN = r"""

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,6 @@ setup(
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.2",
         "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
     ],

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,6 @@ setup(
 
         "Programming Language :: Python",
         "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.6",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.2",

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,8 @@ setup(
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
     ],
 
     packages=[

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,pypy,py33,py34,docs,pep8,py2pep8
+envlist = py27,pypy,py33,py34,py35,py36,py37,docs,pep8,py2pep8
 
 [testenv]
 deps =
@@ -15,6 +15,7 @@ commands =
     py.test --capture=no --strict {posargs}
 
 [testenv:docs]
+basepython = python3.6
 deps =
     sphinx
     sphinx_rtd_theme

--- a/tox.ini
+++ b/tox.ini
@@ -9,8 +9,6 @@ deps =
 commands =
     python -m coverage run --source packaging/ -m pytest --strict {posargs}
     python -m coverage report -m --fail-under 100
-install_command =
-    pip install --find-links https://wheels.caremad.io/ {opts} {packages}
 
 # Python 2.6 doesn't support python -m on a package.
 [testenv:py26]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,pypy,py32,py33,py34,docs,pep8,py2pep8
+envlist = py27,pypy,py32,py33,py34,docs,pep8,py2pep8
 
 [testenv]
 deps =
@@ -9,12 +9,6 @@ deps =
 commands =
     python -m coverage run --source packaging/ -m pytest --strict {posargs}
     python -m coverage report -m --fail-under 100
-
-# Python 2.6 doesn't support python -m on a package.
-[testenv:py26]
-commands =
-    python -m coverage.__main__ run --source packaging/ -m pytest --strict {posargs}
-    python -m coverage.__main__ report -m --fail-under 100
 
 # coverage.py doesn't support Python 3.2 anymore.
 [testenv:py32]
@@ -42,7 +36,7 @@ deps =
 commands = flake8 .
 
 [testenv:py2pep8]
-basepython = python2.6
+basepython = python2.7
 deps =
     flake8
     pep8-naming

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,pypy,py32,py33,py34,docs,pep8,py2pep8
+envlist = py27,pypy,py33,py34,docs,pep8,py2pep8
 
 [testenv]
 deps =
@@ -9,11 +9,6 @@ deps =
 commands =
     python -m coverage run --source packaging/ -m pytest --strict {posargs}
     python -m coverage report -m --fail-under 100
-
-# coverage.py doesn't support Python 3.2 anymore.
-[testenv:py32]
-commands =
-    py.test --strict {posargs}
 
 [testenv:pypy]
 commands =
@@ -29,7 +24,7 @@ commands =
     sphinx-build -W -b doctest -d {envtmpdir}/doctrees docs docs/_build/html
 
 [testenv:pep8]
-basepython = python3.2
+basepython = python3.4
 deps =
     flake8
     pep8-naming

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,11 @@ deps =
     coverage
     pretend
     pytest
+    https://github.com/pypa/pip/archive/master.zip#egg=pip
+# The --ignore-installed install options is needed to install pip url
+# (needed to issue #95). This can be removed once pip 10.0 is out.
+install_command =
+    pip install {opts} {packages} --ignore-installed
 commands =
     python -m coverage run --source packaging/ -m pytest --strict {posargs}
     python -m coverage report -m --fail-under 100


### PR DESCRIPTION
This makes packaging use pip master to avoid #95 .
And since  pip 10 dropped support for python 2.6 & 3.2, packaging will do the same.