### PR TITLE
Remove dependency on six to make package lighter

### DIFF
--- a/packaging/requirements.py
+++ b/packaging/requirements.py
@@ -5,15 +5,21 @@ from __future__ import absolute_import, division, print_function
 
 import string
 import re
+import sys
 
 from pyparsing import stringStart, stringEnd, originalTextFor, ParseException
 from pyparsing import ZeroOrMore, Word, Optional, Regex, Combine
 from pyparsing import Literal as L  # noqa
-from six.moves.urllib import parse as urlparse
 
 from ._typing import TYPE_CHECKING
 from .markers import MARKER_EXPR, Marker
 from .specifiers import LegacySpecifier, Specifier, SpecifierSet
+
+if sys.version_info[0] >= 3:
+    from urllib import parse as urlparse  # pragma: no cover
+else:  # pragma: no cover
+    import urlparse
+
 
 if TYPE_CHECKING:  # pragma: no cover
     from typing import List

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
     author=about["__author__"],
     author_email=about["__email__"],
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
-    install_requires=["pyparsing>=2.0.2", "six"],  # Needed to avoid issue #91
+    install_requires=["pyparsing>=2.0.2"],  # Needed to avoid issue #91
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",


### PR DESCRIPTION
From @pradyunsg in [https://discuss.python.org](https://discuss.python.org/t/split-tags-into-a-separate-package/4965/17?u=hugovk):

> Honestly, I think the “best” solution is to make packaging not have dependencies. This would involve dropping pyparsing and six.
>
> Both of them are used only in `packaging.requirements` . pyparsing is used to generate the parser for PEP 508 requirements. six is used for getting `urlib.urlparse.urlparse` in a Py2-Py3 compatible way. six should be super easy to drop (PRs welcome!) ...

---

What's the best way to deal with mypy for the `try`/`except ImportError`?

```console
$ pre-commit run --all-files
Check Toml...........................................(no files to check)Skipped
Check Yaml...............................................................Passed
Fix End of Files.........................................................Passed
Trim Trailing Whitespace.................................................Passed
mypy.....................................................................Failed
- hook id: mypy
- exit code: 1

packaging/requirements.py:12: error: Name 'urlparse' already defined (by an import)
Found 1 error in 1 file (checked 12 source files)

mypy for Python 2........................................................Failed
- hook id: mypy
- exit code: 1

packaging/requirements.py:10: error: Module 'urllib' has no attribute 'parse'
packaging/requirements.py:12: error: Name 'urlparse' already defined (possibly by an import)
Found 2 errors in 1 file (checked 11 source files)

black....................................................................Passed
flake8...................................................................Passed
check-manifest...........................................................Passed
```
