### PR TITLE
Fix comments on marker variable declarations

### DIFF
--- a/packaging/markers.py
+++ b/packaging/markers.py
@@ -91,7 +91,7 @@ VARIABLE = (
     | L("platform.machine")  # PEP-345
     | L("platform.python_implementation")  # PEP-345
     | L("python_implementation")  # undocumented setuptools legacy
-    | L("extra")
+    | L("extra")  # PEP-508
 )
 ALIASES = {
     "os.name": "os_name",

--- a/packaging/markers.py
+++ b/packaging/markers.py
@@ -85,13 +85,13 @@ VARIABLE = (
     | L("python_version")
     | L("sys_platform")
     | L("os_name")
-    | L("os.name")
+    | L("os.name")  # PEP-345
     | L("sys.platform")  # PEP-345
     | L("platform.version")  # PEP-345
     | L("platform.machine")  # PEP-345
     | L("platform.python_implementation")  # PEP-345
-    | L("python_implementation")  # PEP-345
-    | L("extra")  # undocumented setuptools legacy
+    | L("python_implementation")  # undocumented setuptools legacy
+    | L("extra")
 )
 ALIASES = {
     "os.name": "os_name",


### PR DESCRIPTION
In #146 ([here](https://github.com/pypa/packaging/pull/146/files#diff-99b1c21fa480edb4456d111df29c50adR88-R94)) these were shifted down by 1 inadvertently. They are now aligned correctly and the "extra" variable has a reference.