### PR TITLE
Give Version structured info attributes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,12 @@ Changelog
 * Drop support for python 2.6 and 3.2
 * Define minimal pyparsing version to 2.0.2 (:issue:`91`).
 
+* Add ``epoch``, ``release``, ``prerelease``, ``development``, ``postrelease``,
+  and ``local_info`` attributes to ``Version`` and ``LegacyVersion``
+
+* Add ``Version().is_development`` and ``LegacyVersion().is_development`` to
+  make it easy to determine if a release is a developmental release.
+
 
 16.8 - 2016-10-29
 ~~~~~~~~~~~~~~~~~

--- a/docs/version.rst
+++ b/docs/version.rst
@@ -21,6 +21,12 @@ Usage
     <Version('1.0')>
     >>> v1 < v2
     True
+    >>> v1.epoch
+    0
+    >>> v1.release
+    (1, 0)
+    >>> v1.prerelease
+    ('a', 5)
     >>> v1.is_prerelease
     True
     >>> v2.is_prerelease
@@ -29,8 +35,11 @@ Usage
     Traceback (most recent call last):
         ...
     InvalidVersion: Invalid version: 'french toast'
+    >>> Version("1.0").postrelease
     >>> Version("1.0").is_postrelease
     False
+    >>> Version("1.0.post0").postrelease
+    0
     >>> Version("1.0.post0").is_postrelease
     True
 
@@ -66,15 +75,56 @@ Reference
         instance. The base version is the public version of the project without
         any pre or post release markers.
 
+    .. attribute:: epoch
+
+        An integer giving the version epoch of this :class:`Version` instance
+
+    .. attribute:: release
+
+        A tuple of integers giving the components of the release segment of
+        this :class:`Version` instance; that is, the ``1.2.3`` part of the
+        version number, including trailing zeroes but not including the epoch
+        or any prerelease/development/postrelease suffixes
+
     .. attribute:: local
 
         A string representing the local version portion of this ``Version()``
         if it has one, or ``None`` otherwise.
 
+    .. attribute:: local_info
+
+        If this :class:`Version` instance has a local version portion, this
+        attribute will be a tuple of the local version segments (a mixture of
+        integers and strings); otherwise, it will be `None`.
+
+    .. attribute:: prerelease
+
+        If this :class:`Version` instance represents a prerelease, this
+        attribute will be a pair of the prerelease phase (the string ``"a"``,
+        ``"b"``, or ``"rc"``) and the prerelease number (an integer).  If this
+        instance is not a prerelease, the attribute will be `None`.
+
     .. attribute:: is_prerelease
 
         A boolean value indicating whether this :class:`Version` instance
-        represents a prerelease or a final release.
+        represents a prerelease and/or developmental release.
+
+    .. attribute:: development
+
+        If this :class:`Version` instance represents a developmental release,
+        this attribute will be the development release number (an integer);
+        otherwise, it will be `None`.
+
+    .. attribute:: is_development
+
+        A boolean value indicating whether this :class:`Version` instance
+        represents a developmental release.
+
+    .. attribute:: postrelease
+
+        If this :class:`Version` instance represents a postrelease, this
+        attribute will be the postrelease number (an integer); otherwise, it
+        will be `None`.
 
     .. attribute:: is_postrelease
 
@@ -106,18 +156,63 @@ Reference
         :class:`LegacyVersion` instance. This will always be the entire version
         string.
 
+    .. attribute:: epoch
+
+        This will always be ``-1`` since without `PEP 440`_ we do not have the
+        concept of version epochs.  The value reflects the fact that
+        :class:`LegacyVersion` instances always compare less than
+        :class:`Version` instances.
+
+    .. attribute:: release
+
+        This will always be ``None`` since without `PEP 440`_ we do not have
+        the concept of a release segment or its components.  It exists
+        primarily to allow a :class:`LegacyVersion` to be used as a stand in
+        for a :class:`Version`.
+
     .. attribute:: local
 
         This will always be ``None`` since without `PEP 440`_ we do not have
         the concept of a local version. It exists primarily to allow a
         :class:`LegacyVersion` to be used as a stand in for a :class:`Version`.
 
+    .. attribute:: local_info
+
+        This will always be ``None`` since without `PEP 440`_ we do not have
+        the concept of a local version. It exists primarily to allow a
+        :class:`LegacyVersion` to be used as a stand in for a :class:`Version`.
+
+    .. attribute:: prerelease
+
+        This will always be ``None`` since without `PEP 440`_ we do not have
+        the concept of a prerelease. It exists primarily to allow a
+        :class:`LegacyVersion` to be used as a stand in for a :class:`Version`.
+
     .. attribute:: is_prerelease
 
         A boolean value indicating whether this :class:`LegacyVersion`
-        represents a prerelease or a final release. Since without `PEP 440`_
-        there is no concept of pre or final releases this will always be
-        `False` and exists for compatibility with :class:`Version`.
+        represents a prerelease and/or developmental release.  Since without
+        `PEP 440`_ there is no concept of pre or dev releases this will
+        always be `False` and exists for compatibility with :class:`Version`.
+
+    .. attribute:: development
+
+        This will always be ``None`` since without `PEP 440`_ we do not have
+        the concept of a developmental release. It exists primarily to allow a
+        :class:`LegacyVersion` to be used as a stand in for a :class:`Version`.
+
+    .. attribute:: is_development
+
+        A boolean value indicating whether this :class:`LegacyVersion`
+        represents a developmental release.  Since without `PEP 440`_ there is
+        no concept of dev releases this will always be `False` and exists for
+        compatibility with :class:`Version`.
+
+    .. attribute:: postrelease
+
+        This will always be ``None`` since without `PEP 440`_ we do not have
+        the concept of a postrelease. It exists primarily to allow a
+        :class:`LegacyVersion` to be used as a stand in for a :class:`Version`.
 
     .. attribute:: is_postrelease
 

--- a/packaging/version.py
+++ b/packaging/version.py
@@ -90,12 +90,40 @@ class LegacyVersion(_BaseVersion):
         return self._version
 
     @property
+    def epoch(self):
+        return -1
+
+    @property
+    def release(self):
+        return None
+
+    @property
     def local(self):
+        return None
+
+    @property
+    def local_info(self):
+        return None
+
+    @property
+    def prerelease(self):
         return None
 
     @property
     def is_prerelease(self):
         return False
+
+    @property
+    def development(self):
+        return None
+
+    @property
+    def is_development(self):
+        return False
+
+    @property
+    def postrelease(self):
+        return None
 
     @property
     def is_postrelease(self):
@@ -282,14 +310,48 @@ class Version(_BaseVersion):
         return "".join(parts)
 
     @property
+    def epoch(self):
+        return self._version.epoch
+
+    @property
+    def release(self):
+        return self._version.release
+
+    @property
     def local(self):
         version_string = str(self)
         if "+" in version_string:
             return version_string.split("+", 1)[1]
 
     @property
+    def local_info(self):
+        return self._version.local
+
+    @property
+    def prerelease(self):
+        return self._version.pre
+
+    @property
     def is_prerelease(self):
         return bool(self._version.dev or self._version.pre)
+
+    @property
+    def development(self):
+        if self._version.dev is not None:
+            return self._version.dev[1]
+        else:
+            return None
+
+    @property
+    def is_development(self):
+        return bool(self._version.dev)
+
+    @property
+    def postrelease(self):
+        if self._version.post is not None:
+            return self._version.post[1]
+        else:
+            return None
 
     @property
     def is_postrelease(self):

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -333,6 +333,78 @@ class TestVersion:
         assert Version(version).base_version == base_version
 
     @pytest.mark.parametrize(
+        ("version", "epoch"),
+        [
+            ("1.0", 0),
+            ("1.0.dev6", 0),
+            ("1.0a1", 0),
+            ("1.0a1.post5", 0),
+            ("1.0a1.post5.dev6", 0),
+            ("1.0rc4", 0),
+            ("1.0.post5", 0),
+            ("1!1.0", 1),
+            ("1!1.0.dev6", 1),
+            ("1!1.0a1", 1),
+            ("1!1.0a1.post5", 1),
+            ("1!1.0a1.post5.dev6", 1),
+            ("1!1.0rc4", 1),
+            ("1!1.0.post5", 1),
+            ("1.0+deadbeef", 0),
+            ("1.0.dev6+deadbeef", 0),
+            ("1.0a1+deadbeef", 0),
+            ("1.0a1.post5+deadbeef", 0),
+            ("1.0a1.post5.dev6+deadbeef", 0),
+            ("1.0rc4+deadbeef", 0),
+            ("1.0.post5+deadbeef", 0),
+            ("1!1.0+deadbeef", 1),
+            ("1!1.0.dev6+deadbeef", 1),
+            ("1!1.0a1+deadbeef", 1),
+            ("1!1.0a1.post5+deadbeef", 1),
+            ("1!1.0a1.post5.dev6+deadbeef", 1),
+            ("1!1.0rc4+deadbeef", 1),
+            ("1!1.0.post5+deadbeef", 1),
+        ],
+    )
+    def test_version_epoch(self, version, epoch):
+        assert Version(version).epoch == epoch
+
+    @pytest.mark.parametrize(
+        ("version", "release"),
+        [
+            ("1.0", (1, 0)),
+            ("1.0.dev6", (1, 0)),
+            ("1.0a1", (1, 0)),
+            ("1.0a1.post5", (1, 0)),
+            ("1.0a1.post5.dev6", (1, 0)),
+            ("1.0rc4", (1, 0)),
+            ("1.0.post5", (1, 0)),
+            ("1!1.0", (1, 0)),
+            ("1!1.0.dev6", (1, 0)),
+            ("1!1.0a1", (1, 0)),
+            ("1!1.0a1.post5", (1, 0)),
+            ("1!1.0a1.post5.dev6", (1, 0)),
+            ("1!1.0rc4", (1, 0)),
+            ("1!1.0.post5", (1, 0)),
+            ("1.0+deadbeef", (1, 0)),
+            ("1.0.dev6+deadbeef", (1, 0)),
+            ("1.0a1+deadbeef", (1, 0)),
+            ("1.0a1.post5+deadbeef", (1, 0)),
+            ("1.0a1.post5.dev6+deadbeef", (1, 0)),
+            ("1.0rc4+deadbeef", (1, 0)),
+            ("1.0.post5+deadbeef", (1, 0)),
+            ("1!1.0+deadbeef", (1, 0)),
+            ("1!1.0.dev6+deadbeef", (1, 0)),
+            ("1!1.0a1+deadbeef", (1, 0)),
+            ("1!1.0a1.post5+deadbeef", (1, 0)),
+            ("1!1.0a1.post5.dev6+deadbeef", (1, 0)),
+            ("1!1.0rc4+deadbeef", (1, 0)),
+            ("1!1.0.post5+deadbeef", (1, 0)),
+        ],
+    )
+    def test_version_release(self, version, release):
+        assert Version(version).release == release
+
+    @pytest.mark.parametrize(
         ("version", "local"),
         [
             ("1.0", None),
@@ -369,6 +441,98 @@ class TestVersion:
         assert Version(version).local == local
 
     @pytest.mark.parametrize(
+        ("version", "local_info"),
+        [
+            ("1.0.dev456", None),
+            ("1.0a1", None),
+            ("1.0a2.dev456", None),
+            ("1.0a12.dev456", None),
+            ("1.0a12", None),
+            ("1.0b1.dev456", None),
+            ("1.0b2", None),
+            ("1.0b2.post345.dev456", None),
+            ("1.0b2.post345", None),
+            ("1.0rc1.dev456", None),
+            ("1.0rc1", None),
+            ("1.0", None),
+            ("1.0.post456.dev34", None),
+            ("1.0.post456", None),
+            ("1.0.1", None),
+            ("0!1.0.2", None),
+            ("1.0.3+7", (7,)),
+            ("0!1.0.4+8.0", (8, 0)),
+            ("1.0.5+9.5", (9, 5)),
+            ("1.2+1234.abc", (1234, "abc")),
+            ("1.2+123456", (123456,)),
+            ("1.2+123abc", ("123abc",)),
+            ("1.2+123abc456", ("123abc456",)),
+            ("1.2+abc", ("abc",)),
+            ("1.2+ABC", ("abc",)),
+            ("1.2+abc123", ("abc123",)),
+            ("1.2+abc123def", ("abc123def",)),
+            ("1.1.dev1", None),
+            ("7!1.0.dev456", None),
+            ("7!1.0a1", None),
+            ("7!1.0a2.dev456", None),
+            ("7!1.0a12.dev456", None),
+            ("7!1.0a12", None),
+            ("7!1.0b1.dev456", None),
+            ("7!1.0b2", None),
+            ("7!1.0b2.post345.dev456", None),
+            ("7!1.0b2.post345", None),
+            ("7!1.0rc1.dev456", None),
+            ("7!1.0rc1", None),
+            ("7!1.0", None),
+            ("7!1.0.post456.dev34", None),
+            ("7!1.0.post456", None),
+            ("7!1.0.1", None),
+            ("7!1.0.2", None),
+            ("7!1.0.3+7", (7,)),
+            ("7!1.0.4+8.0", (8, 0)),
+            ("7!1.0.5+9.5", (9, 5)),
+            ("7!1.1.dev1", None),
+        ],
+    )
+    def test_version_local_info(self, version, local_info):
+        assert Version(version).local_info == local_info
+
+    @pytest.mark.parametrize(
+        ("version", "prerelease"),
+        [
+            ("1.0", None),
+            ("1.0.dev6", None),
+            ("1.0a1", ('a', 1)),
+            ("1.0a1.post5", ('a', 1)),
+            ("1.0a1.post5.dev6", ('a', 1)),
+            ("1.0rc4", ('rc', 4)),
+            ("1.0.post5", None),
+            ("1!1.0", None),
+            ("1!1.0.dev6", None),
+            ("1!1.0a1", ('a', 1)),
+            ("1!1.0a1.post5", ('a', 1)),
+            ("1!1.0a1.post5.dev6", ('a', 1)),
+            ("1!1.0rc4", ('rc', 4)),
+            ("1!1.0.post5", None),
+            ("1.0+deadbeef", None),
+            ("1.0.dev6+deadbeef", None),
+            ("1.0a1+deadbeef", ('a', 1)),
+            ("1.0a1.post5+deadbeef", ('a', 1)),
+            ("1.0a1.post5.dev6+deadbeef", ('a', 1)),
+            ("1.0rc4+deadbeef", ('rc', 4)),
+            ("1.0.post5+deadbeef", None),
+            ("1!1.0+deadbeef", None),
+            ("1!1.0.dev6+deadbeef", None),
+            ("1!1.0a1+deadbeef", ('a', 1)),
+            ("1!1.0a1.post5+deadbeef", ('a', 1)),
+            ("1!1.0a1.post5.dev6+deadbeef", ('a', 1)),
+            ("1!1.0rc4+deadbeef", ('rc', 4)),
+            ("1!1.0.post5+deadbeef", None),
+        ],
+    )
+    def test_version_prerelease(self, version, prerelease):
+        assert Version(version).prerelease == prerelease
+
+    @pytest.mark.parametrize(
         ("version", "expected"),
         [
             ("1.0.dev1", True),
@@ -396,6 +560,114 @@ class TestVersion:
     )
     def test_version_is_prerelease(self, version, expected):
         assert Version(version).is_prerelease is expected
+
+    @pytest.mark.parametrize(
+        ("version", "development"),
+        [
+            ("1.0", None),
+            ("1.0.dev6", 6),
+            ("1.0a1", None),
+            ("1.0a1.post5", None),
+            ("1.0a1.post5.dev6", 6),
+            ("1.0rc4", None),
+            ("1.0.post5", None),
+            ("1!1.0", None),
+            ("1!1.0.dev6", 6),
+            ("1!1.0a1", None),
+            ("1!1.0a1.post5", None),
+            ("1!1.0a1.post5.dev6", 6),
+            ("1!1.0rc4", None),
+            ("1!1.0.post5", None),
+            ("1.0+deadbeef", None),
+            ("1.0.dev6+deadbeef", 6),
+            ("1.0a1+deadbeef", None),
+            ("1.0a1.post5+deadbeef", None),
+            ("1.0a1.post5.dev6+deadbeef", 6),
+            ("1.0rc4+deadbeef", None),
+            ("1.0.post5+deadbeef", None),
+            ("1!1.0+deadbeef", None),
+            ("1!1.0.dev6+deadbeef", 6),
+            ("1!1.0a1+deadbeef", None),
+            ("1!1.0a1.post5+deadbeef", None),
+            ("1!1.0a1.post5.dev6+deadbeef", 6),
+            ("1!1.0rc4+deadbeef", None),
+            ("1!1.0.post5+deadbeef", None),
+        ],
+    )
+    def test_version_development(self, version, development):
+        assert Version(version).development == development
+
+    @pytest.mark.parametrize(
+        ("version", "expected"),
+        [
+            ("1.0", False),
+            ("1.0.dev6", True),
+            ("1.0a1", False),
+            ("1.0a1.post5", False),
+            ("1.0a1.post5.dev6", True),
+            ("1.0rc4", False),
+            ("1.0.post5", False),
+            ("1!1.0", False),
+            ("1!1.0.dev6", True),
+            ("1!1.0a1", False),
+            ("1!1.0a1.post5", False),
+            ("1!1.0a1.post5.dev6", True),
+            ("1!1.0rc4", False),
+            ("1!1.0.post5", False),
+            ("1.0+deadbeef", False),
+            ("1.0.dev6+deadbeef", True),
+            ("1.0a1+deadbeef", False),
+            ("1.0a1.post5+deadbeef", False),
+            ("1.0a1.post5.dev6+deadbeef", True),
+            ("1.0rc4+deadbeef", False),
+            ("1.0.post5+deadbeef", False),
+            ("1!1.0+deadbeef", False),
+            ("1!1.0.dev6+deadbeef", True),
+            ("1!1.0a1+deadbeef", False),
+            ("1!1.0a1.post5+deadbeef", False),
+            ("1!1.0a1.post5.dev6+deadbeef", True),
+            ("1!1.0rc4+deadbeef", False),
+            ("1!1.0.post5+deadbeef", False),
+        ],
+    )
+    def test_version_is_development(self, version, expected):
+        assert Version(version).is_development is expected
+
+    @pytest.mark.parametrize(
+        ("version", "postrelease"),
+        [
+            ("1.0", None),
+            ("1.0.dev6", None),
+            ("1.0a1", None),
+            ("1.0a1.post5", 5),
+            ("1.0a1.post5.dev6", 5),
+            ("1.0rc4", None),
+            ("1.0.post5", 5),
+            ("1!1.0", None),
+            ("1!1.0.dev6", None),
+            ("1!1.0a1", None),
+            ("1!1.0a1.post5", 5),
+            ("1!1.0a1.post5.dev6", 5),
+            ("1!1.0rc4", None),
+            ("1!1.0.post5", 5),
+            ("1.0+deadbeef", None),
+            ("1.0.dev6+deadbeef", None),
+            ("1.0a1+deadbeef", None),
+            ("1.0a1.post5+deadbeef", 5),
+            ("1.0a1.post5.dev6+deadbeef", 5),
+            ("1.0rc4+deadbeef", None),
+            ("1.0.post5+deadbeef", 5),
+            ("1!1.0+deadbeef", None),
+            ("1!1.0.dev6+deadbeef", None),
+            ("1!1.0a1+deadbeef", None),
+            ("1!1.0a1.post5+deadbeef", 5),
+            ("1!1.0a1.post5.dev6+deadbeef", 5),
+            ("1!1.0rc4+deadbeef", None),
+            ("1!1.0.post5+deadbeef", 5),
+        ],
+    )
+    def test_version_postrelease(self, version, postrelease):
+        assert Version(version).postrelease == postrelease
 
     @pytest.mark.parametrize(
         ("version", "expected"),
@@ -531,12 +803,40 @@ class TestLegacyVersion:
         assert LegacyVersion(version).base_version == version
 
     @pytest.mark.parametrize("version", VERSIONS + LEGACY_VERSIONS)
+    def test_legacy_version_epoch(self, version):
+        assert LegacyVersion(version).epoch == -1
+
+    @pytest.mark.parametrize("version", VERSIONS + LEGACY_VERSIONS)
+    def test_legacy_version_release(self, version):
+        assert LegacyVersion(version).release is None
+
+    @pytest.mark.parametrize("version", VERSIONS + LEGACY_VERSIONS)
     def test_legacy_version_local(self, version):
         assert LegacyVersion(version).local is None
 
     @pytest.mark.parametrize("version", VERSIONS + LEGACY_VERSIONS)
+    def test_legacy_version_local_info(self, version):
+        assert LegacyVersion(version).local_info is None
+
+    @pytest.mark.parametrize("version", VERSIONS + LEGACY_VERSIONS)
+    def test_legacy_version_prerelease(self, version):
+        assert LegacyVersion(version).prerelease is None
+
+    @pytest.mark.parametrize("version", VERSIONS + LEGACY_VERSIONS)
     def test_legacy_version_is_prerelease(self, version):
         assert not LegacyVersion(version).is_prerelease
+
+    @pytest.mark.parametrize("version", VERSIONS + LEGACY_VERSIONS)
+    def test_legacy_version_development(self, version):
+        assert LegacyVersion(version).development is None
+
+    @pytest.mark.parametrize("version", VERSIONS + LEGACY_VERSIONS)
+    def test_legacy_version_is_development(self, version):
+        assert not LegacyVersion(version).is_development
+
+    @pytest.mark.parametrize("version", VERSIONS + LEGACY_VERSIONS)
+    def test_legacy_version_postrelease(self, version):
+        assert LegacyVersion(version).postrelease is None
 
     @pytest.mark.parametrize("version", VERSIONS + LEGACY_VERSIONS)
     def test_legacy_version_is_postrelease(self, version):


### PR DESCRIPTION
Addressing both #34 and #84, this patch adds the following attributes to `Version` instances:

- `epoch`
- `release` — a tuple of the integers in the version's release segment (including trailing zeroes)
- `prerelease` — If the `Version` is a prerelease, this is a pair of the prerelease phase (`'a'`, `'b'`, or `'rc'`) and the prerelease number; for non-prereleases, the attribute is `None`
- `development` — The developmental release number, or `None` if the `Version` is not a developmental release
- `is_development` — `True` iff the `Version` is a developmental release
- `postrelease` — The postrelease number, or `None` if the `Version` is not a postrelease
- `local_info` — a tuple of the local version segments, or `None` if the `Version` does not have a local portion

Corresponding compatibility attributes have also been added to `LegacyVersion`; they are always `None`, except for `epoch` (which is always `-1`) and `is_development` (which is always `False`).
