### PR TITLE
Update python_version definition

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,8 @@ Changelog
 
 .. note:: This version is not yet released and is under active development.
 
-* Add the `packaging.tags` module.
+* Add the ``packaging.tags`` module. (:issue:`156`)
+* Correctly handle two-digit versions in ``python_version`` (:issue:`119`)
 
 
 19.0 - 2019-01-20

--- a/packaging/markers.py
+++ b/packaging/markers.py
@@ -259,7 +259,7 @@ def default_environment():
         "platform_version": platform.version(),
         "python_full_version": platform.python_version(),
         "platform_python_implementation": platform.python_implementation(),
-        "python_version": platform.python_version()[:3],
+        "python_version": ".".join(platform.python_version_tuple()[:2]),
         "sys_platform": sys.platform,
     }
 

--- a/tests/test_markers.py
+++ b/tests/test_markers.py
@@ -112,7 +112,7 @@ class TestDefaultEnvironment:
             "platform_version": platform.version(),
             "python_full_version": platform.python_version(),
             "platform_python_implementation": platform.python_implementation(),
-            "python_version": platform.python_version()[:3],
+            "python_version": ".".join(platform.python_version_tuple()[:2]),
             "sys_platform": sys.platform,
         }
 
@@ -134,7 +134,7 @@ class TestDefaultEnvironment:
             "platform_version": platform.version(),
             "python_full_version": platform.python_version(),
             "platform_python_implementation": platform.python_implementation(),
-            "python_version": platform.python_version()[:3],
+            "python_version": ".".join(platform.python_version_tuple()[:2]),
             "sys_platform": sys.platform,
         }
 
@@ -162,7 +162,7 @@ class TestDefaultEnvironment:
             "platform_version": platform.version(),
             "python_full_version": platform.python_version(),
             "platform_python_implementation": platform.python_implementation(),
-            "python_version": platform.python_version()[:3],
+            "python_version": ".".join(platform.python_version_tuple()[:2]),
             "sys_platform": sys.platform,
         }
 
@@ -188,9 +188,21 @@ class TestDefaultEnvironment:
             "platform_version": platform.version(),
             "python_full_version": platform.python_version(),
             "platform_python_implementation": platform.python_implementation(),
-            "python_version": platform.python_version()[:3],
+            "python_version": ".".join(platform.python_version_tuple()[:2]),
             "sys_platform": sys.platform,
         }
+
+    def test_multidigit_minor_version(self, monkeypatch):
+        version_info = (3, 10, 0, "final", 0)
+        monkeypatch.setattr(sys, "version_info", version_info, raising=False)
+
+        monkeypatch.setattr(platform, "python_version", lambda: "3.10.0", raising=False)
+        monkeypatch.setattr(
+            platform, "python_version_tuple", lambda: ("3", "10", "0"), raising=False
+        )
+
+        environment = default_environment()
+        assert environment["python_version"] == "3.10"
 
     def tests_when_releaselevel_final(self):
         v = FakeVersionInfo(3, 4, 2, "final", 0)


### PR DESCRIPTION
This definition of python_version accommodates Python versions with more than two digits in the major or minor version. This implements an accompanying change in PEP 508.

See GH issue #119 and https://github.com/python/peps/pull/1123 .

Fixes #119.