### PR TITLE
Removing the --ignore-installed option because pip > 10.0

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ deps =
     coverage
     pretend
     pytest
-    https://github.com/pypa/pip/archive/master.zip#egg=pip
+    pip
 
 install_command =
     pip install {opts} {packages}

--- a/tox.ini
+++ b/tox.ini
@@ -6,8 +6,7 @@ deps =
     coverage
     pretend
     pytest
-    pip
-
+    pip>=9.0.2
 install_command =
     pip install {opts} {packages}
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -7,8 +7,6 @@ deps =
     pretend
     pytest
     pip>=9.0.2
-install_command =
-    pip install {opts} {packages}
 commands =
     python -m coverage run --source packaging/ -m pytest --strict {posargs}
     python -m coverage report -m --fail-under 100

--- a/tox.ini
+++ b/tox.ini
@@ -7,10 +7,9 @@ deps =
     pretend
     pytest
     https://github.com/pypa/pip/archive/master.zip#egg=pip
-# The --ignore-installed install options is needed to install pip url
-# (needed to issue #95). This can be removed once pip 10.0 is out.
+
 install_command =
-    pip install {opts} {packages} --ignore-installed
+    pip install {opts} {packages}
 commands =
     python -m coverage run --source packaging/ -m pytest --strict {posargs}
     python -m coverage report -m --fail-under 100


### PR DESCRIPTION
```
#The --ignore-installed install options is needed to install pip url
# (needed to issue #95). This can be removed once pip 10.0 is out.
```