### PR TITLE
Drop support for EOL Python 3.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .tox/
 .cache/
 .coverage
+.idea
 
 __pycache__/
 _build/

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ matrix:
   include:
     - python: 2.7
       env: TOXENV=py27
-    - python: 3.3
-      env: TOXENV=py33
     - python: 3.4
       env: TOXENV=py34
     - python: 3.5

--- a/docs/development/getting-started.rst
+++ b/docs/development/getting-started.rst
@@ -37,11 +37,12 @@ each supported Python version and run the tests. For example:
 
     $ tox
     ...
-    ERROR:   py26: InterpreterNotFound: python2.6
      py27: commands succeeded
     ERROR:   pypy: InterpreterNotFound: pypy
-    ERROR:   py32: InterpreterNotFound: python3.2
-     py33: commands succeeded
+    ERROR:   py34: InterpreterNotFound: python3.4
+    ERROR:   py35: InterpreterNotFound: python3.5
+     py36: commands succeeded
+    ERROR:   py37: InterpreterNotFound: python3.7
      docs: commands succeeded
      pep8: commands succeeded
 

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,8 @@ setup(
     author=about["__author__"],
     author_email=about["__email__"],
 
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
+
     install_requires=[
         "pyparsing>=2.0.2",  # Needed to avoid issue #91
         "six",
@@ -65,7 +67,6 @@ setup(
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,pypy,py33,py34,py35,py36,py37,docs,pep8,py2pep8
+envlist = py27,pypy,py34,py35,py36,py37,docs,pep8,py2pep8
 
 [testenv]
 deps =


### PR DESCRIPTION
An alternative to https://github.com/pypa/packaging/pull/117.

Here's the pip installs for docopt from PyPI for the last month (via `pypinfo --percent --pip --markdown docopt pyversion`) showing a small fraction for Python 3.3, which is EOL and no longer receiving security updates.

| python_version | percent | download_count |
| -------------- | ------: | -------------: |
| 2.7            |   77.5% |        961,861 |
| 3.6            |    9.7% |        120,364 |
| 3.5            |    7.0% |         87,098 |
| 3.4            |    4.3% |         53,284 |
| 2.6            |    0.6% |          7,966 |
| 3.3            |    0.5% |          5,592 |
| 3.7            |    0.4% |          4,736 |
| 3.2            |    0.1% |            956 |
| None           |    0.0% |              1 |