### PR TITLE
Restrict coverage version to '<5.0.0'

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install coverage pretend pytest
+        python -m pip install coverage<5.0.0 pretend pytest
 
     - name: Test coverage
       run: |
@@ -59,7 +59,7 @@ jobs:
     # pytest >= 5.0.0 fails with pypy3 https://github.com/pytest-dev/pytest/issues/5807
       run: |
         python -m pip install --upgrade pip
-        python -m pip install coverage pretend pytest==4.6.5
+        python -m pip install coverage<5.0.0 pretend pytest==4.6.5
 
     - name: Test coverage
       run: |

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist = py27,pypy,pypy3,py34,py35,py36,py37,py38,docs,lint
 
 [testenv]
 deps =
-    coverage
+    coverage<5.0.0
     pretend
     pytest
     pip>=9.0.2


### PR DESCRIPTION
Mitigate #246

I don't think this is a long-term solution but I couldn't figure out how to do this properly with coverage 5.0.0
Might be a bug in coverage, wait & see.
