### PR TITLE
#257: save list in memory to avoid reusing exhausted iterator

### DIFF
--- a/packaging/tags.py
+++ b/packaging/tags.py
@@ -328,8 +328,7 @@ def compatible_tags(
     """
     if not python_version:
         python_version = sys.version_info[:2]
-    if not platforms:
-        platforms = _platform_tags()
+    platforms = list(platforms or _platform_tags())
     for version in _py_interpreter_range(python_version):
         for platform_ in platforms:
             yield Tag(version, "none", platform_)

--- a/packaging/tags.py
+++ b/packaging/tags.py
@@ -315,7 +315,7 @@ def _py_interpreter_range(py_version):
 def compatible_tags(
     python_version=None,  # type: Optional[PythonVersion]
     interpreter=None,  # type: Optional[str]
-    platforms=None,  # type: Optional[Iterator[str]]
+    platforms=None,  # type: Optional[Iterable[str]]
 ):
     # type: (...) -> Iterator[Tag]
     """

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -923,12 +923,15 @@ class TestCompatibleTags:
         ]
 
     def test_default_platforms(self, monkeypatch):
-        monkeypatch.setattr(tags, "_platform_tags", lambda: ["plat"])
+        monkeypatch.setattr(tags, "_platform_tags", lambda: iter(["plat", "plat2"]))
         result = list(tags.compatible_tags((3, 1), "cp31"))
         assert result == [
             tags.Tag("py31", "none", "plat"),
+            tags.Tag("py31", "none", "plat2"),
             tags.Tag("py3", "none", "plat"),
+            tags.Tag("py3", "none", "plat2"),
             tags.Tag("py30", "none", "plat"),
+            tags.Tag("py30", "none", "plat2"),
             tags.Tag("cp31", "none", "any"),
             tags.Tag("py31", "none", "any"),
             tags.Tag("py3", "none", "any"),


### PR DESCRIPTION
This should resolve https://github.com/pypa/packaging/issues/257

The solution I proposed in the issue, I did not use, but I resorted to the same way this variable was handled in the other functions "generic_tags" and "cpython_tags"

The test added was also tested against the unmodified code to ensure failure.

Only tested with "tox -e py37", full environment list is still running.