### PR TITLE
Version canonizalization & exposing the `Version` structure

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,13 +7,14 @@ Changelog
 .. note:: This version is not yet released and is under active development.
 
 * Drop support for python 2.6 and 3.2
+
 * Define minimal pyparsing version to 2.0.2 (:issue:`91`).
 
-* Add ``epoch``, ``release``, ``prerelease``, ``development``, ``postrelease``,
-  and ``local_info`` attributes to ``Version`` and ``LegacyVersion``
+* Add ``epoch``, ``release``, ``pre``, ``dev``, and ``post`` attributes to
+  ``Version`` and ``LegacyVersion`` (:issue:`34`).
 
-* Add ``Version().is_development`` and ``LegacyVersion().is_development`` to
-  make it easy to determine if a release is a developmental release.
+* Add ``Version().is_devrelease`` and ``LegacyVersion().is_devrelease`` to
+  make it easy to determine if a release is a development release.
 
 
 16.8 - 2016-10-29

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,12 @@ Changelog
 * Drop support for python 2.6 and 3.2
 * Define minimal pyparsing version to 2.0.2 (:issue:`91`).
 
+* Add ``epoch``, ``release``, ``prerelease``, ``development``, ``postrelease``,
+  and ``local_info`` attributes to ``Version`` and ``LegacyVersion``
+
+* Add ``Version().is_development`` and ``LegacyVersion().is_development`` to
+  make it easy to determine if a release is a developmental release.
+
 
 16.8 - 2016-10-29
 ~~~~~~~~~~~~~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,9 @@ Changelog
 * Add ``Version().is_devrelease`` and ``LegacyVersion().is_devrelease`` to
   make it easy to determine if a release is a development release.
 
+* Add ``utils.canonicalize_version`` to canonicalize version strings or
+  ``Version`` instances (:issue:`121`).
+
 
 16.8 - 2016-10-29
 ~~~~~~~~~~~~~~~~~

--- a/docs/utils.rst
+++ b/docs/utils.rst
@@ -26,3 +26,16 @@ Reference
         'oslo-concurrency'
         >>> canonicalize_name("requests")
         'requests'
+
+.. function:: canonicalize_version(version)
+
+    This function takes a string representing a package version (or a
+    ``Version`` instance), and returns the normalized form of it.
+
+    :param str version: The version to normalize.
+
+    .. doctest::
+
+        >>> from packaging.utils import canonicalize_version
+        >>> canonicalize_version('1.4.0.0.0')
+        '1.4'

--- a/docs/version.rst
+++ b/docs/version.rst
@@ -21,6 +21,12 @@ Usage
     <Version('1.0')>
     >>> v1 < v2
     True
+    >>> v1.epoch
+    0
+    >>> v1.release
+    (1, 0)
+    >>> v1.prerelease
+    ('a', 5)
     >>> v1.is_prerelease
     True
     >>> v2.is_prerelease
@@ -29,8 +35,11 @@ Usage
     Traceback (most recent call last):
         ...
     InvalidVersion: Invalid version: 'french toast'
+    >>> Version("1.0").postrelease
     >>> Version("1.0").is_postrelease
     False
+    >>> Version("1.0.post0").postrelease
+    0
     >>> Version("1.0.post0").is_postrelease
     True
 
@@ -66,15 +75,56 @@ Reference
         instance. The base version is the public version of the project without
         any pre or post release markers.
 
+    .. attribute:: epoch
+
+        An integer giving the version epoch of this :class:`Version` instance
+
+    .. attribute:: release
+
+        A tuple of integers giving the components of the release segment of
+        this :class:`Version` instance; that is, the ``1.2.3`` part of the
+        version number, including trailing zeroes but not including the epoch
+        or any prerelease/development/postrelease suffixes
+
     .. attribute:: local
 
         A string representing the local version portion of this ``Version()``
         if it has one, or ``None`` otherwise.
 
+    .. attribute:: local_info
+
+        If this :class:`Version` instance has a local version portion, this
+        attribute will be a tuple of the local version segments (a mixture of
+        integers and strings); otherwise, it will be `None`.
+
+    .. attribute:: prerelease
+
+        If this :class:`Version` instance represents a prerelease, this
+        attribute will be a pair of the prerelease phase (the string ``"a"``,
+        ``"b"``, or ``"rc"``) and the prerelease number (an integer).  If this
+        instance is not a prerelease, the attribute will be `None`.
+
     .. attribute:: is_prerelease
 
         A boolean value indicating whether this :class:`Version` instance
-        represents a prerelease or a final release.
+        represents a prerelease and/or developmental release.
+
+    .. attribute:: development
+
+        If this :class:`Version` instance represents a developmental release,
+        this attribute will be the development release number (an integer);
+        otherwise, it will be `None`.
+
+    .. attribute:: is_development
+
+        A boolean value indicating whether this :class:`Version` instance
+        represents a developmental release.
+
+    .. attribute:: postrelease
+
+        If this :class:`Version` instance represents a postrelease, this
+        attribute will be the postrelease number (an integer); otherwise, it
+        will be `None`.
 
     .. attribute:: is_postrelease
 
@@ -106,18 +156,63 @@ Reference
         :class:`LegacyVersion` instance. This will always be the entire version
         string.
 
+    .. attribute:: epoch
+
+        This will always be ``-1`` since without `PEP 440`_ we do not have the
+        concept of version epochs.  The value reflects the fact that
+        :class:`LegacyVersion` instances always compare less than
+        :class:`Version` instances.
+
+    .. attribute:: release
+
+        This will always be ``None`` since without `PEP 440`_ we do not have
+        the concept of a release segment or its components.  It exists
+        primarily to allow a :class:`LegacyVersion` to be used as a stand in
+        for a :class:`Version`.
+
     .. attribute:: local
 
         This will always be ``None`` since without `PEP 440`_ we do not have
         the concept of a local version. It exists primarily to allow a
         :class:`LegacyVersion` to be used as a stand in for a :class:`Version`.
 
+    .. attribute:: local_info
+
+        This will always be ``None`` since without `PEP 440`_ we do not have
+        the concept of a local version. It exists primarily to allow a
+        :class:`LegacyVersion` to be used as a stand in for a :class:`Version`.
+
+    .. attribute:: prerelease
+
+        This will always be ``None`` since without `PEP 440`_ we do not have
+        the concept of a prerelease. It exists primarily to allow a
+        :class:`LegacyVersion` to be used as a stand in for a :class:`Version`.
+
     .. attribute:: is_prerelease
 
         A boolean value indicating whether this :class:`LegacyVersion`
-        represents a prerelease or a final release. Since without `PEP 440`_
-        there is no concept of pre or final releases this will always be
-        `False` and exists for compatibility with :class:`Version`.
+        represents a prerelease and/or developmental release.  Since without
+        `PEP 440`_ there is no concept of pre or dev releases this will
+        always be `False` and exists for compatibility with :class:`Version`.
+
+    .. attribute:: development
+
+        This will always be ``None`` since without `PEP 440`_ we do not have
+        the concept of a developmental release. It exists primarily to allow a
+        :class:`LegacyVersion` to be used as a stand in for a :class:`Version`.
+
+    .. attribute:: is_development
+
+        A boolean value indicating whether this :class:`LegacyVersion`
+        represents a developmental release.  Since without `PEP 440`_ there is
+        no concept of dev releases this will always be `False` and exists for
+        compatibility with :class:`Version`.
+
+    .. attribute:: postrelease
+
+        This will always be ``None`` since without `PEP 440`_ we do not have
+        the concept of a postrelease. It exists primarily to allow a
+        :class:`LegacyVersion` to be used as a stand in for a :class:`Version`.
 
     .. attribute:: is_postrelease
 

--- a/docs/version.rst
+++ b/docs/version.rst
@@ -25,7 +25,7 @@ Usage
     0
     >>> v1.release
     (1, 0)
-    >>> v1.prerelease
+    >>> v1.pre
     ('a', 5)
     >>> v1.is_prerelease
     True
@@ -35,10 +35,10 @@ Usage
     Traceback (most recent call last):
         ...
     InvalidVersion: Invalid version: 'french toast'
-    >>> Version("1.0").postrelease
+    >>> Version("1.0").post
     >>> Version("1.0").is_postrelease
     False
-    >>> Version("1.0.post0").postrelease
+    >>> Version("1.0.post0").post
     0
     >>> Version("1.0.post0").is_postrelease
     True
@@ -91,13 +91,7 @@ Reference
         A string representing the local version portion of this ``Version()``
         if it has one, or ``None`` otherwise.
 
-    .. attribute:: local_info
-
-        If this :class:`Version` instance has a local version portion, this
-        attribute will be a tuple of the local version segments (a mixture of
-        integers and strings); otherwise, it will be `None`.
-
-    .. attribute:: prerelease
+    .. attribute:: pre
 
         If this :class:`Version` instance represents a prerelease, this
         attribute will be a pair of the prerelease phase (the string ``"a"``,
@@ -107,20 +101,20 @@ Reference
     .. attribute:: is_prerelease
 
         A boolean value indicating whether this :class:`Version` instance
-        represents a prerelease and/or developmental release.
+        represents a prerelease and/or development release.
 
-    .. attribute:: development
+    .. attribute:: dev
 
-        If this :class:`Version` instance represents a developmental release,
+        If this :class:`Version` instance represents a development release,
         this attribute will be the development release number (an integer);
         otherwise, it will be `None`.
 
-    .. attribute:: is_development
+    .. attribute:: is_devrelease
 
         A boolean value indicating whether this :class:`Version` instance
-        represents a developmental release.
+        represents a development release.
 
-    .. attribute:: postrelease
+    .. attribute:: post
 
         If this :class:`Version` instance represents a postrelease, this
         attribute will be the postrelease number (an integer); otherwise, it
@@ -176,13 +170,7 @@ Reference
         the concept of a local version. It exists primarily to allow a
         :class:`LegacyVersion` to be used as a stand in for a :class:`Version`.
 
-    .. attribute:: local_info
-
-        This will always be ``None`` since without `PEP 440`_ we do not have
-        the concept of a local version. It exists primarily to allow a
-        :class:`LegacyVersion` to be used as a stand in for a :class:`Version`.
-
-    .. attribute:: prerelease
+    .. attribute:: pre
 
         This will always be ``None`` since without `PEP 440`_ we do not have
         the concept of a prerelease. It exists primarily to allow a
@@ -191,24 +179,24 @@ Reference
     .. attribute:: is_prerelease
 
         A boolean value indicating whether this :class:`LegacyVersion`
-        represents a prerelease and/or developmental release.  Since without
+        represents a prerelease and/or development release.  Since without
         `PEP 440`_ there is no concept of pre or dev releases this will
         always be `False` and exists for compatibility with :class:`Version`.
 
-    .. attribute:: development
+    .. attribute:: dev
 
         This will always be ``None`` since without `PEP 440`_ we do not have
-        the concept of a developmental release. It exists primarily to allow a
+        the concept of a development release. It exists primarily to allow a
         :class:`LegacyVersion` to be used as a stand in for a :class:`Version`.
 
-    .. attribute:: is_development
+    .. attribute:: is_devrelease
 
         A boolean value indicating whether this :class:`LegacyVersion`
-        represents a developmental release.  Since without `PEP 440`_ there is
+        represents a development release.  Since without `PEP 440`_ there is
         no concept of dev releases this will always be `False` and exists for
         compatibility with :class:`Version`.
 
-    .. attribute:: postrelease
+    .. attribute:: post
 
         This will always be ``None`` since without `PEP 440`_ we do not have
         the concept of a postrelease. It exists primarily to allow a

--- a/packaging/utils.py
+++ b/packaging/utils.py
@@ -5,6 +5,8 @@ from __future__ import absolute_import, division, print_function
 
 import re
 
+from .version import parse
+
 
 _canonicalize_regex = re.compile(r"[-_.]+")
 
@@ -12,3 +14,46 @@ _canonicalize_regex = re.compile(r"[-_.]+")
 def canonicalize_name(name):
     # This is taken from PEP 503.
     return _canonicalize_regex.sub("-", name).lower()
+
+
+def canonicalize_version(version):
+    """
+    This is very similar to Version.__str__, but has one subtle differences
+    with the way it handles the release segment.
+    """
+
+    version = parse(version)
+
+    parts = []
+
+    # Epoch
+    if version.epoch != 0:
+        parts.append("{0}!".format(version.epoch))
+
+    # Release segment
+    # NB: This strips trailing '.0's to normalize
+    parts.append(
+        re.sub(
+            r'(\.0)+$',
+            '',
+            ".".join(str(x) for x in version.release)
+        )
+    )
+
+    # Pre-release
+    if version.pre is not None:
+        parts.append("".join(str(x) for x in version.pre))
+
+    # Post-release
+    if version.post is not None:
+        parts.append(".post{0}".format(version.post))
+
+    # Development release
+    if version.dev is not None:
+        parts.append(".dev{0}".format(version.dev))
+
+    # Local version segment
+    if version.local is not None:
+        parts.append("+{0}".format(version.local))
+
+    return "".join(parts)

--- a/packaging/version.py
+++ b/packaging/version.py
@@ -90,12 +90,40 @@ class LegacyVersion(_BaseVersion):
         return self._version
 
     @property
+    def epoch(self):
+        return -1
+
+    @property
+    def release(self):
+        return None
+
+    @property
     def local(self):
+        return None
+
+    @property
+    def local_info(self):
+        return None
+
+    @property
+    def prerelease(self):
         return None
 
     @property
     def is_prerelease(self):
         return False
+
+    @property
+    def development(self):
+        return None
+
+    @property
+    def is_development(self):
+        return False
+
+    @property
+    def postrelease(self):
+        return None
 
     @property
     def is_postrelease(self):
@@ -282,14 +310,48 @@ class Version(_BaseVersion):
         return "".join(parts)
 
     @property
+    def epoch(self):
+        return self._version.epoch
+
+    @property
+    def release(self):
+        return self._version.release
+
+    @property
     def local(self):
         version_string = str(self)
         if "+" in version_string:
             return version_string.split("+", 1)[1]
 
     @property
+    def local_info(self):
+        return self._version.local
+
+    @property
+    def prerelease(self):
+        return self._version.pre
+
+    @property
     def is_prerelease(self):
         return bool(self._version.dev or self._version.pre)
+
+    @property
+    def development(self):
+        if self._version.dev is not None:
+            return self._version.dev[1]
+        else:
+            return None
+
+    @property
+    def is_development(self):
+        return bool(self._version.dev)
+
+    @property
+    def postrelease(self):
+        if self._version.post is not None:
+            return self._version.post[1]
+        else:
+            return None
 
     @property
     def is_postrelease(self):

--- a/packaging/version.py
+++ b/packaging/version.py
@@ -98,15 +98,19 @@ class LegacyVersion(_BaseVersion):
         return None
 
     @property
+    def pre(self):
+        return None
+
+    @property
+    def post(self):
+        return None
+
+    @property
+    def dev(self):
+        return None
+
+    @property
     def local(self):
-        return None
-
-    @property
-    def local_info(self):
-        return None
-
-    @property
-    def prerelease(self):
         return None
 
     @property
@@ -114,19 +118,11 @@ class LegacyVersion(_BaseVersion):
         return False
 
     @property
-    def development(self):
-        return None
-
-    @property
-    def is_development(self):
+    def is_postrelease(self):
         return False
 
     @property
-    def postrelease(self):
-        return None
-
-    @property
-    def is_postrelease(self):
+    def is_devrelease(self):
         return False
 
 
@@ -266,46 +262,27 @@ class Version(_BaseVersion):
         parts = []
 
         # Epoch
-        if self._version.epoch != 0:
-            parts.append("{0}!".format(self._version.epoch))
+        if self.epoch != 0:
+            parts.append("{0}!".format(self.epoch))
 
         # Release segment
-        parts.append(".".join(str(x) for x in self._version.release))
+        parts.append(".".join(str(x) for x in self.release))
 
         # Pre-release
-        if self._version.pre is not None:
-            parts.append("".join(str(x) for x in self._version.pre))
+        if self.pre is not None:
+            parts.append("".join(str(x) for x in self.pre))
 
         # Post-release
-        if self._version.post is not None:
-            parts.append(".post{0}".format(self._version.post[1]))
+        if self.post is not None:
+            parts.append(".post{0}".format(self.post))
 
         # Development release
-        if self._version.dev is not None:
-            parts.append(".dev{0}".format(self._version.dev[1]))
+        if self.dev is not None:
+            parts.append(".dev{0}".format(self.dev))
 
         # Local version segment
-        if self._version.local is not None:
-            parts.append(
-                "+{0}".format(".".join(str(x) for x in self._version.local))
-            )
-
-        return "".join(parts)
-
-    @property
-    def public(self):
-        return str(self).split("+", 1)[0]
-
-    @property
-    def base_version(self):
-        parts = []
-
-        # Epoch
-        if self._version.epoch != 0:
-            parts.append("{0}!".format(self._version.epoch))
-
-        # Release segment
-        parts.append(".".join(str(x) for x in self._version.release))
+        if self.local is not None:
+            parts.append("+{0}".format(self.local))
 
         return "".join(parts)
 
@@ -318,44 +295,52 @@ class Version(_BaseVersion):
         return self._version.release
 
     @property
-    def local(self):
-        version_string = str(self)
-        if "+" in version_string:
-            return version_string.split("+", 1)[1]
-
-    @property
-    def local_info(self):
-        return self._version.local
-
-    @property
-    def prerelease(self):
+    def pre(self):
         return self._version.pre
 
     @property
+    def post(self):
+        return self._version.post[1] if self._version.post else None
+
+    @property
+    def dev(self):
+        return self._version.dev[1] if self._version.dev else None
+
+    @property
+    def local(self):
+        if self._version.local:
+            return ".".join(str(x) for x in self._version.local)
+        else:
+            return None
+
+    @property
+    def public(self):
+        return str(self).split("+", 1)[0]
+
+    @property
+    def base_version(self):
+        parts = []
+
+        # Epoch
+        if self.epoch != 0:
+            parts.append("{0}!".format(self.epoch))
+
+        # Release segment
+        parts.append(".".join(str(x) for x in self.release))
+
+        return "".join(parts)
+
+    @property
     def is_prerelease(self):
-        return bool(self._version.dev or self._version.pre)
-
-    @property
-    def development(self):
-        if self._version.dev is not None:
-            return self._version.dev[1]
-        else:
-            return None
-
-    @property
-    def is_development(self):
-        return bool(self._version.dev)
-
-    @property
-    def postrelease(self):
-        if self._version.post is not None:
-            return self._version.post[1]
-        else:
-            return None
+        return self.dev is not None or self.pre is not None
 
     @property
     def is_postrelease(self):
-        return bool(self._version.post)
+        return self.post is not None
+
+    @property
+    def is_devrelease(self):
+        return self.dev is not None
 
 
 def _parse_letter_version(letter, number):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import, division, print_function
 
 import pytest
 
-from packaging.utils import canonicalize_name
+from packaging.utils import canonicalize_name, canonicalize_version
 
 
 @pytest.mark.parametrize(
@@ -25,3 +25,22 @@ from packaging.utils import canonicalize_name
 )
 def test_canonicalize_name(name, expected):
     assert canonicalize_name(name) == expected
+
+
+@pytest.mark.parametrize(
+    ("version", "expected"),
+    [
+        ('1.4.0', '1.4'),
+        ('1.40.0', '1.40'),
+        ('1.4.0.0.00.000.0000', '1.4'),
+        ('1.0', '1'),
+        ('1.0+abc', '1+abc'),
+        ('1.0.dev0', '1.dev0'),
+        ('1.0.post0', '1.post0'),
+        ('1.0a0', '1a0'),
+        ('1.0rc0', '1rc0'),
+        ('100!0.0', '100!0'),
+    ]
+)
+def test_canonicalize_version(version, expected):
+    assert canonicalize_version(version) == expected

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -264,6 +264,7 @@ class TestVersion:
         ("version", "public"),
         [
             ("1.0", "1.0"),
+            ("1.0.dev0", "1.0.dev0"),
             ("1.0.dev6", "1.0.dev6"),
             ("1.0a1", "1.0a1"),
             ("1.0a1.post5", "1.0a1.post5"),
@@ -300,6 +301,7 @@ class TestVersion:
         ("version", "base_version"),
         [
             ("1.0", "1.0"),
+            ("1.0.dev0", "1.0"),
             ("1.0.dev6", "1.0"),
             ("1.0a1", "1.0"),
             ("1.0a1.post5", "1.0"),
@@ -336,6 +338,7 @@ class TestVersion:
         ("version", "epoch"),
         [
             ("1.0", 0),
+            ("1.0.dev0", 0),
             ("1.0.dev6", 0),
             ("1.0a1", 0),
             ("1.0a1.post5", 0),
@@ -372,6 +375,7 @@ class TestVersion:
         ("version", "release"),
         [
             ("1.0", (1, 0)),
+            ("1.0.dev0", (1, 0)),
             ("1.0.dev6", (1, 0)),
             ("1.0a1", (1, 0)),
             ("1.0a1.post5", (1, 0)),
@@ -408,6 +412,7 @@ class TestVersion:
         ("version", "local"),
         [
             ("1.0", None),
+            ("1.0.dev0", None),
             ("1.0.dev6", None),
             ("1.0a1", None),
             ("1.0a1.post5", None),
@@ -441,65 +446,10 @@ class TestVersion:
         assert Version(version).local == local
 
     @pytest.mark.parametrize(
-        ("version", "local_info"),
-        [
-            ("1.0.dev456", None),
-            ("1.0a1", None),
-            ("1.0a2.dev456", None),
-            ("1.0a12.dev456", None),
-            ("1.0a12", None),
-            ("1.0b1.dev456", None),
-            ("1.0b2", None),
-            ("1.0b2.post345.dev456", None),
-            ("1.0b2.post345", None),
-            ("1.0rc1.dev456", None),
-            ("1.0rc1", None),
-            ("1.0", None),
-            ("1.0.post456.dev34", None),
-            ("1.0.post456", None),
-            ("1.0.1", None),
-            ("0!1.0.2", None),
-            ("1.0.3+7", (7,)),
-            ("0!1.0.4+8.0", (8, 0)),
-            ("1.0.5+9.5", (9, 5)),
-            ("1.2+1234.abc", (1234, "abc")),
-            ("1.2+123456", (123456,)),
-            ("1.2+123abc", ("123abc",)),
-            ("1.2+123abc456", ("123abc456",)),
-            ("1.2+abc", ("abc",)),
-            ("1.2+ABC", ("abc",)),
-            ("1.2+abc123", ("abc123",)),
-            ("1.2+abc123def", ("abc123def",)),
-            ("1.1.dev1", None),
-            ("7!1.0.dev456", None),
-            ("7!1.0a1", None),
-            ("7!1.0a2.dev456", None),
-            ("7!1.0a12.dev456", None),
-            ("7!1.0a12", None),
-            ("7!1.0b1.dev456", None),
-            ("7!1.0b2", None),
-            ("7!1.0b2.post345.dev456", None),
-            ("7!1.0b2.post345", None),
-            ("7!1.0rc1.dev456", None),
-            ("7!1.0rc1", None),
-            ("7!1.0", None),
-            ("7!1.0.post456.dev34", None),
-            ("7!1.0.post456", None),
-            ("7!1.0.1", None),
-            ("7!1.0.2", None),
-            ("7!1.0.3+7", (7,)),
-            ("7!1.0.4+8.0", (8, 0)),
-            ("7!1.0.5+9.5", (9, 5)),
-            ("7!1.1.dev1", None),
-        ],
-    )
-    def test_version_local_info(self, version, local_info):
-        assert Version(version).local_info == local_info
-
-    @pytest.mark.parametrize(
-        ("version", "prerelease"),
+        ("version", "pre"),
         [
             ("1.0", None),
+            ("1.0.dev0", None),
             ("1.0.dev6", None),
             ("1.0a1", ('a', 1)),
             ("1.0a1.post5", ('a', 1)),
@@ -529,12 +479,13 @@ class TestVersion:
             ("1!1.0.post5+deadbeef", None),
         ],
     )
-    def test_version_prerelease(self, version, prerelease):
-        assert Version(version).prerelease == prerelease
+    def test_version_pre(self, version, pre):
+        assert Version(version).pre == pre
 
     @pytest.mark.parametrize(
         ("version", "expected"),
         [
+            ("1.0.dev0", True),
             ("1.0.dev1", True),
             ("1.0a1.dev1", True),
             ("1.0b1.dev1", True),
@@ -562,9 +513,10 @@ class TestVersion:
         assert Version(version).is_prerelease is expected
 
     @pytest.mark.parametrize(
-        ("version", "development"),
+        ("version", "dev"),
         [
             ("1.0", None),
+            ("1.0.dev0", 0),
             ("1.0.dev6", 6),
             ("1.0a1", None),
             ("1.0a1.post5", None),
@@ -594,13 +546,14 @@ class TestVersion:
             ("1!1.0.post5+deadbeef", None),
         ],
     )
-    def test_version_development(self, version, development):
-        assert Version(version).development == development
+    def test_version_dev(self, version, dev):
+        assert Version(version).dev == dev
 
     @pytest.mark.parametrize(
         ("version", "expected"),
         [
             ("1.0", False),
+            ("1.0.dev0", True),
             ("1.0.dev6", True),
             ("1.0a1", False),
             ("1.0a1.post5", False),
@@ -630,13 +583,14 @@ class TestVersion:
             ("1!1.0.post5+deadbeef", False),
         ],
     )
-    def test_version_is_development(self, version, expected):
-        assert Version(version).is_development is expected
+    def test_version_is_devrelease(self, version, expected):
+        assert Version(version).is_devrelease is expected
 
     @pytest.mark.parametrize(
-        ("version", "postrelease"),
+        ("version", "post"),
         [
             ("1.0", None),
+            ("1.0.dev0", None),
             ("1.0.dev6", None),
             ("1.0a1", None),
             ("1.0a1.post5", 5),
@@ -666,8 +620,8 @@ class TestVersion:
             ("1!1.0.post5+deadbeef", 5),
         ],
     )
-    def test_version_postrelease(self, version, postrelease):
-        assert Version(version).postrelease == postrelease
+    def test_version_post(self, version, post):
+        assert Version(version).post == post
 
     @pytest.mark.parametrize(
         ("version", "expected"),
@@ -815,28 +769,24 @@ class TestLegacyVersion:
         assert LegacyVersion(version).local is None
 
     @pytest.mark.parametrize("version", VERSIONS + LEGACY_VERSIONS)
-    def test_legacy_version_local_info(self, version):
-        assert LegacyVersion(version).local_info is None
-
-    @pytest.mark.parametrize("version", VERSIONS + LEGACY_VERSIONS)
-    def test_legacy_version_prerelease(self, version):
-        assert LegacyVersion(version).prerelease is None
+    def test_legacy_version_pre(self, version):
+        assert LegacyVersion(version).pre is None
 
     @pytest.mark.parametrize("version", VERSIONS + LEGACY_VERSIONS)
     def test_legacy_version_is_prerelease(self, version):
         assert not LegacyVersion(version).is_prerelease
 
     @pytest.mark.parametrize("version", VERSIONS + LEGACY_VERSIONS)
-    def test_legacy_version_development(self, version):
-        assert LegacyVersion(version).development is None
+    def test_legacy_version_dev(self, version):
+        assert LegacyVersion(version).dev is None
 
     @pytest.mark.parametrize("version", VERSIONS + LEGACY_VERSIONS)
-    def test_legacy_version_is_development(self, version):
-        assert not LegacyVersion(version).is_development
+    def test_legacy_version_is_devrelease(self, version):
+        assert not LegacyVersion(version).is_devrelease
 
     @pytest.mark.parametrize("version", VERSIONS + LEGACY_VERSIONS)
-    def test_legacy_version_postrelease(self, version):
-        assert LegacyVersion(version).postrelease is None
+    def test_legacy_version_post(self, version):
+        assert LegacyVersion(version).post is None
 
     @pytest.mark.parametrize("version", VERSIONS + LEGACY_VERSIONS)
     def test_legacy_version_is_postrelease(self, version):

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -333,6 +333,78 @@ class TestVersion:
         assert Version(version).base_version == base_version
 
     @pytest.mark.parametrize(
+        ("version", "epoch"),
+        [
+            ("1.0", 0),
+            ("1.0.dev6", 0),
+            ("1.0a1", 0),
+            ("1.0a1.post5", 0),
+            ("1.0a1.post5.dev6", 0),
+            ("1.0rc4", 0),
+            ("1.0.post5", 0),
+            ("1!1.0", 1),
+            ("1!1.0.dev6", 1),
+            ("1!1.0a1", 1),
+            ("1!1.0a1.post5", 1),
+            ("1!1.0a1.post5.dev6", 1),
+            ("1!1.0rc4", 1),
+            ("1!1.0.post5", 1),
+            ("1.0+deadbeef", 0),
+            ("1.0.dev6+deadbeef", 0),
+            ("1.0a1+deadbeef", 0),
+            ("1.0a1.post5+deadbeef", 0),
+            ("1.0a1.post5.dev6+deadbeef", 0),
+            ("1.0rc4+deadbeef", 0),
+            ("1.0.post5+deadbeef", 0),
+            ("1!1.0+deadbeef", 1),
+            ("1!1.0.dev6+deadbeef", 1),
+            ("1!1.0a1+deadbeef", 1),
+            ("1!1.0a1.post5+deadbeef", 1),
+            ("1!1.0a1.post5.dev6+deadbeef", 1),
+            ("1!1.0rc4+deadbeef", 1),
+            ("1!1.0.post5+deadbeef", 1),
+        ],
+    )
+    def test_version_epoch(self, version, epoch):
+        assert Version(version).epoch == epoch
+
+    @pytest.mark.parametrize(
+        ("version", "release"),
+        [
+            ("1.0", (1, 0)),
+            ("1.0.dev6", (1, 0)),
+            ("1.0a1", (1, 0)),
+            ("1.0a1.post5", (1, 0)),
+            ("1.0a1.post5.dev6", (1, 0)),
+            ("1.0rc4", (1, 0)),
+            ("1.0.post5", (1, 0)),
+            ("1!1.0", (1, 0)),
+            ("1!1.0.dev6", (1, 0)),
+            ("1!1.0a1", (1, 0)),
+            ("1!1.0a1.post5", (1, 0)),
+            ("1!1.0a1.post5.dev6", (1, 0)),
+            ("1!1.0rc4", (1, 0)),
+            ("1!1.0.post5", (1, 0)),
+            ("1.0+deadbeef", (1, 0)),
+            ("1.0.dev6+deadbeef", (1, 0)),
+            ("1.0a1+deadbeef", (1, 0)),
+            ("1.0a1.post5+deadbeef", (1, 0)),
+            ("1.0a1.post5.dev6+deadbeef", (1, 0)),
+            ("1.0rc4+deadbeef", (1, 0)),
+            ("1.0.post5+deadbeef", (1, 0)),
+            ("1!1.0+deadbeef", (1, 0)),
+            ("1!1.0.dev6+deadbeef", (1, 0)),
+            ("1!1.0a1+deadbeef", (1, 0)),
+            ("1!1.0a1.post5+deadbeef", (1, 0)),
+            ("1!1.0a1.post5.dev6+deadbeef", (1, 0)),
+            ("1!1.0rc4+deadbeef", (1, 0)),
+            ("1!1.0.post5+deadbeef", (1, 0)),
+        ],
+    )
+    def test_version_release(self, version, release):
+        assert Version(version).release == release
+
+    @pytest.mark.parametrize(
         ("version", "local"),
         [
             ("1.0", None),
@@ -369,6 +441,98 @@ class TestVersion:
         assert Version(version).local == local
 
     @pytest.mark.parametrize(
+        ("version", "local_info"),
+        [
+            ("1.0.dev456", None),
+            ("1.0a1", None),
+            ("1.0a2.dev456", None),
+            ("1.0a12.dev456", None),
+            ("1.0a12", None),
+            ("1.0b1.dev456", None),
+            ("1.0b2", None),
+            ("1.0b2.post345.dev456", None),
+            ("1.0b2.post345", None),
+            ("1.0rc1.dev456", None),
+            ("1.0rc1", None),
+            ("1.0", None),
+            ("1.0.post456.dev34", None),
+            ("1.0.post456", None),
+            ("1.0.1", None),
+            ("0!1.0.2", None),
+            ("1.0.3+7", (7,)),
+            ("0!1.0.4+8.0", (8, 0)),
+            ("1.0.5+9.5", (9, 5)),
+            ("1.2+1234.abc", (1234, "abc")),
+            ("1.2+123456", (123456,)),
+            ("1.2+123abc", ("123abc",)),
+            ("1.2+123abc456", ("123abc456",)),
+            ("1.2+abc", ("abc",)),
+            ("1.2+ABC", ("abc",)),
+            ("1.2+abc123", ("abc123",)),
+            ("1.2+abc123def", ("abc123def",)),
+            ("1.1.dev1", None),
+            ("7!1.0.dev456", None),
+            ("7!1.0a1", None),
+            ("7!1.0a2.dev456", None),
+            ("7!1.0a12.dev456", None),
+            ("7!1.0a12", None),
+            ("7!1.0b1.dev456", None),
+            ("7!1.0b2", None),
+            ("7!1.0b2.post345.dev456", None),
+            ("7!1.0b2.post345", None),
+            ("7!1.0rc1.dev456", None),
+            ("7!1.0rc1", None),
+            ("7!1.0", None),
+            ("7!1.0.post456.dev34", None),
+            ("7!1.0.post456", None),
+            ("7!1.0.1", None),
+            ("7!1.0.2", None),
+            ("7!1.0.3+7", (7,)),
+            ("7!1.0.4+8.0", (8, 0)),
+            ("7!1.0.5+9.5", (9, 5)),
+            ("7!1.1.dev1", None),
+        ],
+    )
+    def test_version_local_info(self, version, local_info):
+        assert Version(version).local_info == local_info
+
+    @pytest.mark.parametrize(
+        ("version", "prerelease"),
+        [
+            ("1.0", None),
+            ("1.0.dev6", None),
+            ("1.0a1", ('a', 1)),
+            ("1.0a1.post5", ('a', 1)),
+            ("1.0a1.post5.dev6", ('a', 1)),
+            ("1.0rc4", ('rc', 4)),
+            ("1.0.post5", None),
+            ("1!1.0", None),
+            ("1!1.0.dev6", None),
+            ("1!1.0a1", ('a', 1)),
+            ("1!1.0a1.post5", ('a', 1)),
+            ("1!1.0a1.post5.dev6", ('a', 1)),
+            ("1!1.0rc4", ('rc', 4)),
+            ("1!1.0.post5", None),
+            ("1.0+deadbeef", None),
+            ("1.0.dev6+deadbeef", None),
+            ("1.0a1+deadbeef", ('a', 1)),
+            ("1.0a1.post5+deadbeef", ('a', 1)),
+            ("1.0a1.post5.dev6+deadbeef", ('a', 1)),
+            ("1.0rc4+deadbeef", ('rc', 4)),
+            ("1.0.post5+deadbeef", None),
+            ("1!1.0+deadbeef", None),
+            ("1!1.0.dev6+deadbeef", None),
+            ("1!1.0a1+deadbeef", ('a', 1)),
+            ("1!1.0a1.post5+deadbeef", ('a', 1)),
+            ("1!1.0a1.post5.dev6+deadbeef", ('a', 1)),
+            ("1!1.0rc4+deadbeef", ('rc', 4)),
+            ("1!1.0.post5+deadbeef", None),
+        ],
+    )
+    def test_version_prerelease(self, version, prerelease):
+        assert Version(version).prerelease == prerelease
+
+    @pytest.mark.parametrize(
         ("version", "expected"),
         [
             ("1.0.dev1", True),
@@ -396,6 +560,114 @@ class TestVersion:
     )
     def test_version_is_prerelease(self, version, expected):
         assert Version(version).is_prerelease is expected
+
+    @pytest.mark.parametrize(
+        ("version", "development"),
+        [
+            ("1.0", None),
+            ("1.0.dev6", 6),
+            ("1.0a1", None),
+            ("1.0a1.post5", None),
+            ("1.0a1.post5.dev6", 6),
+            ("1.0rc4", None),
+            ("1.0.post5", None),
+            ("1!1.0", None),
+            ("1!1.0.dev6", 6),
+            ("1!1.0a1", None),
+            ("1!1.0a1.post5", None),
+            ("1!1.0a1.post5.dev6", 6),
+            ("1!1.0rc4", None),
+            ("1!1.0.post5", None),
+            ("1.0+deadbeef", None),
+            ("1.0.dev6+deadbeef", 6),
+            ("1.0a1+deadbeef", None),
+            ("1.0a1.post5+deadbeef", None),
+            ("1.0a1.post5.dev6+deadbeef", 6),
+            ("1.0rc4+deadbeef", None),
+            ("1.0.post5+deadbeef", None),
+            ("1!1.0+deadbeef", None),
+            ("1!1.0.dev6+deadbeef", 6),
+            ("1!1.0a1+deadbeef", None),
+            ("1!1.0a1.post5+deadbeef", None),
+            ("1!1.0a1.post5.dev6+deadbeef", 6),
+            ("1!1.0rc4+deadbeef", None),
+            ("1!1.0.post5+deadbeef", None),
+        ],
+    )
+    def test_version_development(self, version, development):
+        assert Version(version).development == development
+
+    @pytest.mark.parametrize(
+        ("version", "expected"),
+        [
+            ("1.0", False),
+            ("1.0.dev6", True),
+            ("1.0a1", False),
+            ("1.0a1.post5", False),
+            ("1.0a1.post5.dev6", True),
+            ("1.0rc4", False),
+            ("1.0.post5", False),
+            ("1!1.0", False),
+            ("1!1.0.dev6", True),
+            ("1!1.0a1", False),
+            ("1!1.0a1.post5", False),
+            ("1!1.0a1.post5.dev6", True),
+            ("1!1.0rc4", False),
+            ("1!1.0.post5", False),
+            ("1.0+deadbeef", False),
+            ("1.0.dev6+deadbeef", True),
+            ("1.0a1+deadbeef", False),
+            ("1.0a1.post5+deadbeef", False),
+            ("1.0a1.post5.dev6+deadbeef", True),
+            ("1.0rc4+deadbeef", False),
+            ("1.0.post5+deadbeef", False),
+            ("1!1.0+deadbeef", False),
+            ("1!1.0.dev6+deadbeef", True),
+            ("1!1.0a1+deadbeef", False),
+            ("1!1.0a1.post5+deadbeef", False),
+            ("1!1.0a1.post5.dev6+deadbeef", True),
+            ("1!1.0rc4+deadbeef", False),
+            ("1!1.0.post5+deadbeef", False),
+        ],
+    )
+    def test_version_is_development(self, version, expected):
+        assert Version(version).is_development is expected
+
+    @pytest.mark.parametrize(
+        ("version", "postrelease"),
+        [
+            ("1.0", None),
+            ("1.0.dev6", None),
+            ("1.0a1", None),
+            ("1.0a1.post5", 5),
+            ("1.0a1.post5.dev6", 5),
+            ("1.0rc4", None),
+            ("1.0.post5", 5),
+            ("1!1.0", None),
+            ("1!1.0.dev6", None),
+            ("1!1.0a1", None),
+            ("1!1.0a1.post5", 5),
+            ("1!1.0a1.post5.dev6", 5),
+            ("1!1.0rc4", None),
+            ("1!1.0.post5", 5),
+            ("1.0+deadbeef", None),
+            ("1.0.dev6+deadbeef", None),
+            ("1.0a1+deadbeef", None),
+            ("1.0a1.post5+deadbeef", 5),
+            ("1.0a1.post5.dev6+deadbeef", 5),
+            ("1.0rc4+deadbeef", None),
+            ("1.0.post5+deadbeef", 5),
+            ("1!1.0+deadbeef", None),
+            ("1!1.0.dev6+deadbeef", None),
+            ("1!1.0a1+deadbeef", None),
+            ("1!1.0a1.post5+deadbeef", 5),
+            ("1!1.0a1.post5.dev6+deadbeef", 5),
+            ("1!1.0rc4+deadbeef", None),
+            ("1!1.0.post5+deadbeef", 5),
+        ],
+    )
+    def test_version_postrelease(self, version, postrelease):
+        assert Version(version).postrelease == postrelease
 
     @pytest.mark.parametrize(
         ("version", "expected"),
@@ -531,12 +803,40 @@ class TestLegacyVersion:
         assert LegacyVersion(version).base_version == version
 
     @pytest.mark.parametrize("version", VERSIONS + LEGACY_VERSIONS)
+    def test_legacy_version_epoch(self, version):
+        assert LegacyVersion(version).epoch == -1
+
+    @pytest.mark.parametrize("version", VERSIONS + LEGACY_VERSIONS)
+    def test_legacy_version_release(self, version):
+        assert LegacyVersion(version).release is None
+
+    @pytest.mark.parametrize("version", VERSIONS + LEGACY_VERSIONS)
     def test_legacy_version_local(self, version):
         assert LegacyVersion(version).local is None
 
     @pytest.mark.parametrize("version", VERSIONS + LEGACY_VERSIONS)
+    def test_legacy_version_local_info(self, version):
+        assert LegacyVersion(version).local_info is None
+
+    @pytest.mark.parametrize("version", VERSIONS + LEGACY_VERSIONS)
+    def test_legacy_version_prerelease(self, version):
+        assert LegacyVersion(version).prerelease is None
+
+    @pytest.mark.parametrize("version", VERSIONS + LEGACY_VERSIONS)
     def test_legacy_version_is_prerelease(self, version):
         assert not LegacyVersion(version).is_prerelease
+
+    @pytest.mark.parametrize("version", VERSIONS + LEGACY_VERSIONS)
+    def test_legacy_version_development(self, version):
+        assert LegacyVersion(version).development is None
+
+    @pytest.mark.parametrize("version", VERSIONS + LEGACY_VERSIONS)
+    def test_legacy_version_is_development(self, version):
+        assert not LegacyVersion(version).is_development
+
+    @pytest.mark.parametrize("version", VERSIONS + LEGACY_VERSIONS)
+    def test_legacy_version_postrelease(self, version):
+        assert LegacyVersion(version).postrelease is None
 
     @pytest.mark.parametrize("version", VERSIONS + LEGACY_VERSIONS)
     def test_legacy_version_is_postrelease(self, version):


### PR DESCRIPTION
Fixes #34, fixes #84, fixes #121, closes #109.

This PR provides `utils.canonicalize_version` to fix #121.

It was necessary to expose the components of the `Version` as proposed in #34 in order to do so. This PR builds off an attempt to do this in #109, but I found that the API provided in that PR wasn't quite what I'd expected, and it could generally be simplified.

Commit 44e5868 implements `canonicalize_version`. I left the entirety of #109 in place as commit e31549a to provide credit where credit is due. Commit 55cb55c is everything I changed from #109, namely:

* ~~Get rid of the internal `_version` `NamedTuple` and set the attributes on the `Version` instance directly instead of using `@property` to wrap `_version`.~~ (This change was reverted)
  * ~~This is just a simplification but required a bit of refactoring.~~
* Change `.prerelease`, `.postrelease` and `.development` attributes to `.pre`, `.post` and `.dev`. 
  * Technically `.development` should have been `.devrelease` to match, but I think the "release" part of these attributes is unnecessary.
  * Using the shorter form more closely matches the `dev`/`post` strings used in the versions themselves as well.
* Change the return type of `.post` and `.dev` from a tuple to just the post/dev release number (e.g. (e.g. `('post', 0)` becomes just `0`).
  * I felt like it was redundant/unnecessary to return the parsed type as well as the release number 
* Resolve ambiguity between `.local` and `.local_info` (by eliminating the latter)
  * The name of `.local_info` seemed out of place
  * The usefulness of this attribute returning a tuple seemed doubtful
  * So `.local` continues to return a string representing the local part (fully backwards compatible)
* Rename `is_development` to `is_devrelease` to match the `.dev` attribute and the `is_postrelease` and `is_prerelease` properties.
  * A small refactor but `is_development` seemed to be not the best name here considering the existing API.

So the new API for `Version` is:
* `.epoch -> int`
* `.release -> tuple`
* `.pre -> tuple`
* `.post -> int`
* `.dev -> int`
* `.local -> str` (remains the same)
* `.is_development -> bool` (for #84)

And for `utils`:
* `canonicalize_version(version: str) -> str` (for #121)