### PR TITLE
Use a secure variable for IRC channel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,10 @@ script:
 notifications:
   irc:
     channels:
-      - "irc.freenode.org#pypa-dev"
+      # This is set to a secure variable to prevent forks from notifying the
+      # IRC channel whenever they fail a build. This can be removed when travis
+      # implements https://github.com/travis-ci/travis-ci/issues/1094.
+      # The actual value here is: irc.freenode.org#pypa-dev
+      - secure: "Br6aYBYkjL17fBZ6+AczCkaBMWQAY6To8IH4zqhHrORXAWq4zeuC4VyCZ4MXmDzk0WbA3h3Ea7u9kodUf1sVK1h0q7HX66p8qmFyTncQoLFgo2LF/x1aU1FGWKDDSX5K6qKOzUKrHUhQyVq+uAuRVUm7bJhJL0/viPwEoh+bONo="
     use_notice: true
     skip_join: true


### PR DESCRIPTION
Currently, failing builds from forks result in spam on #pypa-dev.

Using a secure variable is a workaround.