### PR TITLE
Remove distutils fallback and outdated comment

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,18 +6,7 @@ from __future__ import absolute_import, division, print_function
 
 import os
 import re
-
-# While I generally consider it an antipattern to try and support both
-# setuptools and distutils with a single setup.py, in this specific instance
-# where packaging is a dependency of setuptools, it can create a circular
-# dependency when projects attempt to unbundle stuff from setuptools and pip.
-# Though we don't really support that, it makes things easier if we do this and
-# should hopefully cause less issues for end users.
-try:
-    from setuptools import setup
-except ImportError:
-    from distutils.core import setup
-
+from setuptools import setup
 
 base_dir = os.path.dirname(__file__)
 


### PR DESCRIPTION
setuptools includes a vendored version of packaging (and other
dependencies). They are not install through traditional tools.
Therefore, distutils is not required as fallback to facilitate
setuptools.

https://github.com/pypa/setuptools/tree/v40.6.3/setuptools/_vendor/packaging