### PR TITLE
Fix test_linux_platforms_manylinux* on architectures other than x86_64

### DIFF
--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -442,7 +442,8 @@ class TestManylinuxPlatform:
         if platform.system() != "Linux":
             monkeypatch.setattr(distutils.util, "get_platform", lambda: "linux_x86_64")
         platforms = list(tags._linux_platforms(is_32bit=False))
-        assert platforms == ["manylinux1_x86_64", "linux_x86_64"]
+        arch = platform.machine()
+        assert platforms == ["manylinux1_" + arch, "linux_" + arch]
 
     def test_linux_platforms_manylinux2010(self, monkeypatch):
         monkeypatch.setattr(
@@ -451,7 +452,8 @@ class TestManylinuxPlatform:
         if platform.system() != "Linux":
             monkeypatch.setattr(distutils.util, "get_platform", lambda: "linux_x86_64")
         platforms = list(tags._linux_platforms(is_32bit=False))
-        expected = ["manylinux2010_x86_64", "manylinux1_x86_64", "linux_x86_64"]
+        arch = platform.machine()
+        expected = ["manylinux2010_" + arch, "manylinux1_" + arch, "linux_" + arch]
         assert platforms == expected
 
     def test_linux_platforms_manylinux2014(self, monkeypatch):
@@ -461,11 +463,12 @@ class TestManylinuxPlatform:
         if platform.system() != "Linux":
             monkeypatch.setattr(distutils.util, "get_platform", lambda: "linux_x86_64")
         platforms = list(tags._linux_platforms(is_32bit=False))
+        arch = platform.machine()
         expected = [
-            "manylinux2014_x86_64",
-            "manylinux2010_x86_64",
-            "manylinux1_x86_64",
-            "linux_x86_64",
+            "manylinux2014_" + arch,
+            "manylinux2010_" + arch,
+            "manylinux1_" + arch,
+            "linux_" + arch,
         ]
         assert platforms == expected
 

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -435,33 +435,36 @@ class TestManylinuxPlatform:
         linux_platform = list(tags._linux_platforms(is_32bit=False))
         assert linux_platform == ["linux_x86_64"]
 
-    def test_linux_platforms_manylinux1(self, monkeypatch):
+    def test_linux_platforms_manylinux1(self, is_x86, monkeypatch):
         monkeypatch.setattr(
             tags, "_is_manylinux_compatible", lambda name, _: name == "manylinux1"
         )
-        if platform.system() != "Linux":
+        if platform.system() != "Linux" or not is_x86:
             monkeypatch.setattr(distutils.util, "get_platform", lambda: "linux_x86_64")
+            monkeypatch.setattr(platform, "machine", lambda: "x86_64")
         platforms = list(tags._linux_platforms(is_32bit=False))
         arch = platform.machine()
         assert platforms == ["manylinux1_" + arch, "linux_" + arch]
 
-    def test_linux_platforms_manylinux2010(self, monkeypatch):
+    def test_linux_platforms_manylinux2010(self, is_x86, monkeypatch):
         monkeypatch.setattr(
             tags, "_is_manylinux_compatible", lambda name, _: name == "manylinux2010"
         )
-        if platform.system() != "Linux":
+        if platform.system() != "Linux" or not is_x86:
             monkeypatch.setattr(distutils.util, "get_platform", lambda: "linux_x86_64")
+            monkeypatch.setattr(platform, "machine", lambda: "x86_64")
         platforms = list(tags._linux_platforms(is_32bit=False))
         arch = platform.machine()
         expected = ["manylinux2010_" + arch, "manylinux1_" + arch, "linux_" + arch]
         assert platforms == expected
 
-    def test_linux_platforms_manylinux2014(self, monkeypatch):
+    def test_linux_platforms_manylinux2014(self, is_x86, monkeypatch):
         monkeypatch.setattr(
             tags, "_is_manylinux_compatible", lambda name, _: name == "manylinux2014"
         )
-        if platform.system() != "Linux":
+        if platform.system() != "Linux" or not is_x86:
             monkeypatch.setattr(distutils.util, "get_platform", lambda: "linux_x86_64")
+            monkeypatch.setattr(platform, "machine", lambda: "x86_64")
         platforms = list(tags._linux_platforms(is_32bit=False))
         arch = platform.machine()
         expected = [


### PR DESCRIPTION
These patches allow the manylinux tests to pass on non-x86 by mocking the platform.  Tested on armv7, aarch64, i686, and x86_64 GNU/Linux.