### PR TITLE
Support "macosx_10_9_universal2" wheels

### DIFF
--- a/packaging/tags.py
+++ b/packaging/tags.py
@@ -461,12 +461,12 @@ def mac_platforms(version=None, arch=None):
     if version >= (11, 0):
         # Mac OS 11 on x86_64 is compatible with binaries from previous releases.
         # Arm64 support was introduced in 11.0, so no Arm binaries from previous
-        # releases exist. 
+        # releases exist.
         #
         # However, the "universal2" binary format can have a
         # macOS version earlier than 11.0 when the x86_64 part of the binary supports
         # that version of macOS.
-        if arch == 'x86_64':
+        if arch == "x86_64":
             for minor_version in range(16, 3, -1):
                 compat_version = 10, minor_version
                 binary_formats = _mac_binary_formats(compat_version, arch)
@@ -479,14 +479,12 @@ def mac_platforms(version=None, arch=None):
         else:
             for minor_version in range(16, 3, -1):
                 compat_version = 10, minor_version
-                binary_format='universal2'
+                binary_format = "universal2"
                 yield "macosx_{major}_{minor}_{binary_format}".format(
                     major=compat_version[0],
                     minor=compat_version[1],
                     binary_format=binary_format,
                 )
-
-
 
 
 # From PEP 513, PEP 600

--- a/packaging/tags.py
+++ b/packaging/tags.py
@@ -458,19 +458,35 @@ def mac_platforms(version=None, arch=None):
                     major=major_version, minor=0, binary_format=binary_format
                 )
 
-    if version >= (11, 0) and arch == "x86_64":
+    if version >= (11, 0):
         # Mac OS 11 on x86_64 is compatible with binaries from previous releases.
         # Arm64 support was introduced in 11.0, so no Arm binaries from previous
-        # releases exist.
-        for minor_version in range(16, 3, -1):
-            compat_version = 10, minor_version
-            binary_formats = _mac_binary_formats(compat_version, arch)
-            for binary_format in binary_formats:
+        # releases exist. 
+        #
+        # However, the "universal2" binary format can have a
+        # macOS version earlier than 11.0 when the x86_64 part of the binary supports
+        # that version of macOS.
+        if arch == 'x86_64':
+            for minor_version in range(16, 3, -1):
+                compat_version = 10, minor_version
+                binary_formats = _mac_binary_formats(compat_version, arch)
+                for binary_format in binary_formats:
+                    yield "macosx_{major}_{minor}_{binary_format}".format(
+                        major=compat_version[0],
+                        minor=compat_version[1],
+                        binary_format=binary_format,
+                    )
+        else:
+            for minor_version in range(16, 3, -1):
+                compat_version = 10, minor_version
+                binary_format='universal2'
                 yield "macosx_{major}_{minor}_{binary_format}".format(
                     major=compat_version[0],
                     minor=compat_version[1],
                     binary_format=binary_format,
                 )
+
+
 
 
 # From PEP 513, PEP 600

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -266,7 +266,9 @@ class TestMacOSPlatforms:
             )
         version = platform.mac_ver()[0].split(".")
         if version[0] == 10:
-            expected = "macosx_{major}_{minor}".format(major=version[0], minor=version[1])
+            expected = "macosx_{major}_{minor}".format(
+                major=version[0], minor=version[1]
+            )
         else:
             expected = "macosx_{major}_{minor}".format(major=version[0], minor=0)
         platforms = list(tags.mac_platforms(arch="x86_64"))

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -265,7 +265,7 @@ class TestMacOSPlatforms:
                 platform, "mac_ver", lambda: ("10.14", ("", "", ""), "x86_64")
             )
         version = platform.mac_ver()[0].split(".")
-        if version[0] == '10':
+        if version[0] == "10":
             expected = "macosx_{major}_{minor}".format(
                 major=version[0], minor=version[1]
             )

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -265,7 +265,7 @@ class TestMacOSPlatforms:
                 platform, "mac_ver", lambda: ("10.14", ("", "", ""), "x86_64")
             )
         version = platform.mac_ver()[0].split(".")
-        if version[0] == 10:
+        if version[0] == '10':
             expected = "macosx_{major}_{minor}".format(
                 major=version[0], minor=version[1]
             )

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -316,6 +316,7 @@ class TestMacOSPlatforms:
         # with the environment variable SYSTEM_VERSION_COMPAT=1.
         assert "macosx_10_16_x86_64" in platforms
         assert "macosx_10_15_x86_64" in platforms
+        assert "macosx_10_15_universal2" in platforms
         assert "macosx_10_4_x86_64" in platforms
         assert "macosx_10_3_x86_64" not in platforms
         if major >= 12:
@@ -328,6 +329,7 @@ class TestMacOSPlatforms:
         assert "macosx_11_3_arm64" not in platforms
         assert "macosx_11_0_universal" not in platforms
         assert "macosx_11_0_universal2" in platforms
+        assert "macosx_10_15_universal2" in platforms
         assert "macosx_10_15_x86_64" not in platforms
         assert "macosx_10_4_x86_64" not in platforms
         assert "macosx_10_3_x86_64" not in platforms

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -265,8 +265,12 @@ class TestMacOSPlatforms:
                 platform, "mac_ver", lambda: ("10.14", ("", "", ""), "x86_64")
             )
         version = platform.mac_ver()[0].split(".")
-        expected = "macosx_{major}_{minor}".format(major=version[0], minor=version[1])
+        if version[0] == 10:
+            expected = "macosx_{major}_{minor}".format(major=version[0], minor=version[1])
+        else:
+            expected = "macosx_{major}_{minor}".format(major=version[0], minor=0)
         platforms = list(tags.mac_platforms(arch="x86_64"))
+        print(platforms, expected)
         assert platforms[0].startswith(expected)
 
     @pytest.mark.parametrize("arch", ["x86_64", "i386"])


### PR DESCRIPTION
This PR fixes #379 and adds support for "universal2" wheels where the macOS version is lower than macOS 11.

The first commit ensures that tests pass on macOS 11.1 and is technically unrelated to the issue.