### PR TITLE
More compatibility with pep425tags

### DIFF
--- a/docs/tags.rst
+++ b/docs/tags.rst
@@ -73,7 +73,7 @@ Reference
     :param str tag: The tag to parse, e.g. ``"py3-none-any"``.
 
 
-.. function:: sys_tags()
+.. function:: sys_tags(warn=False)
 
     Create an iterable of tags that the running interpreter supports.
 
@@ -93,6 +93,8 @@ Reference
     The function returns an iterable in order to allow for the possible
     short-circuiting of tag generation if the entire sequence is not necessary
     and calculating some tags happens to be expensive.
+
+    :param bool warn: Whether warnings should be logged. Defaults to ``False``.
 
 
 .. _abbreviation codes: https://www.python.org/dev/peps/pep-0425/#python-tag

--- a/packaging/tags.py
+++ b/packaging/tags.py
@@ -105,7 +105,7 @@ def parse_tag(tag):
     return frozenset(tags)
 
 
-def _get_config_var(name, warn=True):
+def _get_config_var(name, warn=False):
     # type: (str, Optional[bool]) -> Union[int, str, None]
     value = sysconfig.get_config_var(name)
     if value is None and warn:

--- a/packaging/tags.py
+++ b/packaging/tags.py
@@ -347,7 +347,7 @@ def _glibc_version_string_confstr():
     # platform module:
     # https://github.com/python/cpython/blob/fcf1d003bf4f0100c9d0921ff3d70e1127ca1b71/Lib/platform.py#L175-L183
     try:
-        # os.confstr("CS_GNU_LIBC_VERSION") returns a string like "glibc 2.17":
+        # os.confstr("CS_GNU_LIBC_VERSION") returns a string like "glibc 2.17".
         version_string = os.confstr("CS_GNU_LIBC_VERSION")
         assert version_string is not None
         _, version = version_string.split()

--- a/packaging/tags.py
+++ b/packaging/tags.py
@@ -360,7 +360,6 @@ def _glibc_version_string_confstr():
 def _glibc_version_string_ctypes():
     # type: () -> Optional[str]
     "Fallback implementation of glibc_version_string using ctypes."
-
     try:
         import ctypes
     except ImportError:

--- a/packaging/tags.py
+++ b/packaging/tags.py
@@ -344,7 +344,7 @@ def _glibc_version_string_confstr():
     "Primary implementation of glibc_version_string using os.confstr."
     # os.confstr is quite a bit faster than ctypes.DLL. It's also less likely
     # to be broken or missing. This strategy is used in the standard library
-    # platform module:
+    # platform module.
     # https://github.com/python/cpython/blob/fcf1d003bf4f0100c9d0921ff3d70e1127ca1b71/Lib/platform.py#L175-L183
     try:
         # os.confstr("CS_GNU_LIBC_VERSION") returns a string like "glibc 2.17".

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -525,6 +525,7 @@ def test_glibc_version_string(version_str, expected, monkeypatch):
 
     process_namespace = ProcessNamespace(LibcVersion(version_str))
     monkeypatch.setattr(ctypes, "CDLL", lambda _: process_namespace)
+    monkeypatch.setattr(tags, "_glibc_version_string_confstr", lambda: False)
 
     assert tags._glibc_version_string() == expected
 

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -556,6 +556,24 @@ def test_glibc_version_string_ctypes_missing(monkeypatch):
     assert tags._glibc_version_string_ctypes() is None
 
 
+def test_get_config_var_does_not_log(monkeypatch):
+    debug = pretend.call_recorder(lambda *a: None)
+    monkeypatch.setattr(tags.logger, "debug", debug)
+    tags._get_config_var("missing")
+    assert debug.calls == []
+
+
+def test_get_config_var_does_log(monkeypatch):
+    debug = pretend.call_recorder(lambda *a: None)
+    monkeypatch.setattr(tags.logger, "debug", debug)
+    tags._get_config_var("missing", warn=True)
+    assert debug.calls == [
+        pretend.call(
+            "Config variable '%s' is unset, Python ABI tag may be incorrect", "missing"
+        )
+    ]
+
+
 def test_have_compatible_glibc(monkeypatch):
     if platform.system() == "Linux":
         # Assuming no one is running this test with a version of glibc released in

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -326,7 +326,7 @@ def test_cpython_tags():
 def test_sys_tags_on_mac_cpython(monkeypatch):
     if platform.python_implementation() != "CPython":
         monkeypatch.setattr(platform, "python_implementation", lambda: "CPython")
-        monkeypatch.setattr(tags, "_cpython_abis", lambda py_version: ["cp33m"])
+        monkeypatch.setattr(tags, "_cpython_abis", lambda *a: ["cp33m"])
     if platform.system() != "Darwin":
         monkeypatch.setattr(platform, "system", lambda: "Darwin")
         monkeypatch.setattr(tags, "_mac_platforms", lambda: ["macosx_10_5_x86_64"])
@@ -439,7 +439,7 @@ def test_generic_tags():
 def test_sys_tags_on_windows_cpython(monkeypatch):
     if platform.python_implementation() != "CPython":
         monkeypatch.setattr(platform, "python_implementation", lambda: "CPython")
-        monkeypatch.setattr(tags, "_cpython_abis", lambda py_version: ["cp33m"])
+        monkeypatch.setattr(tags, "_cpython_abis", lambda *a: ["cp33m"])
     if platform.system() != "Windows":
         monkeypatch.setattr(platform, "system", lambda: "Windows")
         monkeypatch.setattr(tags, "_generic_platforms", lambda: ["win_amd64"])
@@ -652,7 +652,7 @@ def test_linux_platforms_manylinux2014(monkeypatch):
 def test_sys_tags_linux_cpython(monkeypatch):
     if platform.python_implementation() != "CPython":
         monkeypatch.setattr(platform, "python_implementation", lambda: "CPython")
-        monkeypatch.setattr(tags, "_cpython_abis", lambda py_version: ["cp33m"])
+        monkeypatch.setattr(tags, "_cpython_abis", lambda *a: ["cp33m"])
     if platform.system() != "Linux":
         monkeypatch.setattr(platform, "system", lambda: "Linux")
         monkeypatch.setattr(tags, "_linux_platforms", lambda: ["linux_x86_64"])


### PR DESCRIPTION
This PR adds logging around `get_config_var` as mentioned here: https://github.com/pypa/pip/issues/6908#issuecomment-524536011

It also fixes #171.

(cc @pradyunsg @cjerdonek)