### PR TITLE
Fix LEQ/GEQ for SpecifierSets when considering versions with a local version label

### DIFF
--- a/packaging/specifiers.py
+++ b/packaging/specifiers.py
@@ -516,11 +516,19 @@ class Specifier(_IndividualSpecifier):
     @_require_version_compare
     def _compare_less_than_equal(self, prospective, spec):
         # type: (ParsedVersion, str) -> bool
+
+        # NB: Local version identifiers are NOT permitted in the version
+        # specifier, so local version labels can be universally removed from
+        # the prospective version.
         return Version(prospective.public) <= Version(spec)
 
     @_require_version_compare
     def _compare_greater_than_equal(self, prospective, spec):
         # type: (ParsedVersion, str) -> bool
+
+        # NB: Local version identifiers are NOT permitted in the version
+        # specifier, so local version labels can be universally removed from
+        # the prospective version.
         return Version(prospective.public) >= Version(spec)
 
     @_require_version_compare

--- a/packaging/specifiers.py
+++ b/packaging/specifiers.py
@@ -516,12 +516,12 @@ class Specifier(_IndividualSpecifier):
     @_require_version_compare
     def _compare_less_than_equal(self, prospective, spec):
         # type: (ParsedVersion, str) -> bool
-        return prospective <= Version(spec)
+        return Version(prospective.public) <= Version(spec)
 
     @_require_version_compare
     def _compare_greater_than_equal(self, prospective, spec):
         # type: (ParsedVersion, str) -> bool
-        return prospective >= Version(spec)
+        return Version(prospective.public) >= Version(spec)
 
     @_require_version_compare
     def _compare_less_than(self, prospective, spec_str):

--- a/tests/test_specifiers.py
+++ b/tests/test_specifiers.py
@@ -976,3 +976,17 @@ class TestSpecifierSet:
     def test_comparison_non_specifier(self):
         assert SpecifierSet("==1.0") != 12
         assert not SpecifierSet("==1.0") == 12
+
+    @pytest.mark.parametrize(
+        ("version", "specifier", "expected"),
+        [
+            ("1.0.0+local", "==1.0.0", True),
+            ("1.0.0+local", "!=1.0.0", False),
+            ("1.0.0+local", "<=1.0.0", True),
+            ("1.0.0+local", ">=1.0.0", True),
+            ("1.0.0+local", "<1.0.0", False),
+            ("1.0.0+local", ">1.0.0", False),
+        ],
+    )
+    def test_comparison_ignores_local(self, version, specifier, expected):
+        assert (Version(version) in SpecifierSet(specifier)) == expected


### PR DESCRIPTION
Fixes #300.

PEP 440 specifies:

"If the specified version identifier is a public version identifier (no local version label), then the local version label of any candidate versions MUST be ignored when matching versions."

The existing equality comparison for a `SpecifierSet` removes the local version label before comparison, but the other two comparisons that also consider equality (LEQ/GEQ) do not do the same, resulting in this bug:

```python
>>> Version('1.0.0+1') in SpecifierSet("==1.0.0")
True
>>> Version('1.0.0+1') in SpecifierSet("<=1.0.0")
False
```

Note that we can _always_ ignore the local version label when checking for inclusion with specifiers using LEQ and GEQ, since when considering inclusive ordered comparison for specifiers, PEP 440 says:

> Local version identifiers are NOT permitted in this version specifier.

So the "<=" and ">=" specifiers will never have a local version label, unlike specifiers that use "==" or "!=".