### PR TITLE
Improved error message in ParseException

### DIFF
--- a/packaging/requirements.py
+++ b/packaging/requirements.py
@@ -101,7 +101,7 @@ class Requirement(object):
             parsed_url = urlparse.urlparse(req.url)
             if not (parsed_url.scheme and parsed_url.netloc) or (
                     not parsed_url.scheme and not parsed_url.netloc):
-                raise InvalidRequirement("Invalid URL given")
+                raise InvalidRequirement("Invalid URL: {0}".format(req.url))
             self.url = req.url
         else:
             self.url = None

--- a/packaging/requirements.py
+++ b/packaging/requirements.py
@@ -92,7 +92,9 @@ class Requirement(object):
         try:
             req = REQUIREMENT.parseString(requirement_string)
         except ParseException as e:
-            raise InvalidRequirement("Parse error: {0!r}".format(e))
+            raise InvalidRequirement("Parse error at \"{0!r}\": {1}".format(
+                requirement_string[e.loc:e.loc + 8], e.msg
+            ))
 
         self.name = req.name
         if req.url:

--- a/packaging/requirements.py
+++ b/packaging/requirements.py
@@ -92,9 +92,7 @@ class Requirement(object):
         try:
             req = REQUIREMENT.parseString(requirement_string)
         except ParseException as e:
-            raise InvalidRequirement(
-                "Invalid requirement, parse error at \"{0!r}\"".format(
-                    requirement_string[e.loc:e.loc + 8]))
+            raise InvalidRequirement("Parse error: {0!r}".format(e))
 
         self.name = req.name
         if req.url:

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -170,3 +170,8 @@ class TestRequirements:
         assert req.marker is not None
         assert req.marker.evaluate(dict(sys_platform="foo")) is True
         assert req.marker.evaluate(dict(sys_platform="bar")) is False
+
+    def test_parseexception_error_msg(self):
+        with pytest.raises(InvalidRequirement) as e:
+            Requirement("toto 42")
+            assert "Invalid Requiremnt" not in e

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -97,8 +97,9 @@ class TestRequirements:
         assert str(parsed.marker) == 'os_name == "a"'
 
     def test_invalid_url(self):
-        with pytest.raises(InvalidRequirement):
+        with pytest.raises(InvalidRequirement) as e:
             Requirement("name @ gopher:/foo/com")
+            assert "Invalid URL: " in e
 
     def test_extras_and_url_and_marker(self):
         req = Requirement(

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -99,7 +99,8 @@ class TestRequirements:
     def test_invalid_url(self):
         with pytest.raises(InvalidRequirement) as e:
             Requirement("name @ gopher:/foo/com")
-            assert "Invalid URL: " in e
+        assert "Invalid URL: " in str(e)
+        assert "gopher:/foo/com" in str(e)
 
     def test_extras_and_url_and_marker(self):
         req = Requirement(
@@ -175,4 +176,4 @@ class TestRequirements:
     def test_parseexception_error_msg(self):
         with pytest.raises(InvalidRequirement) as e:
             Requirement("toto 42")
-            assert "Expected stringEnd" in e
+        assert "Expected stringEnd" in str(e)

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -174,4 +174,4 @@ class TestRequirements:
     def test_parseexception_error_msg(self):
         with pytest.raises(InvalidRequirement) as e:
             Requirement("toto 42")
-            assert "Invalid Requiremnt" not in e
+            assert "Expected stringEnd" in e


### PR DESCRIPTION
Hello,

This PR will help to fix  https://github.com/pypa/pip/issues/5147 and https://github.com/pypa/pip/pull/5170. It changes the string being passed in the `InvalidRequirement` to something like `Parse error: Expected stringEnd (at char 5), (line:1, col:6)` which can be easily used by `pip` to produce a nicer error message on parsing errors.