### PR TITLE
tags: Separate versions with multidigit components with '_'

### DIFF
--- a/packaging/tags.py
+++ b/packaging/tags.py
@@ -162,7 +162,7 @@ def _cpython_abis(py_version, warn=False):
     # type: (PythonVersion, bool) -> List[str]
     py_version = tuple(py_version)  # To allow for version comparison.
     abis = []
-    version = "{}{}".format(*py_version[:2])
+    version = _version_nodot(py_version[:2])
     debug = pymalloc = ucs4 = ""
     with_debug = _get_config_var("Py_DEBUG", warn)
     has_refcount = hasattr(sys, "gettotalrefcount")
@@ -221,10 +221,7 @@ def cpython_tags(
     if not python_version:
         python_version = sys.version_info[:2]
 
-    if len(python_version) < 2:
-        interpreter = "cp{}".format(python_version[0])
-    else:
-        interpreter = "cp{}{}".format(*python_version[:2])
+    interpreter = "cp{}".format(_version_nodot(python_version[:2]))
 
     if abis is None:
         if len(python_version) > 1:
@@ -252,8 +249,8 @@ def cpython_tags(
     if _abi3_applies(python_version):
         for minor_version in range(python_version[1] - 1, 1, -1):
             for platform_ in platforms:
-                interpreter = "cp{major}{minor}".format(
-                    major=python_version[0], minor=minor_version
+                interpreter = "cp{version}".format(
+                    version=_version_nodot((python_version[0], minor_version))
                 )
                 yield Tag(interpreter, "abi3", platform_)
 
@@ -305,11 +302,11 @@ def _py_interpreter_range(py_version):
     all previous versions of that major version.
     """
     if len(py_version) > 1:
-        yield "py{major}{minor}".format(major=py_version[0], minor=py_version[1])
+        yield "py{version}".format(version=_version_nodot(py_version[:2]))
     yield "py{major}".format(major=py_version[0])
     if len(py_version) > 1:
         for minor in range(py_version[1] - 1, -1, -1):
-            yield "py{major}{minor}".format(major=py_version[0], minor=minor)
+            yield "py{version}".format(version=_version_nodot((py_version[0], minor)))
 
 
 def compatible_tags(
@@ -704,8 +701,17 @@ def interpreter_version(**kwargs):
     if version:
         version = str(version)
     else:
-        version = "".join(map(str, sys.version_info[:2]))
+        version = _version_nodot(sys.version_info[:2])
     return version
+
+
+def _version_nodot(version):
+    # type: (PythonVersion) -> str
+    if any(v >= 10 for v in version):
+        sep = "_"
+    else:
+        sep = ""
+    return sep.join(map(str, version))
 
 
 def sys_tags(**kwargs):

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -196,10 +196,20 @@ class TestInterpreterVersion:
         monkeypatch.setattr(tags, "_get_config_var", lambda var, warn: "NN")
         assert tags.interpreter_version() == "NN"
 
-    def test_sys_version_info(self, monkeypatch):
+    @pytest.mark.parametrize(
+        "version_info,version_str",
+        [
+            ((1, 2, 3), "12"),
+            ((1, 12, 3), "1_12"),
+            ((11, 2, 3), "11_2"),
+            ((11, 12, 3), "11_12"),
+            ((1, 2, 13), "12"),
+        ],
+    )
+    def test_sys_version_info(self, version_info, version_str, monkeypatch):
         monkeypatch.setattr(tags, "_get_config_var", lambda *args, **kwargs: None)
-        monkeypatch.setattr(sys, "version_info", ("L", "M", "N"))
-        assert tags.interpreter_version() == "LM"
+        monkeypatch.setattr(sys, "version_info", version_info)
+        assert tags.interpreter_version() == version_str
 
 
 class TestMacOSPlatforms:
@@ -687,7 +697,11 @@ class TestCPythonABI:
         config = {"Py_DEBUG": 0, "WITH_PYMALLOC": 0, "Py_UNICODE_SIZE": unicode_size}
         monkeypatch.setattr(sysconfig, "get_config_var", config.__getitem__)
         monkeypatch.setattr(sys, "maxunicode", maxunicode)
-        base_abi = "cp{}{}".format(version[0], version[1])
+        if version[0] >= 10 or version[1] >= 10:
+            sep = "_"
+        else:
+            sep = ""
+        base_abi = "cp{}{}{}".format(version[0], sep, version[1])
         expected = [base_abi + "u" if result else base_abi]
         assert tags._cpython_abis(version) == expected
 
@@ -697,9 +711,41 @@ class TestCPythonTags:
         result_iterator = tags.cpython_tags(
             (3, 8), ["cp38d", "cp38"], ["plat1", "plat2"]
         )
-        isinstance(result_iterator, collections_abc.Iterator)
+        assert isinstance(result_iterator, collections_abc.Iterator)
 
     def test_all_args(self):
+        result_iterator = tags.cpython_tags(
+            (3, 11), ["cp3_11d", "cp3_11"], ["plat1", "plat2"]
+        )
+        result = list(result_iterator)
+        assert result == [
+            tags.Tag("cp3_11", "cp3_11d", "plat1"),
+            tags.Tag("cp3_11", "cp3_11d", "plat2"),
+            tags.Tag("cp3_11", "cp3_11", "plat1"),
+            tags.Tag("cp3_11", "cp3_11", "plat2"),
+            tags.Tag("cp3_11", "abi3", "plat1"),
+            tags.Tag("cp3_11", "abi3", "plat2"),
+            tags.Tag("cp3_11", "none", "plat1"),
+            tags.Tag("cp3_11", "none", "plat2"),
+            tags.Tag("cp3_10", "abi3", "plat1"),
+            tags.Tag("cp3_10", "abi3", "plat2"),
+            tags.Tag("cp39", "abi3", "plat1"),
+            tags.Tag("cp39", "abi3", "plat2"),
+            tags.Tag("cp38", "abi3", "plat1"),
+            tags.Tag("cp38", "abi3", "plat2"),
+            tags.Tag("cp37", "abi3", "plat1"),
+            tags.Tag("cp37", "abi3", "plat2"),
+            tags.Tag("cp36", "abi3", "plat1"),
+            tags.Tag("cp36", "abi3", "plat2"),
+            tags.Tag("cp35", "abi3", "plat1"),
+            tags.Tag("cp35", "abi3", "plat2"),
+            tags.Tag("cp34", "abi3", "plat1"),
+            tags.Tag("cp34", "abi3", "plat2"),
+            tags.Tag("cp33", "abi3", "plat1"),
+            tags.Tag("cp33", "abi3", "plat2"),
+            tags.Tag("cp32", "abi3", "plat1"),
+            tags.Tag("cp32", "abi3", "plat2"),
+        ]
         result_iterator = tags.cpython_tags(
             (3, 8), ["cp38d", "cp38"], ["plat1", "plat2"]
         )
@@ -726,6 +772,7 @@ class TestCPythonTags:
             tags.Tag("cp32", "abi3", "plat1"),
             tags.Tag("cp32", "abi3", "plat2"),
         ]
+
         result = list(tags.cpython_tags((3, 3), ["cp33m"], ["plat1", "plat2"]))
         assert result == [
             tags.Tag("cp33", "cp33m", "plat1"),
@@ -740,7 +787,11 @@ class TestCPythonTags:
 
     def test_python_version_defaults(self):
         tag = next(tags.cpython_tags(abis=["abi3"], platforms=["any"]))
-        interpreter = "cp{}{}".format(*sys.version_info[:2])
+        if sys.version_info[0] >= 10 or sys.version_info[1] >= 10:
+            sep = "_"
+        else:
+            sep = ""
+        interpreter = "cp{}{}{}".format(sys.version_info[0], sep, sys.version_info[1])
         assert interpreter == tag.interpreter
 
     def test_abi_defaults(self, monkeypatch):
@@ -750,10 +801,22 @@ class TestCPythonTags:
         assert tags.Tag("cp38", "abi3", "any") in result
         assert tags.Tag("cp38", "none", "any") in result
 
+    def test_abi_defaults_needs_underscore(self, monkeypatch):
+        monkeypatch.setattr(tags, "_cpython_abis", lambda _1, _2: ["cp3_11"])
+        result = list(tags.cpython_tags((3, 11), platforms=["any"]))
+        assert tags.Tag("cp3_11", "cp3_11", "any") in result
+        assert tags.Tag("cp3_11", "abi3", "any") in result
+        assert tags.Tag("cp3_11", "none", "any") in result
+
     def test_platforms_defaults(self, monkeypatch):
         monkeypatch.setattr(tags, "_platform_tags", lambda: ["plat1"])
         result = list(tags.cpython_tags((3, 8), abis=["whatever"]))
         assert tags.Tag("cp38", "whatever", "plat1") in result
+
+    def test_platforms_defaults_needs_underscore(self, monkeypatch):
+        monkeypatch.setattr(tags, "_platform_tags", lambda: ["plat1"])
+        result = list(tags.cpython_tags((3, 11), abis=["whatever"]))
+        assert tags.Tag("cp3_11", "whatever", "plat1") in result
 
     def test_major_only_python_version(self):
         result = list(tags.cpython_tags((3,), ["abi"], ["plat"]))
@@ -890,6 +953,51 @@ class TestCompatibleTags:
             tags.Tag("py30", "none", "any"),
         ]
 
+    def test_all_args_needs_underscore(self):
+        result = list(tags.compatible_tags((3, 11), "cp3_11", ["plat1", "plat2"]))
+        assert result == [
+            tags.Tag("py3_11", "none", "plat1"),
+            tags.Tag("py3_11", "none", "plat2"),
+            tags.Tag("py3", "none", "plat1"),
+            tags.Tag("py3", "none", "plat2"),
+            tags.Tag("py3_10", "none", "plat1"),
+            tags.Tag("py3_10", "none", "plat2"),
+            tags.Tag("py39", "none", "plat1"),
+            tags.Tag("py39", "none", "plat2"),
+            tags.Tag("py38", "none", "plat1"),
+            tags.Tag("py38", "none", "plat2"),
+            tags.Tag("py37", "none", "plat1"),
+            tags.Tag("py37", "none", "plat2"),
+            tags.Tag("py36", "none", "plat1"),
+            tags.Tag("py36", "none", "plat2"),
+            tags.Tag("py35", "none", "plat1"),
+            tags.Tag("py35", "none", "plat2"),
+            tags.Tag("py34", "none", "plat1"),
+            tags.Tag("py34", "none", "plat2"),
+            tags.Tag("py33", "none", "plat1"),
+            tags.Tag("py33", "none", "plat2"),
+            tags.Tag("py32", "none", "plat1"),
+            tags.Tag("py32", "none", "plat2"),
+            tags.Tag("py31", "none", "plat1"),
+            tags.Tag("py31", "none", "plat2"),
+            tags.Tag("py30", "none", "plat1"),
+            tags.Tag("py30", "none", "plat2"),
+            tags.Tag("cp3_11", "none", "any"),
+            tags.Tag("py3_11", "none", "any"),
+            tags.Tag("py3", "none", "any"),
+            tags.Tag("py3_10", "none", "any"),
+            tags.Tag("py39", "none", "any"),
+            tags.Tag("py38", "none", "any"),
+            tags.Tag("py37", "none", "any"),
+            tags.Tag("py36", "none", "any"),
+            tags.Tag("py35", "none", "any"),
+            tags.Tag("py34", "none", "any"),
+            tags.Tag("py33", "none", "any"),
+            tags.Tag("py32", "none", "any"),
+            tags.Tag("py31", "none", "any"),
+            tags.Tag("py30", "none", "any"),
+        ]
+
     def test_major_only_python_version(self):
         result = list(tags.compatible_tags((3,), "cp33", ["plat"]))
         assert result == [
@@ -908,6 +1016,39 @@ class TestCompatibleTags:
             tags.Tag("cp31", "none", "any"),
             tags.Tag("py31", "none", "any"),
             tags.Tag("py3", "none", "any"),
+            tags.Tag("py30", "none", "any"),
+        ]
+
+    def test_default_python_version_needs_underscore(self, monkeypatch):
+        monkeypatch.setattr(sys, "version_info", (3, 11))
+        result = list(tags.compatible_tags(interpreter="cp3_11", platforms=["plat"]))
+        assert result == [
+            tags.Tag("py3_11", "none", "plat"),
+            tags.Tag("py3", "none", "plat"),
+            tags.Tag("py3_10", "none", "plat"),
+            tags.Tag("py39", "none", "plat"),
+            tags.Tag("py38", "none", "plat"),
+            tags.Tag("py37", "none", "plat"),
+            tags.Tag("py36", "none", "plat"),
+            tags.Tag("py35", "none", "plat"),
+            tags.Tag("py34", "none", "plat"),
+            tags.Tag("py33", "none", "plat"),
+            tags.Tag("py32", "none", "plat"),
+            tags.Tag("py31", "none", "plat"),
+            tags.Tag("py30", "none", "plat"),
+            tags.Tag("cp3_11", "none", "any"),
+            tags.Tag("py3_11", "none", "any"),
+            tags.Tag("py3", "none", "any"),
+            tags.Tag("py3_10", "none", "any"),
+            tags.Tag("py39", "none", "any"),
+            tags.Tag("py38", "none", "any"),
+            tags.Tag("py37", "none", "any"),
+            tags.Tag("py36", "none", "any"),
+            tags.Tag("py35", "none", "any"),
+            tags.Tag("py34", "none", "any"),
+            tags.Tag("py33", "none", "any"),
+            tags.Tag("py32", "none", "any"),
+            tags.Tag("py31", "none", "any"),
             tags.Tag("py30", "none", "any"),
         ]
 
@@ -960,16 +1101,24 @@ class TestSysTags:
         abis = tags._cpython_abis(sys.version_info[:2])
         platforms = list(tags.mac_platforms())
         result = list(tags.sys_tags())
+        if sys.version_info[0] >= 10 or sys.version_info[1] >= 10:
+            sep = "_"
+        else:
+            sep = ""
         assert len(abis) == 1
         assert result[0] == tags.Tag(
-            "cp{major}{minor}".format(
-                major=sys.version_info[0], minor=sys.version_info[1]
+            "cp{major}{sep}{minor}".format(
+                major=sys.version_info[0], sep=sep, minor=sys.version_info[1]
             ),
             abis[0],
             platforms[0],
         )
         assert result[-1] == tags.Tag(
-            "py{}0".format(sys.version_info[0]), "none", "any"
+            "py{}{}0".format(
+                sys.version_info[0], "_" if sys.version_info[0] >= 10 else ""
+            ),
+            "none",
+            "any",
         )
 
     def test_windows_cpython(self, mock_interpreter_name, monkeypatch):
@@ -981,13 +1130,23 @@ class TestSysTags:
         abis = list(tags._cpython_abis(sys.version_info[:2]))
         platforms = list(tags._generic_platforms())
         result = list(tags.sys_tags())
-        interpreter = "cp{major}{minor}".format(
-            major=sys.version_info[0], minor=sys.version_info[1]
+        if sys.version_info[0] >= 10 or sys.version_info[1] >= 10:
+            sep = "_"
+        else:
+            sep = ""
+        interpreter = "cp{major}{sep}{minor}".format(
+            major=sys.version_info[0], sep=sep, minor=sys.version_info[1]
         )
         assert len(abis) == 1
         expected = tags.Tag(interpreter, abis[0], platforms[0])
         assert result[0] == expected
-        expected = tags.Tag("py{}0".format(sys.version_info[0]), "none", "any")
+        expected = tags.Tag(
+            "py{}{}0".format(
+                sys.version_info[0], "_" if sys.version_info[0] >= 10 else ""
+            ),
+            "none",
+            "any",
+        )
         assert result[-1] == expected
 
     def test_linux_cpython(self, mock_interpreter_name, monkeypatch):
@@ -999,12 +1158,22 @@ class TestSysTags:
         abis = list(tags._cpython_abis(sys.version_info[:2]))
         platforms = list(tags._linux_platforms())
         result = list(tags.sys_tags())
-        expected_interpreter = "cp{major}{minor}".format(
-            major=sys.version_info[0], minor=sys.version_info[1]
+        if sys.version_info[0] >= 10 or sys.version_info[1] >= 10:
+            sep = "_"
+        else:
+            sep = ""
+        expected_interpreter = "cp{major}{sep}{minor}".format(
+            major=sys.version_info[0], sep=sep, minor=sys.version_info[1]
         )
         assert len(abis) == 1
         assert result[0] == tags.Tag(expected_interpreter, abis[0], platforms[0])
-        expected = tags.Tag("py{}0".format(sys.version_info[0]), "none", "any")
+        expected = tags.Tag(
+            "py{}{}0".format(
+                sys.version_info[0], "_" if sys.version_info[0] >= 10 else ""
+            ),
+            "none",
+            "any",
+        )
         assert result[-1] == expected
 
     def test_generic(self, monkeypatch):
@@ -1012,5 +1181,11 @@ class TestSysTags:
         monkeypatch.setattr(tags, "interpreter_name", lambda: "generic")
 
         result = list(tags.sys_tags())
-        expected = tags.Tag("py{}0".format(sys.version_info[0]), "none", "any")
+        expected = tags.Tag(
+            "py{}{}0".format(
+                sys.version_info[0], "_" if sys.version_info[0] >= 10 else ""
+            ),
+            "none",
+            "any",
+        )
         assert result[-1] == expected

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -697,11 +697,7 @@ class TestCPythonABI:
         config = {"Py_DEBUG": 0, "WITH_PYMALLOC": 0, "Py_UNICODE_SIZE": unicode_size}
         monkeypatch.setattr(sysconfig, "get_config_var", config.__getitem__)
         monkeypatch.setattr(sys, "maxunicode", maxunicode)
-        if version[0] >= 10 or version[1] >= 10:
-            sep = "_"
-        else:
-            sep = ""
-        base_abi = "cp{}{}{}".format(version[0], sep, version[1])
+        base_abi = "cp" + tags._version_nodot(version)
         expected = [base_abi + "u" if result else base_abi]
         assert tags._cpython_abis(version) == expected
 
@@ -787,11 +783,7 @@ class TestCPythonTags:
 
     def test_python_version_defaults(self):
         tag = next(tags.cpython_tags(abis=["abi3"], platforms=["any"]))
-        if sys.version_info[0] >= 10 or sys.version_info[1] >= 10:
-            sep = "_"
-        else:
-            sep = ""
-        interpreter = "cp{}{}{}".format(sys.version_info[0], sep, sys.version_info[1])
+        interpreter = "cp" + tags._version_nodot(sys.version_info[:2])
         assert interpreter == tag.interpreter
 
     def test_abi_defaults(self, monkeypatch):
@@ -1101,24 +1093,12 @@ class TestSysTags:
         abis = tags._cpython_abis(sys.version_info[:2])
         platforms = list(tags.mac_platforms())
         result = list(tags.sys_tags())
-        if sys.version_info[0] >= 10 or sys.version_info[1] >= 10:
-            sep = "_"
-        else:
-            sep = ""
         assert len(abis) == 1
         assert result[0] == tags.Tag(
-            "cp{major}{sep}{minor}".format(
-                major=sys.version_info[0], sep=sep, minor=sys.version_info[1]
-            ),
-            abis[0],
-            platforms[0],
+            "cp" + tags._version_nodot(sys.version_info[:2]), abis[0], platforms[0]
         )
         assert result[-1] == tags.Tag(
-            "py{}{}0".format(
-                sys.version_info[0], "_" if sys.version_info[0] >= 10 else ""
-            ),
-            "none",
-            "any",
+            "py" + tags._version_nodot((sys.version_info[0], 0)), "none", "any"
         )
 
     def test_windows_cpython(self, mock_interpreter_name, monkeypatch):
@@ -1130,22 +1110,12 @@ class TestSysTags:
         abis = list(tags._cpython_abis(sys.version_info[:2]))
         platforms = list(tags._generic_platforms())
         result = list(tags.sys_tags())
-        if sys.version_info[0] >= 10 or sys.version_info[1] >= 10:
-            sep = "_"
-        else:
-            sep = ""
-        interpreter = "cp{major}{sep}{minor}".format(
-            major=sys.version_info[0], sep=sep, minor=sys.version_info[1]
-        )
+        interpreter = "cp" + tags._version_nodot(sys.version_info[:2])
         assert len(abis) == 1
         expected = tags.Tag(interpreter, abis[0], platforms[0])
         assert result[0] == expected
         expected = tags.Tag(
-            "py{}{}0".format(
-                sys.version_info[0], "_" if sys.version_info[0] >= 10 else ""
-            ),
-            "none",
-            "any",
+            "py" + tags._version_nodot((sys.version_info[0], 0)), "none", "any"
         )
         assert result[-1] == expected
 
@@ -1158,21 +1128,11 @@ class TestSysTags:
         abis = list(tags._cpython_abis(sys.version_info[:2]))
         platforms = list(tags._linux_platforms())
         result = list(tags.sys_tags())
-        if sys.version_info[0] >= 10 or sys.version_info[1] >= 10:
-            sep = "_"
-        else:
-            sep = ""
-        expected_interpreter = "cp{major}{sep}{minor}".format(
-            major=sys.version_info[0], sep=sep, minor=sys.version_info[1]
-        )
+        expected_interpreter = "cp" + tags._version_nodot(sys.version_info[:2])
         assert len(abis) == 1
         assert result[0] == tags.Tag(expected_interpreter, abis[0], platforms[0])
         expected = tags.Tag(
-            "py{}{}0".format(
-                sys.version_info[0], "_" if sys.version_info[0] >= 10 else ""
-            ),
-            "none",
-            "any",
+            "py" + tags._version_nodot((sys.version_info[0], 0)), "none", "any"
         )
         assert result[-1] == expected
 
@@ -1182,10 +1142,6 @@ class TestSysTags:
 
         result = list(tags.sys_tags())
         expected = tags.Tag(
-            "py{}{}0".format(
-                sys.version_info[0], "_" if sys.version_info[0] >= 10 else ""
-            ),
-            "none",
-            "any",
+            "py" + tags._version_nodot((sys.version_info[0], 0)), "none", "any"
         )
         assert result[-1] == expected


### PR DESCRIPTION
[PEP 425](https://www.python.org/dev/peps/pep-0425/) defines the version string used in Python implementation tags as follows:

> The version is *py_version_nodot*. CPython gets away with no dot, but if one is needed the underscore _ is used instead.

I take this to mean that, starting with Python 3.10, Python implementation tags will be of the form `cp3_10` instead of `cp310`.  This PR thus updates `tags.py` to insert underscores in version strings in tags whenever one or more of the version's components are at least 10.

**Note:** I am assuming that the sysconfig var `py_version_nodot` will be updated to use an underscore when Python 3.10 is released; if it is not, then the definition of `interpreter_version()` will have to be changed to use something other than `py_version_nodot`.