### PR TITLE
Support controlling development releases with semver

### DIFF
--- a/packaging/version.py
+++ b/packaging/version.py
@@ -203,7 +203,7 @@ VERSION_PATTERN = r"""
             )
         )?
         (?P<dev>                                          # dev release
-            [-_\.]?
+            [-_\.+]?
             (?P<dev_l>dev)
             [-_\.]?
             (?P<dev_n>[0-9]+)?

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -504,9 +504,9 @@ class TestVersion:
             ("1.0c1.post1", True),
             ("1.0rc1.post1", True),
             ("1.0", False),
-            ("1.0+dev", False),
+            ("1.0+dev", True),
             ("1.0.post1", False),
-            ("1.0.post1+dev", False),
+            ("1.0.post1+dev", True),
         ],
     )
     def test_version_is_prerelease(self, version, expected):


### PR DESCRIPTION
https://semver.org/#spec-item-10

It would be incredibly useful to allow the parsing/bumping of dev versions https://www.python.org/dev/peps/pep-0440/#developmental-releases via traditional semver methods and have pip recognize it.

For example, pip being able to understand this workflow:

```python
>>> import semver
>>>
>>> semver.bump_minor('6.7.0')
'6.8.0'
>>> semver.bump_prerelease('6.8.0')
'6.8.0-rc.1'
>>> semver.bump_build('6.8.0-rc.1', token='dev')
'6.8.0-rc.1+dev.1'
>>> semver.bump_build('6.8.0-rc.1+dev.1', token='dev')
'6.8.0-rc.1+dev.2'
```

A use case for us would be in https://github.com/DataDog/integrations-core and would allow for just using semver without any custom logic.

We occasionally need to have one release candidate where we rapidly iterate with customers. To do this, each new wheel will first go through our secure wheel distribution pipeline before becoming available on our index server and subsequently to the Agent running on their machines. As this will happen often in short succession, we don't want to assign each new test/preview its own prerelease as those have meaning to us.

Seeing as how the [current regex](https://github.com/pypa/packaging/blob/b7af5da73229b49f5fd340fea1b5f80b34414cfa/packaging/version.py#L182-L213) allows for more specifiers than [the original](https://www.python.org/dev/peps/pep-0440/#public-version-identifiers), I think allowing `+` before `dev` in addition to the current `-_.` would be acceptable.

cc @dstufft @benoit-pierre @pradyunsg WDYT?