### PR TITLE
Package type information

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,4 +67,5 @@ setup(
         "Programming Language :: Python :: Implementation :: PyPy",
     ],
     packages=["packaging"],
+    package_data={"packaging": ["py.typed"]},
 )


### PR DESCRIPTION
As per PEP-561, ship `py.typed' with packaging to allow type checking.