### PR TITLE
cache Tag __hash__

### DIFF
--- a/packaging/tags.py
+++ b/packaging/tags.py
@@ -92,8 +92,8 @@ class Tag(object):
         self._abi = abi.lower()
         self._platform = platform.lower()
         # The __hash__ of every single element in a Set[Tag] will be evaluated each time
-        # that a set calls its `.disjoint()` method, which may be called hundreds of times
-        # when scanning a page of links for packages with tags matching that
+        # that a set calls its `.disjoint()` method, which may be called hundreds of
+        # times when scanning a page of links for packages with tags matching that
         # Set[Tag]. Pre-computing the value here produces significant speedups for
         # downstream consumers.
         self._hash = hash((self._interpreter, self._abi, self._platform))

--- a/packaging/tags.py
+++ b/packaging/tags.py
@@ -84,13 +84,19 @@ class Tag(object):
     is also supported.
     """
 
-    __slots__ = ["_interpreter", "_abi", "_platform"]
+    __slots__ = ["_interpreter", "_abi", "_platform", "_hash"]
 
     def __init__(self, interpreter, abi, platform):
         # type: (str, str, str) -> None
         self._interpreter = interpreter.lower()
         self._abi = abi.lower()
         self._platform = platform.lower()
+        # The __hash__ of every single element in a Set[Tag] will be evaluated each time
+        # that set calls its `.disjoint()` method, which may be called hundreds of times
+        # when scanning a page of links for packages with tags matching that
+        # Set[Tag]. Pre-computing the value here produces significant speedups for
+        # downstream consumers.
+        self._hash = hash((self._interpreter, self._abi, self._platform))
 
     @property
     def interpreter(self):
@@ -120,7 +126,7 @@ class Tag(object):
 
     def __hash__(self):
         # type: () -> int
-        return hash((self._interpreter, self._abi, self._platform))
+        return self._hash
 
     def __str__(self):
         # type: () -> str

--- a/packaging/tags.py
+++ b/packaging/tags.py
@@ -92,7 +92,7 @@ class Tag(object):
         self._abi = abi.lower()
         self._platform = platform.lower()
         # The __hash__ of every single element in a Set[Tag] will be evaluated each time
-        # that set calls its `.disjoint()` method, which may be called hundreds of times
+        # that a set calls its `.disjoint()` method, which may be called hundreds of times
         # when scanning a page of links for packages with tags matching that
         # Set[Tag]. Pre-computing the value here produces significant speedups for
         # downstream consumers.


### PR DESCRIPTION
*This is an awesome project!! I love how easy it was to make this fix!! ^_^*

### Problem

As described in pypa/pip#8480, the `__hash__` of a `packaging.tags.Tag` is calculated many times when the set `.disjoint()` method is called in `pip._internal.models.wheel.Wheel.supported()`.

### Solution

- Add a `_hash` slot to `Tag` and calculate the hash in the constructor.

### Result
A downstream consumer (pip) experiences a 10% speedup resolving `tensorflow==1.14.0`.

**Please let me know if this PR requires any further testing or documentation!!**