### PR TITLE
Support PEP 600 tags

### DIFF
--- a/packaging/tags.py
+++ b/packaging/tags.py
@@ -682,7 +682,7 @@ def _have_compatible_manylinux_abi(arch):
 
 def _manylinux_tags(linux, arch):
     # type: (str, str) -> Iterator[str]
-    # Oldest glibc to be supported is (2, 17).
+    # Oldest glibc to be supported regardless of architecture is (2, 17).
     too_old_glibc2 = glibcVersion(2, 16)
     if arch in {"x86_64", "i686"}:
         # On x86/i686 also oldest glibc to be supported is (2, 5).
@@ -694,7 +694,7 @@ def _manylinux_tags(linux, arch):
     #
     # Build a list of maximum glibc versions so that we can
     # output the canonical list of all glibc from current_glibc
-    # down to too_old_glibc2, including all intermediary versions
+    # down to too_old_glibc2, including all intermediary versions.
     for glibc_major in range(current_glibc.major - 1, 1, -1):
         glibc_max_list.append(glibcVersion(glibc_major, _LAST_GLIBC_MINOR[glibc_major]))
     for glibc_max in glibc_max_list:

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -39,7 +39,7 @@ def is_x86():
 
 @pytest.fixture
 def manylinux_module(monkeypatch):
-    monkeypatch.setattr(tags, "_have_compatible_glibc", lambda *args: False)
+    monkeypatch.setattr(tags, "_get_glibc_version", lambda *args: (2, 20))
     module_name = "_manylinux"
     module = types.ModuleType(module_name)
     monkeypatch.setitem(sys.modules, module_name, module)
@@ -285,26 +285,27 @@ class TestMacOSPlatforms:
 
 
 class TestManylinuxPlatform:
+    def teardown_method(self):
+        # Clear the version cache
+        tags._glibc_version = []
+
     def test_module_declaration_true(self, manylinux_module):
         manylinux_module.manylinux1_compatible = True
-        assert tags._is_manylinux_compatible("manylinux1", (2, 5))
+        assert tags._is_manylinux_compatible("manylinux1", "x86_64", (2, 5))
 
     def test_module_declaration_false(self, manylinux_module):
         manylinux_module.manylinux1_compatible = False
-        assert not tags._is_manylinux_compatible("manylinux1", (2, 5))
+        assert not tags._is_manylinux_compatible("manylinux1", "x86_64", (2, 5))
 
-    def test_module_declaration_missing_attribute(self, manylinux_module):
-        try:
+    def test_module_declaration_missing_attribute(self, monkeypatch, manylinux_module):
+        oldval = getattr(manylinux_module, "manylinux1_compatible", None)
+        if oldval:
             del manylinux_module.manylinux1_compatible
-        except AttributeError:
-            pass
-        assert not tags._is_manylinux_compatible("manylinux1", (2, 5))
-
-    def test_is_manylinux_compatible_module_support(
-        self, manylinux_module, monkeypatch
-    ):
-        monkeypatch.setitem(sys.modules, manylinux_module.__name__, None)
-        assert not tags._is_manylinux_compatible("manylinux1", (2, 5))
+        try:
+            assert tags._is_manylinux_compatible("manylinux1", "x86_64", (2, 5))
+        finally:
+            if oldval:
+                manylinux_module.manylinux1_compatible = oldval
 
     @pytest.mark.parametrize(
         "version,compatible", (((2, 0), True), ((2, 5), True), ((2, 10), False))
@@ -313,29 +314,16 @@ class TestManylinuxPlatform:
         self, version, compatible, monkeypatch
     ):
         monkeypatch.setitem(sys.modules, "_manylinux", None)
-        monkeypatch.setattr(
-            tags,
-            "_have_compatible_glibc",
-            lambda major, minor: (major, minor) <= (2, 5),
+        monkeypatch.setattr(tags, "_get_glibc_version", lambda: (2, 5))
+        assert (
+            bool(tags._is_manylinux_compatible("manylinux1", "any", version))
+            == compatible
         )
-        assert bool(tags._is_manylinux_compatible("manylinux1", version)) == compatible
-
-    @pytest.mark.parametrize(
-        "version_str,major,minor,expected",
-        [
-            ("2.4", 2, 4, True),
-            ("2.4", 2, 5, False),
-            ("2.4", 2, 3, True),
-            ("3.4", 2, 4, True),
-        ],
-    )
-    def test_check_glibc_version(self, version_str, major, minor, expected):
-        assert expected == tags._check_glibc_version(version_str, major, minor)
 
     @pytest.mark.parametrize("version_str", ["glibc-2.4.5", "2"])
     def test_check_glibc_version_warning(self, version_str):
         with warnings.catch_warnings(record=True) as w:
-            tags._check_glibc_version(version_str, 2, 4)
+            tags._parse_glibc_version(version_str)
             assert len(w) == 1
             assert issubclass(w[0].category, RuntimeWarning)
 
@@ -377,7 +365,6 @@ class TestManylinuxPlatform:
         monkeypatch.setattr(os, "confstr", lambda x: None, raising=False)
         monkeypatch.setitem(sys.modules, "ctypes", None)
         assert tags._glibc_version_string() is None
-        assert tags._have_compatible_glibc(2, 5) is False
         assert tags._get_glibc_version() == (-1, -1)
 
     @pytest.mark.parametrize(
@@ -414,18 +401,18 @@ class TestManylinuxPlatform:
         ]
 
     @pytest.mark.skipif(platform.system() != "Linux", reason="requires Linux")
-    def test_have_compatible_glibc_linux(self):
+    def test_is_manylinux_compatible_old(self):
         # Assuming no one is running this test with a version of glibc released in
         # 1997.
-        assert tags._have_compatible_glibc(2, 0)
+        assert tags._is_manylinux_compatible("any", "any", (2, 0))
 
-    def test_have_compatible_glibc(self, monkeypatch):
+    def test_is_manylinux_compatible(self, monkeypatch):
         monkeypatch.setattr(tags, "_glibc_version_string", lambda: "2.4")
-        assert tags._have_compatible_glibc(2, 4)
+        assert tags._is_manylinux_compatible("", "any", (2, 4))
 
     def test_glibc_version_string_none(self, monkeypatch):
         monkeypatch.setattr(tags, "_glibc_version_string", lambda: None)
-        assert not tags._have_compatible_glibc(2, 4)
+        assert not tags._is_manylinux_compatible("any", "any", (2, 4))
 
     @pytest.mark.parametrize(
         "arch,is_32bit,expected",
@@ -454,27 +441,23 @@ class TestManylinuxPlatform:
 
     def test_linux_platforms_manylinux1(self, is_x86, monkeypatch):
         monkeypatch.setattr(
-            tags, "_is_manylinux_compatible", lambda name, _: name == "manylinux1"
+            tags, "_is_manylinux_compatible", lambda name, *args: name == "manylinux1"
         )
-        if platform.system() != "Linux" or not is_x86:
-            monkeypatch.setattr(distutils.util, "get_platform", lambda: "linux_x86_64")
-            monkeypatch.setattr(platform, "machine", lambda: "x86_64")
-            monkeypatch.setattr(os, "confstr", lambda x: "glibc 2.20", raising=False)
+        monkeypatch.setattr(distutils.util, "get_platform", lambda: "linux_x86_64")
+        monkeypatch.setattr(platform, "machine", lambda: "x86_64")
+        monkeypatch.setattr(os, "confstr", lambda x: "glibc 2.20", raising=False)
         platforms = list(tags._linux_platforms(is_32bit=False))
         arch = platform.machine()
         assert platforms == ["manylinux1_" + arch, "linux_" + arch]
 
     def test_linux_platforms_manylinux2010(self, is_x86, monkeypatch):
-        monkeypatch.setattr(
-            tags, "_is_manylinux_compatible", lambda name, _: name == "manylinux2010"
-        )
-        if platform.system() != "Linux" or not is_x86:
-            monkeypatch.setattr(distutils.util, "get_platform", lambda: "linux_x86_64")
-            monkeypatch.setattr(platform, "machine", lambda: "x86_64")
-            monkeypatch.setattr(os, "confstr", lambda x: "glibc 2.20", raising=False)
+        monkeypatch.setattr(distutils.util, "get_platform", lambda: "linux_x86_64")
+        monkeypatch.setattr(platform, "machine", lambda: "x86_64")
+        monkeypatch.setattr(os, "confstr", lambda x: "glibc 2.12", raising=False)
         platforms = list(tags._linux_platforms(is_32bit=False))
         arch = platform.machine()
         expected = [
+            "manylinux_2_12_" + arch,
             "manylinux2010_" + arch,
             "manylinux_2_11_" + arch,
             "manylinux_2_10_" + arch,
@@ -489,16 +472,13 @@ class TestManylinuxPlatform:
         assert platforms == expected
 
     def test_linux_platforms_manylinux2014(self, is_x86, monkeypatch):
-        monkeypatch.setattr(
-            tags, "_is_manylinux_compatible", lambda name, _: name == "manylinux2014"
-        )
-        if platform.system() != "Linux" or not is_x86:
-            monkeypatch.setattr(distutils.util, "get_platform", lambda: "linux_x86_64")
-            monkeypatch.setattr(platform, "machine", lambda: "x86_64")
-            monkeypatch.setattr(os, "confstr", lambda x: "glibc 2.20", raising=False)
+        monkeypatch.setattr(distutils.util, "get_platform", lambda: "linux_x86_64")
+        monkeypatch.setattr(platform, "machine", lambda: "x86_64")
+        monkeypatch.setattr(os, "confstr", lambda x: "glibc 2.17", raising=False)
         platforms = list(tags._linux_platforms(is_32bit=False))
         arch = platform.machine()
         expected = [
+            "manylinux_2_17_" + arch,
             "manylinux2014_" + arch,
             "manylinux_2_16_" + arch,
             "manylinux_2_15_" + arch,
@@ -521,7 +501,9 @@ class TestManylinuxPlatform:
     def test_linux_platforms_manylinux2014_armhf_abi(self, monkeypatch):
         monkeypatch.setattr(tags, "_glibc_version_string", lambda: "2.30")
         monkeypatch.setattr(
-            tags, "_is_manylinux_compatible", lambda name, _: name == "manylinux2014"
+            tags,
+            "_is_manylinux_compatible",
+            lambda name, *args: name == "manylinux2014",
         )
         monkeypatch.setattr(distutils.util, "get_platform", lambda: "linux_armv7l")
         monkeypatch.setattr(
@@ -534,10 +516,7 @@ class TestManylinuxPlatform:
         assert platforms == expected
 
     def test_linux_platforms_manylinux2014_i386_abi(self, monkeypatch):
-        monkeypatch.setattr(tags, "_glibc_version_string", lambda: "2.20")
-        monkeypatch.setattr(
-            tags, "_is_manylinux_compatible", lambda name, _: name == "manylinux2014"
-        )
+        monkeypatch.setattr(tags, "_glibc_version_string", lambda: "2.17")
         monkeypatch.setattr(distutils.util, "get_platform", lambda: "linux_x86_64")
         monkeypatch.setattr(
             sys,
@@ -546,7 +525,7 @@ class TestManylinuxPlatform:
         )
         platforms = list(tags._linux_platforms(is_32bit=True))
         expected = [
-            # "manylinux_2_17_i686",  # rejected since it comes before manylinux2014
+            "manylinux_2_17_i686",
             "manylinux2014_i686",
             "manylinux_2_16_i686",
             "manylinux_2_15_i686",
@@ -569,7 +548,7 @@ class TestManylinuxPlatform:
     def test_linux_platforms_manylinux_glibc3(self, monkeypatch):
         # test for a future glic 3.x version
         monkeypatch.setattr(tags, "_glibc_version_string", lambda: "3.2")
-        monkeypatch.setattr(tags, "_is_manylinux_compatible", lambda name, _: True)
+        monkeypatch.setattr(tags, "_is_manylinux_compatible", lambda name, *args: True)
         monkeypatch.setattr(distutils.util, "get_platform", lambda: "linux_aarch64")
         monkeypatch.setattr(
             sys,
@@ -601,7 +580,7 @@ class TestManylinuxPlatform:
     def test_linux_platforms_not_manylinux_abi(
         self, monkeypatch, machine, abi, alt_machine
     ):
-        monkeypatch.setattr(tags, "_is_manylinux_compatible", lambda name, _: True)
+        monkeypatch.setattr(tags, "_is_manylinux_compatible", lambda name, _: False)
         monkeypatch.setattr(
             distutils.util, "get_platform", lambda: "linux_{}".format(machine)
         )
@@ -1146,6 +1125,10 @@ class TestCompatibleTags:
 
 
 class TestSysTags:
+    def teardown_method(self):
+        # Clear the version cache
+        tags._glibc_version = []
+
     @pytest.mark.parametrize(
         "name,expected",
         [("CPython", "cp"), ("PyPy", "pp"), ("Jython", "jy"), ("IronPython", "ip")],
@@ -1218,3 +1201,100 @@ class TestSysTags:
             "py" + tags._version_nodot((sys.version_info[0], 0)), "none", "any"
         )
         assert result[-1] == expected
+
+    def test_linux_platforms_manylinux2014_armv6l(self, monkeypatch, manylinux_module):
+        monkeypatch.setattr(distutils.util, "get_platform", lambda: "linux_armv6l")
+        monkeypatch.setattr(os, "confstr", lambda x: "glibc 2.20", raising=False)
+        platforms = list(tags._linux_platforms(is_32bit=True))
+        expected = ["linux_armv6l"]
+        assert platforms == expected
+
+    def test_skip_manylinux_2014(self, monkeypatch, manylinux_module):
+        monkeypatch.setattr(distutils.util, "get_platform", lambda: "linux_ppc64")
+        monkeypatch.setattr(tags, "_get_glibc_version", lambda: (2, 20))
+        expected = [
+            "manylinux_2_20_ppc64",
+            "manylinux_2_19_ppc64",
+            "manylinux_2_18_ppc64",
+            # "manylinux2014_ppc64",  # this one is skipped
+            # "manylinux_2_17_ppc64", # this one is also skipped
+            "linux_ppc64",
+        ]
+        manylinux_module.manylinux2014_compatible = False
+        try:
+            platforms = list(tags._linux_platforms())
+            assert platforms == expected
+        finally:
+            delattr(manylinux_module, "manylinux2014_compatible")
+
+    @pytest.mark.parametrize(
+        "machine, abi, alt_machine",
+        [("x86_64", "x32", "i686"), ("armv7l", "armel", "armv7l")],
+    )
+    def test_linux_platforms_not_manylinux_abi(
+        self, monkeypatch, manylinux_module, machine, abi, alt_machine
+    ):
+        monkeypatch.setattr(
+            distutils.util, "get_platform", lambda: "linux_{}".format(machine)
+        )
+        monkeypatch.setattr(
+            sys,
+            "executable",
+            os.path.join(
+                os.path.dirname(__file__), "hello-world-{}-{}".format(machine, abi)
+            ),
+        )
+        platforms = list(tags._linux_platforms(is_32bit=True))
+        expected = ["linux_{}".format(alt_machine)]
+        assert platforms == expected
+
+    @pytest.mark.parametrize(
+        "machine, major, minor, tf", [("x86_64", 2, 20, False), ("s390x", 2, 22, True)]
+    )
+    def test_linux_use_manylinux_compatible(
+        self, monkeypatch, manylinux_module, machine, major, minor, tf
+    ):
+        def manylinux_compatible(tag_major, tag_minor, tag_arch):
+            if tag_major == 2 and tag_minor == 22:
+                return tag_arch == "s390x"
+            return False
+
+        monkeypatch.setattr(tags, "_get_glibc_version", lambda: (major, minor))
+        monkeypatch.setattr(
+            distutils.util, "get_platform", lambda: "linux_{}".format(machine)
+        )
+        manylinux_module.manylinux_compatible = manylinux_compatible
+        try:
+            platforms = list(tags._linux_platforms())
+            if tf:
+                expected = ["manylinux_2_22_{}".format(machine)]
+            else:
+                expected = []
+            expected.append("linux_{}".format(machine))
+            assert platforms == expected
+        finally:
+            delattr(manylinux_module, "manylinux_compatible")
+
+    def test_linux_use_manylinux_compatible_none(self, monkeypatch, manylinux_module):
+        def manylinux_compatible(tag_major, tag_minor, tag_arch):
+            if tag_major == 2 and tag_minor < 25:
+                return False
+            return None
+
+        monkeypatch.setattr(tags, "_get_glibc_version", lambda: (2, 30))
+        monkeypatch.setattr(distutils.util, "get_platform", lambda: "linux_x86_64")
+        manylinux_module.manylinux_compatible = manylinux_compatible
+        try:
+            platforms = list(tags._linux_platforms())
+            expected = [
+                "manylinux_2_30_x86_64",
+                "manylinux_2_29_x86_64",
+                "manylinux_2_28_x86_64",
+                "manylinux_2_27_x86_64",
+                "manylinux_2_26_x86_64",
+                "manylinux_2_25_x86_64",
+                "linux_x86_64",
+            ]
+            assert platforms == expected
+        finally:
+            delattr(manylinux_module, "manylinux_compatible")

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -293,7 +293,9 @@ class TestManylinuxPlatform:
     @pytest.mark.parametrize(
         "attribute,glibc", (("1", (2, 5)), ("2010", (2, 12)), ("2014", (2, 17)))
     )
-    def test_module_declaration(self, monkeypatch, manylinux_module, attribute, glibc, tf):
+    def test_module_declaration(
+        self, monkeypatch, manylinux_module, attribute, glibc, tf
+    ):
         manylinux = "manylinux{}_compatible".format(attribute)
         monkeypatch.setattr(manylinux_module, manylinux, tf, raising=False)
         res = tags._is_manylinux_compatible(manylinux, "x86_64", glibc)
@@ -1214,7 +1216,9 @@ class TestSysTags:
     def test_skip_manylinux_2014(self, monkeypatch, manylinux_module):
         monkeypatch.setattr(distutils.util, "get_platform", lambda: "linux_ppc64")
         monkeypatch.setattr(tags, "_get_glibc_version", lambda: (2, 20))
-        monkeypatch.setattr(manylinux_module, 'manylinux2014_compatible', False, raising=False)
+        monkeypatch.setattr(
+            manylinux_module, "manylinux2014_compatible", False, raising=False
+        )
         expected = [
             "manylinux_2_20_ppc64",
             "manylinux_2_19_ppc64",
@@ -1262,7 +1266,12 @@ class TestSysTags:
         monkeypatch.setattr(
             distutils.util, "get_platform", lambda: "linux_{}".format(machine)
         )
-        monkeypatch.setattr(manylinux_module, 'manylinux_compatible', manylinux_compatible, raising=False)
+        monkeypatch.setattr(
+            manylinux_module,
+            "manylinux_compatible",
+            manylinux_compatible,
+            raising=False,
+        )
         platforms = list(tags._linux_platforms())
         if tf:
             expected = ["manylinux_2_22_{}".format(machine)]
@@ -1279,7 +1288,12 @@ class TestSysTags:
 
         monkeypatch.setattr(tags, "_get_glibc_version", lambda: (2, 30))
         monkeypatch.setattr(distutils.util, "get_platform", lambda: "linux_x86_64")
-        monkeypatch.setattr(manylinux_module, 'manylinux_compatible', manylinux_compatible, raising=False)
+        monkeypatch.setattr(
+            manylinux_module,
+            "manylinux_compatible",
+            manylinux_compatible,
+            raising=False,
+        )
         platforms = list(tags._linux_platforms())
         expected = [
             "manylinux_2_30_x86_64",


### PR DESCRIPTION
xref gh-280. This adds a whole bunch of PEP 600 tags (my python reports `os.confstr('CS_GNU_LIBC_VERSION') of 2.27): **EDIT**: after reversing the order in f432bcd93f4
```
>>> from packaging import tags
>>> print ('\n'.join([str(t) for t in tags.sys_tags()]))
cp37-cp37m-manylinux_2_27_x86_64
cp37-cp37m-manylinux_2_26_x86_64
cp37-cp37m-manylinux_2_25_x86_64
cp37-cp37m-manylinux_2_24_x86_64
cp37-cp37m-manylinux_2_23_x86_64
cp37-cp37m-manylinux_2_22_x86_64
cp37-cp37m-manylinux_2_21_x86_64
cp37-cp37m-manylinux_2_20_x86_64
cp37-cp37m-manylinux_2_19_x86_64
cp37-cp37m-manylinux_2_18_x86_64
cp37-cp37m-manylinux_2_17_x86_64
cp37-cp37m-manylinux2014_x86_64
cp37-cp37m-manylinux_2_16_x86_64
cp37-cp37m-manylinux_2_15_x86_64
cp37-cp37m-manylinux_2_14_x86_64
cp37-cp37m-manylinux_2_13_x86_64
cp37-cp37m-manylinux_2_12_x86_64
cp37-cp37m-manylinux2010_x86_64
cp37-cp37m-manylinux_2_11_x86_64
cp37-cp37m-manylinux_2_10_x86_64
cp37-cp37m-manylinux_2_9_x86_64
cp37-cp37m-manylinux_2_8_x86_64
cp37-cp37m-manylinux_2_7_x86_64
cp37-cp37m-manylinux_2_6_x86_64
cp37-cp37m-manylinux_2_5_x86_64
cp37-cp37m-manylinux1_x86_64
cp37-cp37m-linux_x86_64
cp37-abi3-manylinux_2_27_x86_64
...
```
