### PR TITLE
Fix pep508 logic assuming single-digit minor versions

### DIFF
--- a/packaging/markers.py
+++ b/packaging/markers.py
@@ -264,7 +264,7 @@ def default_environment():
         "platform_version": platform.version(),
         "python_full_version": platform.python_version(),
         "platform_python_implementation": platform.python_implementation(),
-        "python_version": platform.python_version()[:3],
+        "python_version": '.'.join(map(str, sys.version_info[:2])),
         "sys_platform": sys.platform,
     }
 

--- a/tests/test_markers.py
+++ b/tests/test_markers.py
@@ -99,7 +99,7 @@ class TestDefaultEnvironment:
             "platform_version": platform.version(),
             "python_full_version": platform.python_version(),
             "platform_python_implementation": platform.python_implementation(),
-            "python_version": platform.python_version()[:3],
+            "python_version": '.'.join(map(str, sys.version_info[:2])),
             "sys_platform": sys.platform,
         }
 
@@ -120,7 +120,7 @@ class TestDefaultEnvironment:
             "platform_version": platform.version(),
             "python_full_version": platform.python_version(),
             "platform_python_implementation": platform.python_implementation(),
-            "python_version": platform.python_version()[:3],
+            "python_version": '.'.join(map(str, sys.version_info[:2])),
             "sys_platform": sys.platform,
         }
 
@@ -149,7 +149,7 @@ class TestDefaultEnvironment:
             "platform_version": platform.version(),
             "python_full_version": platform.python_version(),
             "platform_python_implementation": platform.python_implementation(),
-            "python_version": platform.python_version()[:3],
+            "python_version": '.'.join(map(str, sys.version_info[:2])),
             "sys_platform": sys.platform,
         }
 
@@ -173,9 +173,24 @@ class TestDefaultEnvironment:
             "platform_version": platform.version(),
             "python_full_version": platform.python_version(),
             "platform_python_implementation": platform.python_implementation(),
-            "python_version": platform.python_version()[:3],
+            "python_version": '.'.join(map(str, sys.version_info[:2])),
             "sys_platform": sys.platform,
         }
+
+    def test_multidigit_minor_version(self, monkeypatch):
+        version_info = (3, 10, 0, "final", 0)
+        monkeypatch.setattr(
+            sys, "version_info",
+            version_info,
+            raising=False)
+
+        monkeypatch.setattr(
+            platform, "python_version",
+            lambda: '3.10.0',
+            raising=False)
+
+        environment = default_environment()
+        assert environment["python_version"] == '3.10'
 
     def tests_when_releaselevel_final(self):
         v = FakeVersionInfo(3, 4, 2, "final", 0)


### PR DESCRIPTION
I created kennethreitz/pipenv#874 earlier without noticing that part of what i changed was a vendored version of this package.

Without the fix in `markers.py` the test case I added fails:

```
>       assert environment["python_version"] == '3.10'
E       AssertionError: assert '3.1' == '3.10'
E         - 3.1
E         + 3.10
E         ?    +
```

The [recommended implementation](https://www.python.org/dev/peps/pep-0508/#environment-markers) for the `python_version` marker in PEP508 is wrong as well, not sure how to get that changed.