### PR TITLE
Make NormalizedName visible at runtime

### DIFF
--- a/packaging/utils.py
+++ b/packaging/utils.py
@@ -12,6 +12,8 @@ if TYPE_CHECKING:  # pragma: no cover
     from typing import NewType, Union
 
     NormalizedName = NewType("NormalizedName", str)
+else:
+    NormalizedName = str
 
 _canonicalize_regex = re.compile(r"[-_.]+")
 


### PR DESCRIPTION
I'm writing a python 3 program and I'd like to use the `canonicalize_name` function and it's return type `NormalizedName` type. It seems I can't because the type is hidden behind the `TYPE_CHECKING` guard and is therefore not available at runtime. This mean I cannot currently write this:

```python
from packaging.utils import NormalizedName

def my_function(name: NormalizedName) -> None:
    ...
```

This PR is an attempt to work around this.