### PR TITLE
Travis CI: Test on Python 3.8 final

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 cache: pip
-python: 3.6
+python: 3.8
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,15 +18,10 @@ matrix:
       env: TOXENV=py36
     - python: 3.7
       env: TOXENV=py37
-      dist: xenial
-    - python: 3.8-dev
-      env: TOXENV=py
-      dist: xenial
+    - python: 3.8
+      env: TOXENV=py38
     - env: TOXENV=lint
     - env: TOXENV=docs
-
-  allow_failures:
-    - python: 3.8-dev
 
 install:
   - pip install tox


### PR DESCRIPTION
Test on Python 3.8 final instead of dev, and require it to pass.

Also use Python 3.8 for lint and docs.
