### PR TITLE
Added Version.bump_(major|minor|patch)

### DIFF
--- a/docs/version.rst
+++ b/docs/version.rst
@@ -31,6 +31,10 @@ Usage
     True
     >>> v2.is_prerelease
     False
+    >>> v1.bump_major()
+    <Version('2.0a5')>
+    >>> v1.bump_minor()
+    <Version('1.1a5')>
     >>> Version("french toast")
     Traceback (most recent call last):
         ...
@@ -124,6 +128,21 @@ Reference
 
         A boolean value indicating whether this :class:`Version` instance
         represents a post-release.
+
+    .. function:: bump_major
+
+        Returns new :class:`Version` instance with the major part of the
+        release segment increased by one.
+
+    .. function:: bump_minor
+
+        Returns new :class:`Version` instance with the minor part of the
+        release segment increased by one.
+
+    .. function:: bump_patch
+
+        Returns new :class:`Version` instance with the patch part of the
+        release segment increased by one.
 
 
 .. class:: LegacyVersion(version)

--- a/packaging/version.py
+++ b/packaging/version.py
@@ -228,18 +228,12 @@ class Version(_BaseVersion):
             self._version = _Version(
                 epoch=int(match.group("epoch")) if match.group("epoch") else 0,
                 release=tuple(int(i) for i in release_groups),
-                pre=_parse_letter_version(
-                    match.group("pre_l"),
-                    match.group("pre_n")
-                ),
+                pre=_parse_letter_version(match.group("pre_l"), match.group("pre_n")),
                 post=_parse_letter_version(
                     match.group("post_l"),
-                    match.group("post_n1") or match.group("post_n2")
+                    match.group("post_n1") or match.group("post_n2"),
                 ),
-                dev=_parse_letter_version(
-                    match.group("dev_l"),
-                    match.group("dev_n")
-                ),
+                dev=_parse_letter_version(match.group("dev_l"), match.group("dev_n")),
                 local=_parse_local_version(match.group("local")),
             )
 
@@ -413,7 +407,7 @@ class Version(_BaseVersion):
 
         """
         if len(self._version.release) <= level:
-            raise ValueError('Level is bigger than release components.')
+            raise ValueError("Level is bigger than release components.")
 
         release = list(self._version.release)
         release[level] += 1
@@ -424,7 +418,7 @@ class Version(_BaseVersion):
             pre=self.pre,
             post=self.post,
             dev=self.dev,
-            local=self.local
+            local=self.local,
         )
         return Version(version)
 

--- a/packaging/version.py
+++ b/packaging/version.py
@@ -230,9 +230,10 @@ class Version(_BaseVersion):
                 raise InvalidVersion("Invalid version: '{0}'".format(version))
 
             # Store the parsed out pieces of the version
+            release_groups = match.group("release").split(".")
             self._version = _Version(
                 epoch=int(match.group("epoch")) if match.group("epoch") else 0,
-                release=tuple(int(i) for i in match.group("release").split(".")),
+                release=tuple(int(i) for i in release_groups),
                 pre=_parse_letter_version(
                     match.group("pre_l"),
                     match.group("pre_n"),

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -450,7 +450,7 @@ class TestVersion:
         version = Version('1.1')
         with pytest.raises(ValueError) as e:
             version.bump_patch()
-        assert 'Level is bigger than release components.' in str(e)
+        assert 'Level is bigger than release components.' in str(e.value)
 
     @pytest.mark.parametrize(
         ("version", "local"),

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -408,6 +408,24 @@ class TestVersion:
     def test_version_release(self, version, release):
         assert Version(version).release == release
 
+    def test_bump_major(self):
+        version = Version('1.1.1')
+        assert version.bump_major().release[0] == 2
+
+    def test_bump_minor(self):
+        version = Version('1.1.1')
+        assert version.bump_minor().release[1] == 2
+
+    def test_bump_patch(self):
+        version = Version('1.1.1')
+        assert version.bump_patch().release[2] == 2
+
+    def test_bump_release(self):
+        version = Version('1.1')
+        with pytest.raises(ValueError) as e:
+            version.bump_patch()
+            assert 'Level is bigger than release components.' in e
+
     @pytest.mark.parametrize(
         ("version", "local"),
         [

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -435,22 +435,22 @@ class TestVersion:
         assert Version(version).release == release
 
     def test_bump_major(self):
-        version = Version('1.1.1')
+        version = Version("1.1.1")
         assert version.bump_major().release[0] == 2
 
     def test_bump_minor(self):
-        version = Version('1.1.1')
+        version = Version("1.1.1")
         assert version.bump_minor().release[1] == 2
 
     def test_bump_patch(self):
-        version = Version('1.1.1')
+        version = Version("1.1.1")
         assert version.bump_patch().release[2] == 2
 
     def test_bump_release(self):
-        version = Version('1.1')
+        version = Version("1.1")
         with pytest.raises(ValueError) as e:
             version.bump_patch()
-        assert 'Level is bigger than release components.' in str(e.value)
+        assert "Level is bigger than release components." in str(e.value)
 
     @pytest.mark.parametrize(
         ("version", "local"),

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -424,7 +424,7 @@ class TestVersion:
         version = Version('1.1')
         with pytest.raises(ValueError) as e:
             version.bump_patch()
-            assert 'Level is bigger than release components.' in e
+        assert 'Level is bigger than release components.' in str(e)
 
     @pytest.mark.parametrize(
         ("version", "local"),


### PR DESCRIPTION
These functions return a new Version instance with the appropriate
.release-part increased by one or raises a ValueError if that part does
not exist.

Closes: #114