### PR TITLE
Update contributing guide to work on first go

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 .cache/
 .coverage
 .idea
+.venv
 
 __pycache__/
 _build/

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,6 @@
 # Install our development requirements
+pretend
+pytest
 tox
 
 # Install packaging itself

--- a/docs/development/getting-started.rst
+++ b/docs/development/getting-started.rst
@@ -9,8 +9,8 @@ dependencies, install packaging in ``editable`` mode. For example:
 .. code-block:: console
 
     $ # Create a virtualenv and activate it
-    $ pip install --requirement dev-requirements.txt
-    $ pip install --editable .
+    $ python -m pip install --requirement dev-requirements.txt
+    $ python -m pip install --editable .
 
 You are now ready to run the tests and build the documentation.
 
@@ -23,7 +23,7 @@ automatically, so all you have to do is:
 
 .. code-block:: console
 
-    $ py.test
+    $ python -m pytest
     ...
     62746 passed in 220.43 seconds
 


### PR DESCRIPTION
The "Getting Started" docs say to use `py.test`, but there's a couple of issues with that.

1. The command doesn't work because `pytest` and other dependencies are not listed in `dev-requirements.txt`
2. It's not named `py.test`
3. Specifying which interpreter you are using via `-m` is usually a good thing 