### PR TITLE
Make 'linux' tags take precedence over manylinux ones

### DIFF
--- a/packaging/tags.py
+++ b/packaging/tags.py
@@ -430,16 +430,14 @@ def _linux_platforms(is_32bit=_32_BIT_INTERPRETER):
         ("manylinux2010", (2, 12)),  # CentOS 6 w/ glibc 2.12 (PEP 571)
         ("manylinux1", (2, 5)),  # CentOS 5 w/ glibc 2.5 (PEP 513)
     )
+    platforms = [linux]
     manylinux_support_iter = iter(manylinux_support)
     for name, glibc_version in manylinux_support_iter:
         if _is_manylinux_compatible(name, glibc_version):
-            platforms = [linux.replace("linux", name)]
+            platforms += [linux.replace("linux", name)]
             break
-    else:
-        platforms = []
     # Support for a later manylinux implies support for an earlier version.
     platforms += [linux.replace("linux", name) for name, _ in manylinux_support_iter]
-    platforms.append(linux)
     return platforms
 
 

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -599,7 +599,7 @@ def test_linux_platforms_64bit_on_64bit_os(is_64bit_os, is_x86, monkeypatch):
     if platform.system() != "Linux" or not is_64bit_os or not is_x86:
         monkeypatch.setattr(distutils.util, "get_platform", lambda: "linux_x86_64")
         monkeypatch.setattr(tags, "_is_manylinux_compatible", lambda *args: False)
-    linux_platform = tags._linux_platforms(is_32bit=False)[-1]
+    linux_platform = tags._linux_platforms(is_32bit=False)[0]
     assert linux_platform == "linux_x86_64"
 
 
@@ -607,7 +607,7 @@ def test_linux_platforms_32bit_on_64bit_os(is_64bit_os, is_x86, monkeypatch):
     if platform.system() != "Linux" or not is_64bit_os or not is_x86:
         monkeypatch.setattr(distutils.util, "get_platform", lambda: "linux_x86_64")
         monkeypatch.setattr(tags, "_is_manylinux_compatible", lambda *args: False)
-    linux_platform = tags._linux_platforms(is_32bit=True)[-1]
+    linux_platform = tags._linux_platforms(is_32bit=True)[0]
     assert linux_platform == "linux_i686"
 
 

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -625,7 +625,7 @@ def test_linux_platforms_manylinux1(monkeypatch):
     if platform.system() != "Linux":
         monkeypatch.setattr(distutils.util, "get_platform", lambda: "linux_x86_64")
     platforms = tags._linux_platforms(is_32bit=False)
-    assert platforms == ["manylinux1_x86_64", "linux_x86_64"]
+    assert platforms == ["linux_x86_64", "manylinux1_x86_64"]
 
 
 def test_linux_platforms_manylinux2010(monkeypatch):
@@ -635,7 +635,7 @@ def test_linux_platforms_manylinux2010(monkeypatch):
     if platform.system() != "Linux":
         monkeypatch.setattr(distutils.util, "get_platform", lambda: "linux_x86_64")
     platforms = tags._linux_platforms(is_32bit=False)
-    expected = ["manylinux2010_x86_64", "manylinux1_x86_64", "linux_x86_64"]
+    expected = ["linux_x86_64", "manylinux2010_x86_64", "manylinux1_x86_64"]
     assert platforms == expected
 
 
@@ -647,10 +647,10 @@ def test_linux_platforms_manylinux2014(monkeypatch):
         monkeypatch.setattr(distutils.util, "get_platform", lambda: "linux_x86_64")
     platforms = tags._linux_platforms(is_32bit=False)
     expected = [
+        "linux_x86_64",
         "manylinux2014_x86_64",
         "manylinux2010_x86_64",
         "manylinux1_x86_64",
-        "linux_x86_64",
     ]
     assert platforms == expected
 


### PR DESCRIPTION
Allows for one to compile a wheel locally to override potentially issues with the manylinux equivalent.

Closes #160