### PR TITLE
Add docstrings to packaging.tags.Tag and packaging.tags.parse_tag()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 .coverage
 .idea
 .venv*
+.vscode/
 
 .mypy_cache/
 .pytest_cache/

--- a/packaging/tags.py
+++ b/packaging/tags.py
@@ -59,8 +59,9 @@ _32_BIT_INTERPRETER = sys.maxsize <= 2 ** 32
 
 class Tag(object):
     """
-    A representation of the tag triple for a wheel. Instances are considered immutable
-    and thus are hashable. Equality checking is also supported.
+    A representation of the tag triple for a wheel.
+    
+    Instances are considered immutable and thus are hashable. Equality checking is also supported.
     """
 
     __slots__ = ["_interpreter", "_abi", "_platform"]

--- a/packaging/tags.py
+++ b/packaging/tags.py
@@ -58,6 +58,10 @@ _32_BIT_INTERPRETER = sys.maxsize <= 2 ** 32
 
 
 class Tag(object):
+    """
+    A representation of the tag triple for a wheel. Instances are considered immutable
+    and thus are hashable. Equality checking is also supported.
+    """
 
     __slots__ = ["_interpreter", "_abi", "_platform"]
 
@@ -108,6 +112,12 @@ class Tag(object):
 
 def parse_tag(tag):
     # type: (str) -> FrozenSet[Tag]
+    """
+    Parses the provided tag (e.g. `py3-none-any`) into a set of Tag instances.
+
+    Returning a set is required due to the possibility that the tag is a
+    compressed tag set.
+    """
     tags = set()
     interpreters, abis, platforms = tag.split("-")
     for interpreter in interpreters.split("."):
@@ -541,7 +551,7 @@ class _ELFFileHeader(object):
         def unpack(fmt):
             # type: (str) -> int
             try:
-                result, = struct.unpack(
+                (result,) = struct.unpack(
                     fmt, file.read(struct.calcsize(fmt))
                 )  # type: (int, )
             except struct.error:

--- a/packaging/tags.py
+++ b/packaging/tags.py
@@ -60,8 +60,9 @@ _32_BIT_INTERPRETER = sys.maxsize <= 2 ** 32
 class Tag(object):
     """
     A representation of the tag triple for a wheel.
-    
-    Instances are considered immutable and thus are hashable. Equality checking is also supported.
+
+    Instances are considered immutable and thus are hashable. Equality checking
+    is also supported.
     """
 
     __slots__ = ["_interpreter", "_abi", "_platform"]
@@ -552,7 +553,7 @@ class _ELFFileHeader(object):
         def unpack(fmt):
             # type: (str) -> int
             try:
-                result, = struct.unpack(
+                (result,) = struct.unpack(
                     fmt, file.read(struct.calcsize(fmt))
                 )  # type: (int, )
             except struct.error:

--- a/packaging/tags.py
+++ b/packaging/tags.py
@@ -114,7 +114,7 @@ class Tag(object):
 def parse_tag(tag):
     # type: (str) -> FrozenSet[Tag]
     """
-    Parses the provided tag (e.g. `py3-none-any`) into a set of Tag instances.
+    Parses the provided tag (e.g. `py3-none-any`) into a frozenset of Tag instances.
 
     Returning a set is required due to the possibility that the tag is a
     compressed tag set.

--- a/packaging/tags.py
+++ b/packaging/tags.py
@@ -551,7 +551,7 @@ class _ELFFileHeader(object):
         def unpack(fmt):
             # type: (str) -> int
             try:
-                (result,) = struct.unpack(
+                result, = struct.unpack(
                     fmt, file.read(struct.calcsize(fmt))
                 )  # type: (int, )
             except struct.error:


### PR DESCRIPTION
Fix for #278

Note: Took the docstring content from [here](/docs/tags.rst@master) and summarized a bit.

This change:
- Adds a docstring to the `packaging.tags.Tag` class.
- Adds a docstring to the `packaging.tags.parse_tag` function.
- Adds the `.vscode/` folder to `.gitignore`.

Potential issues:
- Should I use the same Sphinx syntax in docstring for `parse_tag`?
