### PR TITLE
Drop dependency on attrs

### DIFF
--- a/packaging/tags.py
+++ b/packaging/tags.py
@@ -11,8 +11,6 @@ import sys
 import sysconfig
 import warnings
 
-import attr
-
 
 INTERPRETER_SHORT_NAMES = {
     "python": "py",  # Generic.
@@ -26,14 +24,39 @@ INTERPRETER_SHORT_NAMES = {
 _32_BIT_INTERPRETER = sys.maxsize <= 2 ** 32
 
 
-@attr.s(frozen=True, repr=False)
 class Tag(object):
-    interpreter = attr.ib(converter=str.lower)
-    abi = attr.ib(converter=str.lower)
-    platform = attr.ib(converter=str.lower)
+
+    __slots__ = ["_interpreter", "_abi", "_platform"]
+
+    def __init__(self, interpreter, abi, platform):
+        self._interpreter = str.lower(interpreter)
+        self._abi = str.lower(abi)
+        self._platform = str.lower(platform)
+
+    @property
+    def interpreter(self):
+        return self._interpreter
+
+    @property
+    def abi(self):
+        return self._abi
+
+    @property
+    def platform(self):
+        return self._platform
+
+    def __eq__(self, other):
+        return (
+            (self.platform == other.platform)
+            and (self.abi == other.abi)
+            and (self.interpreter == other.interpreter)
+        )
+
+    def __hash__(self):
+        return hash((self._interpreter, self._abi, self._platform))
 
     def __str__(self):
-        return "{}-{}-{}".format(self.interpreter, self.abi, self.platform)
+        return "{}-{}-{}".format(self._interpreter, self._abi, self._platform)
 
     def __repr__(self):
         return "<{self} @ {self_id}>".format(self=self, self_id=id(self))

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     author=about["__author__"],
     author_email=about["__email__"],
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
-    install_requires=["attrs", "pyparsing>=2.0.2", "six"],  # Needed to avoid issue #91
+    install_requires=["pyparsing>=2.0.2", "six"],  # Needed to avoid issue #91
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -43,6 +43,12 @@ def test_tag_hashing(example_tag):
     assert example_tag in tags
 
 
+def test_tag_hash_equality(example_tag):
+    equal_tag = tags.Tag("py3", "none", "any")
+    assert example_tag == equal_tag
+    assert example_tag.__hash__() == equal_tag.__hash__()
+
+
 def test_tag_str(example_tag):
     assert str(example_tag) == "py3-none-any"
 


### PR DESCRIPTION
- replace `tags.Tag` with a custom implementation instead of using `@attr.s`
- add a sanity check for `__hash__()`
- drop attrs from `setup.py`

This fixes #178