### PR TITLE
Allow custom formatting of Version objects

### DIFF
--- a/packaging/version.py
+++ b/packaging/version.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, division, print_function
 import collections
 import itertools
 import re
+import string
 
 from ._structures import Infinity, NegativeInfinity
 from ._typing import MYPY_CHECK_RUNNING
@@ -415,6 +416,31 @@ class Version(_BaseVersion):
     def micro(self):
         # type: () -> int
         return self.release[2] if len(self.release) >= 3 else 0
+
+    def format(self, format_string):
+        # type: (str) -> str
+        format_parser = string.Formatter()
+        for (_, field_name, _, _) in format_parser.parse(format_string):
+            if field_name not in _FORMAT_KEYS:
+                raise ValueError('"{}" is not a valid format key'.format(field_name))
+        return format_string.format(**{k: getattr(self, k) for k in _FORMAT_KEYS})
+
+
+_FORMAT_KEYS = set(
+    [
+        "epoch",
+        "release",
+        "pre",
+        "post",
+        "dev",
+        "local",
+        "public",
+        "base_version",
+        "major",
+        "minor",
+        "micro",
+    ]
+)
 
 
 def _parse_letter_version(

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -770,6 +770,15 @@ class TestVersion:
         assert Version("2.1").micro == 0
         assert Version("2").micro == 0
 
+    def test_version_rejects_invalid_format_strings(self):
+        with pytest.raises(ValueError):
+            Version("2.1.1").format("{major}.{minor}.{foobar}")
+
+    def test_custom_version_formatting(self):
+        assert (
+            Version("2.1.3").format("custom-{major}.{minor}.{micro}") == "custom-2.1.3"
+        )
+
 
 LEGACY_VERSIONS = ["foobar", "a cat is fine too", "lolwut", "1-0", "2.0-a1"]
 


### PR DESCRIPTION
In #82 there was a desire for a distribution specific attribute being
added to Version. Instead, the idea of allowing a custom format string
seemed generally acceptable and preferred, so let's implement that since
this has been hanging out for 3 years.

Closes #82