### PR TITLE
PEP 641: Use an underscore in the version portion of Python 3.10 compatibility tag

### DIFF
--- a/packaging/tags.py
+++ b/packaging/tags.py
@@ -782,14 +782,13 @@ def interpreter_name():
 def interpreter_version(**kwargs):
     # type: (bool) -> str
     """
-    Returns the version of the running interpreter.
+    Returns the version of the running interpreter for the wheel tag.
+
+    See https://www.python.org/dev/peps/pep-0641/
     """
-    warn = _warn_keyword_parameter("interpreter_version", kwargs)
-    version = _get_config_var("py_version_nodot", warn=warn)
-    if version:
-        version = str(version)
-    else:
-        version = _version_nodot(sys.version_info[:2])
+    # warn kw only parameter is unused, kept for backwards compatibility
+    _warn_keyword_parameter("interpreter_version", kwargs)
+    version = _version_nodot(sys.version_info[:2])
     return version
 
 

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -172,24 +172,13 @@ class TestInterpreterName:
 
 
 class TestInterpreterVersion:
-    def test_warn(self, monkeypatch):
-        class MockConfigVar(object):
-            def __init__(self, return_):
-                self.warn = None
-                self._return = return_
+    def test_python_version_nodot_underscore(self, monkeypatch):
+        monkeypatch.setattr(sys, "version_info", (3, 20, 12))
+        assert tags.interpreter_version() == "3_20"
 
-            def __call__(self, name, warn):
-                self.warn = warn
-                return self._return
-
-        mock_config_var = MockConfigVar("38")
-        monkeypatch.setattr(tags, "_get_config_var", mock_config_var)
-        tags.interpreter_version(warn=True)
-        assert mock_config_var.warn
-
-    def test_python_version_nodot(self, monkeypatch):
-        monkeypatch.setattr(tags, "_get_config_var", lambda var, warn: "NN")
-        assert tags.interpreter_version() == "NN"
+    def test_python_version_nodot_no_underscore(self, monkeypatch):
+        monkeypatch.setattr(sys, "version_info", (3, 9, 12))
+        assert tags.interpreter_version() == "39"
 
     @pytest.mark.parametrize(
         "version_info,version_str",


### PR DESCRIPTION
Regardless of the py_version_nodot variable.

See https://www.python.org/dev/peps/pep-0641/
See https://github.com/python/cpython/pull/22858#issuecomment-720608651

See also https://github.com/pypa/packaging/pull/355