### PR TITLE
Fix GitHub Actions workflow following #247

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,10 +60,9 @@ jobs:
         python-version: ${{ matrix.pypy_version }}
 
     - name: Install dependencies
-    # pytest >= 5.0.0 fails with pypy3 https://github.com/pytest-dev/pytest/issues/5807
       run: |
         python -m pip install --upgrade pip
-        python -m pip install 'coverage<5.0.0' pretend pytest==4.6.5
+        python -m pip install 'coverage<5.0.0' pretend pytest
 
     - name: Test coverage
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,11 +34,13 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install 'coverage<5.0.0' pretend pytest
+      shell: bash
 
     - name: Test coverage
       run: |
         python -m coverage run --source packaging/ -m pytest --strict tests
         python -m coverage report -m --fail-under 100
+      shell: bash
 
 
   test-pypy:
@@ -63,9 +65,11 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install 'coverage<5.0.0' pretend pytest
+      shell: bash
 
     - name: Test coverage
       run: |
         python -m pytest --capture=no --strict
         python -m coverage run --source packaging/ -m pytest --strict tests
         python -m coverage report -m --fail-under 100
+      shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
         # Python 3.4 is not available from actions/setup-python@v1.
@@ -45,6 +46,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
         pypy_version: ['pypy2', 'pypy3']

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,9 +3,11 @@ name: Test
 on:
   pull_request:
     paths:
+      - '.github/workflows/test.yml'
       - '**.py'
   push:
     paths:
+      - '.github/workflows/test.yml'
       - '**.py'
 
 jobs:
@@ -30,7 +32,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install coverage<5.0.0 pretend pytest
+        python -m pip install 'coverage<5.0.0' pretend pytest
 
     - name: Test coverage
       run: |
@@ -59,7 +61,7 @@ jobs:
     # pytest >= 5.0.0 fails with pypy3 https://github.com/pytest-dev/pytest/issues/5807
       run: |
         python -m pip install --upgrade pip
-        python -m pip install coverage<5.0.0 pretend pytest==4.6.5
+        python -m pip install 'coverage<5.0.0' pretend pytest==4.6.5
 
     - name: Test coverage
       run: |

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -804,7 +804,7 @@ class TestSysTags:
             monkeypatch.setattr(platform, "system", lambda: "Windows")
             monkeypatch.setattr(tags, "_generic_platforms", lambda: ["win_amd64"])
         abis = tags._cpython_abis(sys.version_info[:2])
-        platforms = tags._generic_platforms()
+        platforms = list(tags._generic_platforms())
         result = list(tags.sys_tags())
         interpreter = "cp{major}{minor}".format(
             major=sys.version_info[0], minor=sys.version_info[1]


### PR DESCRIPTION
Mitigate #246 

Fix GitHub Actions workflow following #247, also triggers GH Actions workflow on workflow change (7e60ba4)
Do not cancel running jobs on first failure (5014760)
Also fix PyPy test failure following PyPy upgrade on GitHub Actions virtual environments (ca764a5)
Also fix a Windows test issue (failing silently, c.f. ebd0f93 & 076ae9f)