### PR TITLE
travis: update supported Python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,28 @@
 language: python
 cache: pip
+python: 3.6
+env: TOXENV=py
 
 matrix:
   include:
     - python: 2.7
-      env: TOXENV=py27
-    - python: 3.4
-      env: TOXENV=py34
-    - python: 3.5
-      env: TOXENV=py35
-    - python: 3.6
-      env: TOXENV=py36
-    - python: nightly
-      env: TOXENV=py37
     - python: pypy
-      env: TOXENV=pypy
-    - env: TOXENV=pep8
-    - env: TOXENV=py2pep8
+    - python: pypy3
+    - python: 3.4
+    - python: 3.5
     - python: 3.6
-      env: TOXENV=docs
+    - python: 3.7
+      dist: xenial
+    - python: 3.8-dev
+      dist: xenial
+    - env: TOXENV=pep8
+    - python: 2.7
+      env: TOXENV=py2pep8
+    - env: TOXENV=docs
     - env: TOXENV=packaging
 
   allow_failures:
-    - python: nightly
+    - python: 3.8-dev
 
 install:
   - pip install tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,pypy,py34,py35,py36,py37,docs,pep8,py2pep8
+envlist = py27,pypy,pypy3,py34,py35,py36,py37,docs,pep8,py2pep8
 
 [testenv]
 deps =
@@ -20,7 +20,7 @@ commands =
     py.test --capture=no --strict {posargs}
 
 [testenv:docs]
-basepython = python3.6
+basepython = python3
 deps =
     sphinx
     sphinx_rtd_theme
@@ -30,14 +30,14 @@ commands =
     sphinx-build -W -b doctest -d {envtmpdir}/doctrees docs docs/_build/html
 
 [testenv:pep8]
-basepython = python3.4
+basepython = python3
 deps =
     flake8
     pep8-naming
 commands = flake8 .
 
 [testenv:py2pep8]
-basepython = python2.7
+basepython = python2
 deps =
     flake8
     pep8-naming


### PR DESCRIPTION
- use Python 3.7.0 instead of 3.7.0a4+, don't allow failures
- add job for Python 3.8 (3.8.0a0, failures allowed)
- add job for PyPy 3 (5.8.0-beta0)

Note: the coverage data reported on Python 3.8 is currently wrong, so the job is failing.