### PR TITLE
Fix `canonicalize_version` to accept Version instances

### DIFF
--- a/packaging/utils.py
+++ b/packaging/utils.py
@@ -24,7 +24,7 @@ def canonicalize_name(name):
 
 
 def canonicalize_version(version):
-    # type: (Union[Version, str]) -> str
+    # type: (Union[Version, str]) -> Union[Version, str]
     """
     This is very similar to Version.__str__, but has one subtle difference
     with the way it handles the release segment.
@@ -34,7 +34,7 @@ def canonicalize_version(version):
             version = Version(version)
         except InvalidVersion:
             # Legacy versions cannot be normalized
-            return _version
+            return version
 
     parts = []
 

--- a/packaging/utils.py
+++ b/packaging/utils.py
@@ -23,18 +23,18 @@ def canonicalize_name(name):
     return cast("NormalizedName", value)
 
 
-def canonicalize_version(_version):
-    # type: (str) -> Union[Version, str]
+def canonicalize_version(version):
+    # type: (Union[Version, str]) -> str
     """
     This is very similar to Version.__str__, but has one subtle difference
     with the way it handles the release segment.
     """
-
-    try:
-        version = Version(_version)
-    except InvalidVersion:
-        # Legacy versions cannot be normalized
-        return _version
+    if not isinstance(version, Version):
+        try:
+            version = Version(version)
+        except InvalidVersion:
+            # Legacy versions cannot be normalized
+            return _version
 
     parts = []
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, division, print_function
 import pytest
 
 from packaging.utils import canonicalize_name, canonicalize_version
+from packaging.version import Version
 
 
 @pytest.mark.parametrize(
@@ -30,6 +31,7 @@ def test_canonicalize_name(name, expected):
 @pytest.mark.parametrize(
     ("version", "expected"),
     [
+        (Version("1.4.0"), "1.4"),
         ("1.4.0", "1.4"),
         ("1.40.0", "1.40"),
         ("1.4.0.0.00.000.0000", "1.4"),


### PR DESCRIPTION
Docs say it is supported https://packaging.pypa.io/en/latest/utils/#packaging.utils.canonicalize_version