### PR TITLE
Fix GitHub Actions to run under pypy2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,11 +65,11 @@ jobs:
         run: |
           python -m nox --error-on-missing-interpreters -s tests-${{ matrix.python_version }}
         shell: bash
-        if: matrix.python_version != "pypy2"
+        if: matrix.python_version != 'pypy2'
 
       # Binary is named 'pypy', but setup-python specifies it as 'pypy2'.
       - name: Run nox for pypy2
         run: |
           python -m nox --error-on-missing-interpreters -s tests-pypy
         shell: bash
-        if: matrix.python_version == "pypy2"
+        if: matrix.python_version == 'pypy2'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,12 +3,12 @@ name: Test
 on:
   pull_request:
     paths:
-      - '.github/workflows/test.yml'
-      - '**.py'
+      - ".github/workflows/test.yml"
+      - "**.py"
   push:
     paths:
-      - '.github/workflows/test.yml'
-      - '**.py'
+      - ".github/workflows/test.yml"
+      - "**.py"
 
 jobs:
   test:
@@ -19,48 +19,58 @@ jobs:
       matrix:
         os: [Ubuntu, Windows, macOS]
         # Python 3.4 is not available from actions/setup-python@v2.
-        python_version: ['2.7', '3.5', '3.6', '3.7', '3.8', '3.9', 'pypy2', 'pypy3']
+        python_version:
+          ["2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "pypy2", "pypy3"]
         exclude:
           # This is failing due to pip not being in the virtual environment.
           # https://github.com/pypa/packaging/runs/424785871#step:7:9
           - os: windows
             python_version: pypy3
+          # Symlinking not supported on Windows and it's required to make
+          # setup-python and nox happy (issue #348).
+          - os: windows
+            python_version: pypy2
 
     steps:
-    - uses: actions/checkout@v1
+      - uses: actions/checkout@v1
 
-    - uses: actions/setup-python@v2
-      name: Install Python ${{ matrix.python_version }}
-      with:
-        python-version: ${{ matrix.python_version }}
+      - uses: actions/setup-python@v2
+        name: Install Python ${{ matrix.python_version }}
+        with:
+          python-version: ${{ matrix.python_version }}
 
-    # Set `python` to a recent 3.x version if we're not testing Python 3.6+.
-    #    Why? Nox needs Python 3.5+ and everyone likes f-strings.
-    - uses: actions/setup-python@v2
-      name: Install Python 3.x
-      with:
-        python-version: 3.x
-      if: >
-        (
-          matrix.python_version == '2.7' ||
-          matrix.python_version == 'pypy2' ||
-          matrix.python_version == '3.5'
-        )
+      # Set `python` to a recent 3.x version if we're not testing Python 3.6+.
+      #    Why? Nox needs Python 3.5+ and everyone likes f-strings.
+      - uses: actions/setup-python@v2
+        name: Install Python 3.x
+        with:
+          python-version: 3.x
+        if: >
+          (
+            matrix.python_version == '2.7' ||
+            matrix.python_version == 'pypy2' ||
+            matrix.python_version == '3.5'
+          )
 
-    # Workaround https://github.com/theacodes/nox/issues/250
-    - name: Workaround for Windows Python 2.7
-      # This is in PATH, so nox resolves to it - but then subsequent steps fail.
-      run: rm C:/ProgramData/Chocolatey/bin/python2.7.exe
-      shell: bash
-      if: runner.os == 'Windows' && matrix.python_version == '2.7'
+      # Workaround https://github.com/theacodes/nox/issues/250
+      - name: Workaround for Windows Python 2.7
+        # This is in PATH, so nox resolves to it - but then subsequent steps fail.
+        run: rm C:/ProgramData/Chocolatey/bin/python2.7.exe
+        shell: bash
+        if: runner.os == 'Windows' && matrix.python_version == '2.7'
 
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install nox
-      shell: bash
+      - name: alias pypy to pypy2
+        run: ln -s ${{ env.pythonLocation }}/pypy ${{ env.pythonLocation }}/pypy2
+        shell: bash
+        if: matrix.python_version == 'pypy2'
 
-    - name: Run nox
-      run: |
-        python -m nox -s tests-${{ matrix.python_version }}
-      shell: bash
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install nox
+        shell: bash
+
+      - name: Run nox
+        run: |
+          python -m nox --error-on-missing-interpreters -s tests-${{ matrix.python_version }}
+        shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,10 +26,6 @@ jobs:
           # https://github.com/pypa/packaging/runs/424785871#step:7:9
           - os: windows
             python_version: pypy3
-          # Symlinking not supported on Windows and it's required to make
-          # setup-python and nox happy (issue #348).
-          - os: windows
-            python_version: pypy2
 
     steps:
       - uses: actions/checkout@v1
@@ -59,11 +55,6 @@ jobs:
         shell: bash
         if: runner.os == 'Windows' && matrix.python_version == '2.7'
 
-      - name: alias pypy to pypy2
-        run: ln -s ${{ env.pythonLocation }}/pypy ${{ env.pythonLocation }}/pypy2
-        shell: bash
-        if: matrix.python_version == 'pypy2'
-
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -74,3 +65,11 @@ jobs:
         run: |
           python -m nox --error-on-missing-interpreters -s tests-${{ matrix.python_version }}
         shell: bash
+        if: matrix.python_version != "pypy2"
+
+      # Binary is named 'pypy', but setup-python specifies it as 'pypy2'.
+      - name: Run nox for pypy2
+        run: |
+          python -m nox --error-on-missing-interpreters -s tests-pypy
+        shell: bash
+        if: matrix.python_version == "pypy2"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ matrix:
     - python: 2.7
       env: NOXSESSION=tests-2.7
     - python: pypy
-      env: NOXSESSION=tests-pypy2
+      env: NOXSESSION=tests-pypy
     - python: pypy3
       env: NOXSESSION=tests-pypy3
     - python: 3.4

--- a/noxfile.py
+++ b/noxfile.py
@@ -20,7 +20,7 @@ nox.options.sessions = ["lint"]
 nox.options.reuse_existing_virtualenvs = True
 
 
-@nox.session(python=["2.7", "3.4", "3.5", "3.6", "3.7", "3.8", "3.9", "pypy2", "pypy3"])
+@nox.session(python=["2.7", "3.4", "3.5", "3.6", "3.7", "3.8", "3.9", "pypy", "pypy3"])
 def tests(session):
     def coverage(*args):
         session.run("python", "-m", "coverage", *args)
@@ -185,8 +185,7 @@ def _get_version_from_arguments(arguments):
 
 
 def _check_working_directory_state(session):
-    """Check state of the working directory, prior to making the release.
-    """
+    """Check state of the working directory, prior to making the release."""
     should_not_exist = ["build/", "dist/"]
 
     bad_existing_paths = list(filter(os.path.exists, should_not_exist))
@@ -195,8 +194,7 @@ def _check_working_directory_state(session):
 
 
 def _check_git_state(session, version_tag):
-    """Check state of the git repository, prior to making the release.
-    """
+    """Check state of the git repository, prior to making the release."""
     # Ensure the upstream remote pushes to the correct URL.
     allowed_upstreams = [
         "git@github.com:pypa/packaging.git",
@@ -269,8 +267,7 @@ def _replace_file(original_path):
 
 
 def _changelog_update_unreleased_title(version, *, file):
-    """Update an "*unreleased*" heading to "{version} - {date}"
-    """
+    """Update an "*unreleased*" heading to "{version} - {date}" """
     yyyy_mm_dd = datetime.datetime.today().strftime("%Y-%m-%d")
     title = f"{version} - {yyyy_mm_dd}"
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -86,7 +86,7 @@ def docs(session):
 def release(session):
     package_name = "packaging"
     version_file = Path(f"{package_name}/__about__.py")
-    changelog_file = Path(f"CHANGELOG.rst")
+    changelog_file = Path("CHANGELOG.rst")
 
     try:
         release_version = _get_version_from_arguments(session.posargs)
@@ -129,7 +129,7 @@ def release(session):
     session.run("python", "setup.py", "sdist", "bdist_wheel")
 
     # Check what files are in dist/ for upload.
-    files = sorted(glob.glob(f"dist/*"))
+    files = sorted(glob.glob("dist/*"))
     expected = [
         f"dist/{package_name}-{release_version}-py2.py3-none-any.whl",
         f"dist/{package_name}-{release_version}.tar.gz",
@@ -222,7 +222,7 @@ def _check_git_state(session, version_tag):
     )
     if result.stdout:
         print(result.stdout, end="", file=sys.stderr)
-        session.error(f"The working tree has uncommitted changes")
+        session.error("The working tree has uncommitted changes")
 
     # Ensure this tag doesn't exist already.
     result = subprocess.run(
@@ -244,7 +244,7 @@ def _bump(session, *, version, file, kind):
     )
     file.write_text(new_contents)
 
-    session.log(f"git commit")
+    session.log("git commit")
     subprocess.run(["git", "add", str(file)])
     subprocess.run(["git", "commit", "-m", f"Bump for {kind}"])
 

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -566,7 +566,7 @@ class TestManylinuxPlatform:
             "executable",
             os.path.join(os.path.dirname(__file__), "hello-world-aarch64"),
         )
-        platforms = list(tags._linux_platforms())
+        platforms = list(tags._linux_platforms(is_32bit=False))
         expected = (
             ["manylinux_3_2_aarch64", "manylinux_3_1_aarch64", "manylinux_3_0_aarch64"]
             + ["manylinux_2_{}_aarch64".format(i) for i in range(50, 16, -1)]
@@ -1279,7 +1279,7 @@ class TestSysTags:
             manylinux_compatible,
             raising=False,
         )
-        platforms = list(tags._linux_platforms())
+        platforms = list(tags._linux_platforms(is_32bit=False))
         if tf:
             expected = ["manylinux_2_22_{}".format(machine)]
         else:
@@ -1301,7 +1301,7 @@ class TestSysTags:
             manylinux_compatible,
             raising=False,
         )
-        platforms = list(tags._linux_platforms())
+        platforms = list(tags._linux_platforms(is_32bit=False))
         expected = [
             "manylinux_2_30_x86_64",
             "manylinux_2_29_x86_64",


### PR DESCRIPTION
Required setting up a special "run pypy2" step to deal with the discrepancy of setup-python taking "pypy2" but the actual executable -- and thus what nox wants -- being "pypy".

In the process, also fix some failing manylinux tests where the bit-ness for the architecture wasn't forced, thus failing under PyPy2 for Windows which is 32-bit.

Closes #348