### PR TITLE
Fix Python 3.3 jobs on Travis.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist = py27,pypy,py33,py34,py35,py36,py37,docs,pep8,py2pep8
 deps =
     coverage
     pretend
-    pytest
+    pytest<=3.2.5
     https://github.com/pypa/pip/archive/master.zip#egg=pip
 # The --ignore-installed install options is needed to install pip url
 # (needed to issue #95). This can be removed once pip 10.0 is out.


### PR DESCRIPTION
As @benoit-pierre mentioned in https://github.com/pypa/pip/pull/4897, the most current version of pytest no longer supports Python 3.3. This causes Travis to fail.

This PR applies a fix similar to the one used in https://github.com/pypa/pip/pull/4897.