### PR TITLE
Fixed links in documentation.

### DIFF
--- a/docs/requirements.rst
+++ b/docs/requirements.rst
@@ -75,11 +75,11 @@ Reference
 
     .. attribute:: specifier
 
-      A :class:`SpecifierSet` of the version specified by the requirement.
+      A :class:`~.SpecifierSet` of the version specified by the requirement.
 
     .. attribute:: marker
 
-      A :class:`Marker` of the marker for the requirement. Can be None.
+      A :class:`~.Marker` of the marker for the requirement. Can be None.
 
 .. exception:: InvalidRequirement
 

--- a/docs/specifiers.rst
+++ b/docs/specifiers.rst
@@ -110,8 +110,8 @@ Reference
 
     .. method:: filter(iterable, prereleases=None)
 
-        Takes an iterable that can contain version strings, :class:`Version`,
-        and :class:`LegacyVersion` instances and will then filter it, returning
+        Takes an iterable that can contain version strings, :class:`~.Version`,
+        and :class:`~.LegacyVersion` instances and will then filter it, returning
         an iterable that contains only items which match the rules of this
         specifier object.
 

--- a/docs/tags.rst
+++ b/docs/tags.rst
@@ -4,7 +4,7 @@ Tags
 .. currentmodule:: packaging.tags
 
 Wheels encode the Python interpreter, ABI, and platform that they support in
-their filenames using *`platform compatibility tags`_*. This module provides
+their filenames using `platform compatibility tags`_. This module provides
 support for both parsing these tags as well as discovering what tags the
 running Python interpreter supports.
 


### PR DESCRIPTION
Hi,

Some "links" to other classes in the documentation were not actually hyperlinked, as Sphinx could not determine which class to actually link to. The links had been done like this:

```
:class:`SpecifierSet`
```

However, because "SpecifierSet" wasn't defined within that reST document, Sphinx didn't know what to link to. 

Instead, the links should be done like:

```
:class:`~.SpecifierSet`
```

A fully qualified name can also be used to avoid collisions, but I don't think there are any duplicated names in packaging.

There is also a hyperlink on https://packaging.pypa.io/en/latest/tags/ to the "platform compatibility tags" page on packaging.python.org, but the link was conflicting with asterisks added to make it italic. I've removed the asterisks, which makes the link work correctly but of course it's no longer italic. If you *really* want the link to be italic there is apparently a workaround, but its a bit of a hack: https://stackoverflow.com/a/10766650/3092681

Let me know if you'd like any changes.

