### PR TITLE
Fix tags PyPy version string.

### DIFF
--- a/packaging/tags.py
+++ b/packaging/tags.py
@@ -571,6 +571,22 @@ def interpreter_version(**kwargs):
     """
     Returns the version of the running interpreter.
     """
+    pypy_version_info = getattr(sys, "pypy_version_info", None)
+    if pypy_version_info:
+        # PyPy is treated differently as per https://github.com/pypa/pip/issues/2882.
+        # PyPy community takes:
+        # + https://mail.python.org/pipermail/pypy-dev/2017-July/015243.html
+        # + https://bitbucket.org/pypy/pypy/issues/2613/fix-the-abi-tag
+        # Prior art:
+        # + https://github.com/pypa/wheel/blob/0.33.6/wheel/pep425tags.py#L49
+        # + https://github.com/pypa/pip/blob/19.3.1/src/pip/_internal/pep425tags.py#L67
+        return "".join(
+            map(
+                str,
+                (sys.version_info[0], pypy_version_info.major, pypy_version_info.minor),
+            )
+        )
+
     warn = _warn_keyword_parameter("interpreter_version", kwargs)
     version = _get_config_var("py_version_nodot", warn=warn)
     if version:

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -176,7 +176,11 @@ class TestInterpreterName:
         assert tags.interpreter_name() == "cp"
 
 
-class TestInterpreterVersion:
+class TestInterpreterVersionNotPyPy:
+    @pytest.fixture(autouse=True)
+    def patch_not_pypy(self, monkeypatch):
+        monkeypatch.delattr(sys, "pypy_version_info", raising=False)
+
     def test_warn(self, monkeypatch):
         class MockConfigVar(object):
             def __init__(self, return_):
@@ -200,6 +204,20 @@ class TestInterpreterVersion:
         monkeypatch.setattr(tags, "_get_config_var", lambda *args, **kwargs: None)
         monkeypatch.setattr(sys, "version_info", ("L", "M", "N"))
         assert tags.interpreter_version() == "LM"
+
+
+class TestInterpreterVersionPyPy:
+    def test_version_info(self, monkeypatch):
+        class PyPyVersionInfo(object):
+            def __init__(self, major, minor):
+                self.major = major
+                self.minor = minor
+
+        monkeypatch.setattr(sys, "version_info", ("L", "M", "N"))
+        monkeypatch.setattr(
+            sys, "pypy_version_info", PyPyVersionInfo("O", "P"), raising=False
+        )
+        assert tags.interpreter_version() == "LOP"
 
 
 class TestMacOSPlatforms:


### PR DESCRIPTION
This brings `packaging.tags` in line with prior art in wheel, pip and
setuptools. Importantly, it aligns the compatible tags reported for
PyPy with the tags for PyPy wheels generated by `bdist_wheel`.