### PR TITLE
Fix debug wheel support for Python 3.8

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,7 @@
 Changelog
 ---------
 
-20.0 - `master`_
+20.0 - master_
 ~~~~~~~~~~~~~~~~
 
 .. note:: This version is not yet released and is under active development.
@@ -11,6 +11,12 @@ Changelog
 * Use appropriate fallbacks for CPython ABI tag (:issue:`181`, :issue:`185`)
 
 * Add manylinux2014 support (:issue:`186`)
+
+* Improve ABI detection (:issue:`181`)
+
+* Properly handle debug wheels for Python 3.8 (:issue:`172`)
+
+* Improve detection of debug builds on Windows (:issue:`194`)
 
 19.1 - 2019-07-30
 ~~~~~~~~~~~~~~~~~

--- a/packaging/tags.py
+++ b/packaging/tags.py
@@ -8,7 +8,7 @@ import distutils.util
 
 try:
     from importlib.machinery import EXTENSION_SUFFIXES
-except ImportError:
+except ImportError:  # pragma: no cover
     import imp
 
     EXTENSION_SUFFIXES = [x[0] for x in imp.get_suffixes()]

--- a/packaging/tags.py
+++ b/packaging/tags.py
@@ -5,6 +5,14 @@
 from __future__ import absolute_import
 
 import distutils.util
+
+try:
+    from importlib.machinery import EXTENSION_SUFFIXES
+except ImportError:
+    import imp
+
+    EXTENSION_SUFFIXES = [x[0] for x in imp.get_suffixes()]
+    del imp
 import platform
 import re
 import sys
@@ -81,35 +89,44 @@ def _cpython_interpreter(py_version):
     return "cp{major}{minor}".format(major=py_version[0], minor=py_version[1])
 
 
-def _cpython_abi(py_version):
-    soabi = sysconfig.get_config_var("SOABI")
-    if soabi:
-        options = soabi.split("-", 2)[1]
-    else:
-        found_options = [str(py_version[0]), str(py_version[1])]
-        debug = sysconfig.get_config_var("Py_DEBUG")
-        if debug or (debug is None and hasattr(sys, "gettotalrefcount")):
-            found_options.append("d")
-        if py_version < (3, 8):
-            with_pymalloc = sysconfig.get_config_var("WITH_PYMALLOC")
-            if with_pymalloc or with_pymalloc is None:
-                found_options.append("m")
-        if py_version < (3, 3):
-            unicode_size = sysconfig.get_config_var("Py_UNICODE_SIZE")
-            if unicode_size == 4 or (
-                unicode_size is None and sys.maxunicode == 0x10FFFF
-            ):
-                found_options.append("u")
-        options = "".join(found_options)
-    return "cp{options}".format(options=options)
+def _cpython_abis(py_version):
+    abis = []
+    version = "{}{}".format(*py_version[:2])
+    debug = pymalloc = ucs4 = ""
+    with_debug = sysconfig.get_config_var("Py_DEBUG")
+    has_refcount = hasattr(sys, "gettotalrefcount")
+    # Windows doesn't set Py_DEBUG, so checking for support of debug-compiled
+    # extension modules is the best option.
+    has_ext = "_d.pyd" in EXTENSION_SUFFIXES
+    if with_debug or (with_debug is None and (has_refcount or has_ext)):
+        debug = "d"
+    if py_version < (3, 8):
+        with_pymalloc = sysconfig.get_config_var("WITH_PYMALLOC")
+        if with_pymalloc or with_pymalloc is None:
+            pymalloc = "m"
+    if py_version < (3, 3):
+        unicode_size = sysconfig.get_config_var("Py_UNICODE_SIZE")
+        if unicode_size == 4 or (unicode_size is None and sys.maxunicode == 0x10FFFF):
+            ucs4 = "u"
+    abis.append(
+        "cp{version}{debug}{pymalloc}{ucs4}".format(
+            version=version, debug=debug, pymalloc=pymalloc, ucs4=ucs4
+        )
+    )
+    if py_version >= (3, 8) and debug:
+        # Debug builds can also load "normal" extension modules.
+        # We can also assume no UCS-4 or pymalloc requirement.
+        abis.append("cp{version}".format(version=version))
+    return abis
 
 
-def _cpython_tags(py_version, interpreter, abi, platforms):
-    for tag in (Tag(interpreter, abi, platform) for platform in platforms):
+def _cpython_tags(py_version, interpreter, abis, platforms):
+    for abi in abis:
+        for platform_ in platforms:
+            yield Tag(interpreter, abi, platform_)
+    for tag in (Tag(interpreter, "abi3", platform_) for platform_ in platforms):
         yield tag
-    for tag in (Tag(interpreter, "abi3", platform) for platform in platforms):
-        yield tag
-    for tag in (Tag(interpreter, "none", platform) for platform in platforms):
+    for tag in (Tag(interpreter, "none", platform_) for platform_ in platforms):
         yield tag
     # PEP 384 was first implemented in Python 3.2.
     for minor_version in range(py_version[1] - 1, 1, -1):
@@ -366,8 +383,8 @@ def sys_tags():
 
     if interpreter_name == "cp":
         interpreter = _cpython_interpreter(py_version)
-        abi = _cpython_abi(py_version)
-        for tag in _cpython_tags(py_version, interpreter, abi, platforms):
+        abis = _cpython_abis(py_version)
+        for tag in _cpython_tags(py_version, interpreter, abis, platforms):
             yield tag
     elif interpreter_name == "pp":
         interpreter = _pypy_interpreter()

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -304,6 +304,17 @@ def test_cpython_tags():
         tags.Tag("cp32", "abi3", "plat1"),
         tags.Tag("cp32", "abi3", "plat2"),
     ]
+    result = list(tags._cpython_tags((3, 3), "cp33", ["cp33m"], ["plat1", "plat2"]))
+    assert result == [
+        tags.Tag("cp33", "cp33m", "plat1"),
+        tags.Tag("cp33", "cp33m", "plat2"),
+        tags.Tag("cp33", "abi3", "plat1"),
+        tags.Tag("cp33", "abi3", "plat2"),
+        tags.Tag("cp33", "none", "plat1"),
+        tags.Tag("cp33", "none", "plat2"),
+        tags.Tag("cp32", "abi3", "plat1"),
+        tags.Tag("cp32", "abi3", "plat2"),
+    ]
 
 
 def test_sys_tags_on_mac_cpython(monkeypatch):

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -198,11 +198,7 @@ def test_macos_arch_detection(arch, monkeypatch):
     [(1, False, True), (0, False, False), (None, True, True)],
 )
 def test_cpython_abis_debug(py_debug, gettotalrefcount, result, monkeypatch):
-    config = {
-        "Py_DEBUG": py_debug,
-        "WITH_PYMALLOC": 0,
-        "Py_UNICODE_SIZE": 2,
-    }
+    config = {"Py_DEBUG": py_debug, "WITH_PYMALLOC": 0, "Py_UNICODE_SIZE": 2}
     monkeypatch.setattr(sysconfig, "get_config_var", config.__getitem__)
     if gettotalrefcount:
         monkeypatch.setattr(sys, "gettotalrefcount", 1, raising=False)
@@ -219,8 +215,7 @@ def test_cpython_abis_debug_file_extension(monkeypatch):
 
 
 @pytest.mark.parametrize(
-    "debug,expected",
-    [(True, ["cp38d", "cp38"]), (False, ["cp38"])]
+    "debug,expected", [(True, ["cp38d", "cp38"]), (False, ["cp38"])]
 )
 def test_cpython_abis_debug_38(debug, expected, monkeypatch):
     config = {"Py_DEBUG": debug}
@@ -233,11 +228,7 @@ def test_cpython_abis_debug_38(debug, expected, monkeypatch):
     [(1, (3, 7), True), (0, (3, 7), False), (None, (3, 7), True), (1, (3, 8), False)],
 )
 def test_cpython_abis_pymalloc(pymalloc, version, result, monkeypatch):
-    config = {
-        "Py_DEBUG": 0,
-        "WITH_PYMALLOC": pymalloc,
-        "Py_UNICODE_SIZE": 2,
-    }
+    config = {"Py_DEBUG": 0, "WITH_PYMALLOC": pymalloc, "Py_UNICODE_SIZE": 2}
     monkeypatch.setattr(sysconfig, "get_config_var", config.__getitem__)
     base_abi = "cp{}{}".format(version[0], version[1])
     expected = [base_abi + "m" if result else base_abi]
@@ -257,11 +248,7 @@ def test_cpython_abis_pymalloc(pymalloc, version, result, monkeypatch):
 def test_cpython_abis_wide_unicode(
     unicode_size, maxunicode, version, result, monkeypatch
 ):
-    config = {
-        "Py_DEBUG": 0,
-        "WITH_PYMALLOC": 0,
-        "Py_UNICODE_SIZE": unicode_size,
-    }
+    config = {"Py_DEBUG": 0, "WITH_PYMALLOC": 0, "Py_UNICODE_SIZE": unicode_size}
     monkeypatch.setattr(sysconfig, "get_config_var", config.__getitem__)
     monkeypatch.setattr(sys, "maxunicode", maxunicode)
     base_abi = "cp{}{}".format(version[0], version[1])
@@ -292,7 +279,9 @@ def test_independent_tags():
 
 
 def test_cpython_tags():
-    result = list(tags._cpython_tags((3, 8), "cp38", ["cp38d", "cp38"], ["plat1", "plat2"]))
+    result = list(
+        tags._cpython_tags((3, 8), "cp38", ["cp38d", "cp38"], ["plat1", "plat2"])
+    )
     assert result == [
         tags.Tag("cp38", "cp38d", "plat1"),
         tags.Tag("cp38", "cp38d", "plat2"),


### PR DESCRIPTION
Python 3.8 debug builds can load both debug and non-debug wheels, so support both.

Also made debug build detection on Windows more robust.

Closes #172 and #194 