### PR TITLE
Add additional overrides to manylinux logic

### DIFF
--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -288,6 +288,30 @@ class TestManylinuxPlatform:
         manylinux_module.manylinux1_compatible = False
         assert not tags._is_manylinux_compatible("manylinux1", (2, 5))
 
+    @pytest.mark.parametrize(
+        "tag,version",
+        [
+            ("manylinux2014", (2, 17)),
+            ("manylinux2010", (2, 12)),
+            ("manylinux1", (2, 5)),
+        ],
+    )
+    def test_module_no_manylinux_compatible(self, manylinux_module, tag, version):
+        manylinux_module.manylinux_compatible = False
+        assert not tags._is_manylinux_compatible(tag, version)
+
+    @pytest.mark.parametrize(
+        "tag,version",
+        [
+            ("manylinux2014", (2, 17)),
+            ("manylinux2010", (2, 12)),
+            ("manylinux1", (2, 5)),
+        ],
+    )
+    def test_envvar_no_manylinux_compatible(self, monkeypatch, tag, version):
+        monkeypatch.setenv("PYTHON_NO_MANYLINUX", "1")
+        assert not tags._is_manylinux_compatible(tag, version)
+
     def test_module_declaration_missing_attribute(self, manylinux_module):
         try:
             del manylinux_module.manylinux1_compatible


### PR DESCRIPTION
Currently, if not all the manylinux compat variables are set in the
_manylinux module, the current logic may override the specified value
(towards manylinux being supported).  Given that the most likely reasons
to disable manylinux is to prevent the install of all manylinux modules,
this patch adds support for completely disabling manylinux via
_manylinux.manylinux_compat = False and PYTHON_NO_MANYLINUX.

See https://github.com/pypa/pip/issues/7648 for more context. This should also solve https://github.com/pypa/pip/issues/3689.