### PR TITLE
Call pytest using "python -m pytest"

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -21,7 +21,9 @@ def tests(session):
         coverage("report", "-m", "--fail-under", "100")
     else:
         # Don't do coverage tracking for PyPy, since it's SLOW.
-        session.run("pytest", "--capture=no", "--strict", *session.posargs)
+        session.run(
+            "python", "-m", "pytest", "--capture=no", "--strict", *session.posargs
+        )
 
 
 @nox.session(python="3.8")


### PR DESCRIPTION
Directly calling "pytest" sometimes breaks tests on "pypy", such as #234, because the actual current code is untested. As explained from pypy website <https://docs.pytest.org/en/latest/usage.html>:

> ["python -m pytest"] is almost equivalent to invoking the command line
> script pytest [...] directly, except that calling via python will also
> add the current directory to sys.path.

Note that, unlike the tests for pypy, the pytest script is not directly invoked in tests for other Python interpreters.