### PR TITLE
Appease mypy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 .idea
 .venv*
 
+.mypy_cache/
 .pytest_cache/
 __pycache__/
 _build/

--- a/packaging/markers.py
+++ b/packaging/markers.py
@@ -268,8 +268,8 @@ def format_full_version(info):
 def default_environment():
     # type: () -> Dict[str, str]
     if hasattr(sys, "implementation"):
-        iver = format_full_version(sys.implementation.version)
-        implementation_name = sys.implementation.name
+        iver = format_full_version(sys.implementation.version)  # type: ignore
+        implementation_name = sys.implementation.name  # type: ignore
     else:
         iver = "0"
         implementation_name = ""

--- a/packaging/markers.py
+++ b/packaging/markers.py
@@ -268,6 +268,9 @@ def format_full_version(info):
 def default_environment():
     # type: () -> Dict[str, str]
     if hasattr(sys, "implementation"):
+        # Ignoring the `sys.implementation` reference for type checking due to
+        # mypy not liking that the attribute doesn't exist in Python 2.7 when
+        # run with the `--py27` flag.
         iver = format_full_version(sys.implementation.version)  # type: ignore
         implementation_name = sys.implementation.name  # type: ignore
     else:

--- a/packaging/tags.py
+++ b/packaging/tags.py
@@ -168,6 +168,8 @@ def _cpython_tags(py_version, interpreter, abis, platforms):
 
 def _pypy_interpreter():
     # type: () -> str
+    # Ignoring sys.pypy_version_info for type checking due to typeshed lacking
+    # the reference to the attribute.
     return "pp{py_major}{pypy_major}{pypy_minor}".format(
         py_major=sys.version_info[0],
         pypy_major=sys.pypy_version_info.major,  # type: ignore

--- a/packaging/tags.py
+++ b/packaging/tags.py
@@ -170,8 +170,8 @@ def _pypy_interpreter():
     # type: () -> str
     return "pp{py_major}{pypy_major}{pypy_minor}".format(
         py_major=sys.version_info[0],
-        pypy_major=sys.pypy_version_info.major,
-        pypy_minor=sys.pypy_version_info.minor,
+        pypy_major=sys.pypy_version_info.major,  # type: ignore
+        pypy_minor=sys.pypy_version_info.minor,  # type: ignore
     )
 
 


### PR DESCRIPTION
Mypy doesn't like `sys` attributes that don't exist universally or in the specific version being type checked for.

Closes #210 