### PR TITLE
Change the return type for the build number portion of utils.parse_wheel_filename()

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog
 ~~~~~~~~~~~~
 
 * Run [isort](https://pypi.org/project/isort/) over the code base (:issue:`377`)
-* Add support for the ``macosx_10_9_universal2`` platform tag (:issue:`379`)
+* Add support for the ``macosx_10_*_universal2`` platform tags (:issue:`379`)
 * Introduce ``packaging.utils.parse_wheel_filename()`` and ``parse_sdist_filename()``
   (:issue:`387` and :issue:`389`)
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,10 @@ Changelog
 *unreleased*
 ~~~~~~~~~~~~
 
-No unreleased changes.
+* Run [isort](https://pypi.org/project/isort/) over the code base (:issue:`377`)
+* Add support for the ``macosx_10_9_universal2`` platform tag (:issue:`379`)
+* Introduce ``packaging.utils.parse_wheel_filename()`` and ``parse_sdist_filename()``
+  (:issue:`387` and :issue:`389`)
 
 20.8 - 2020-12-11
 ~~~~~~~~~~~~~~~~~

--- a/docs/utils.rst
+++ b/docs/utils.rst
@@ -30,7 +30,8 @@ Reference
 .. function:: canonicalize_version(version)
 
     This function takes a string representing a package version (or a
-    ``Version`` instance), and returns the normalized form of it.
+    :class:`~packaging.version.Version` instance), and returns the
+    normalized form of it.
 
     :param str version: The version to normalize.
 
@@ -43,9 +44,14 @@ Reference
 .. function:: parse_wheel_filename(filename)
 
     This function takes the filename of a wheel file, and parses it,
-    returning a tuple of name, version, build number and tags. The
-    build number will be ``None`` if there is no build number in the
-    wheel filename.
+    returning a tuple of name, version, build number, and tags.
+
+    The name part of the tuple is normalized. The version portion is an
+    instance of :class:`~packaging.version.Version`. The build number
+    is``()`` if there is no build number in the wheel filename,
+    otherwise a two-item tuple of an integer for the leading digits and
+    a string for the rest of the build number. The tags portion is an
+    instance of :class:`~packaging.tags.Tag`.
 
     :param str filename: The name of the wheel file.
 
@@ -53,31 +59,34 @@ Reference
 
         >>> from packaging.utils import parse_wheel_filename
         >>> from packaging.tags import Tag
+        >>> from packaging.version import Version
         >>> name, ver, build, tags = parse_wheel_filename("foo-1.0-py3-none-any.whl")
         >>> name
         'foo'
-        >>> ver
-        <Version('1.0')>
+        >>> ver == Version('1.0')
+        True
         >>> tags == {Tag("py3", "none", "any")}
         True
-        >>> build is None
+        >>> not build
         True
 
 .. function:: parse_sdist_filename(filename)
 
     This function takes the filename of a sdist file (as specified
     in the `Source distribution format`_ documentation), and parses
-    it, returning a tuple of name and version.
+    it, returning a tuple of the normalized name and version as
+    represented by an instance of :class:`~packaging.version.Version`.
 
     :param str filename: The name of the sdist file.
 
     .. doctest::
 
         >>> from packaging.utils import parse_sdist_filename
+        >>> from packaging.version import Version
         >>> name, ver = parse_sdist_filename("foo-1.0.tar.gz")
         >>> name
         'foo'
-        >>> ver
-        <Version('1.0')>
+        >>> ver == Version('1.0')
+        True
 
 .. _Source distribution format: https://packaging.python.org/specifications/source-distribution-format/#source-distribution-file-name

--- a/docs/utils.rst
+++ b/docs/utils.rst
@@ -48,7 +48,7 @@ Reference
 
     The name part of the tuple is normalized. The version portion is an
     instance of :class:`~packaging.version.Version`. The build number
-    is``()`` if there is no build number in the wheel filename,
+    is ``()`` if there is no build number in the wheel filename,
     otherwise a two-item tuple of an integer for the leading digits and
     a string for the rest of the build number. The tags portion is an
     instance of :class:`~packaging.tags.Tag`.

--- a/packaging/utils.py
+++ b/packaging/utils.py
@@ -10,10 +10,12 @@ from .tags import Tag, parse_tag
 from .version import InvalidVersion, Version
 
 if TYPE_CHECKING:  # pragma: no cover
-    from typing import FrozenSet, NewType, Optional, Tuple, Union
+    from typing import FrozenSet, NewType, Tuple, Union
 
+    BuildTag = Union[Tuple[()], Tuple[int, str]]
     NormalizedName = NewType("NormalizedName", str)
 else:
+    BuildTag = tuple
     NormalizedName = str
 
 
@@ -30,13 +32,15 @@ class InvalidSdistFilename(ValueError):
 
 
 _canonicalize_regex = re.compile(r"[-_.]+")
+# PEP 427: The build number must start with a digit.
+_build_tag_regex = re.compile(r"(\d+)(.*)")
 
 
 def canonicalize_name(name):
     # type: (str) -> NormalizedName
     # This is taken from PEP 503.
     value = _canonicalize_regex.sub("-", name).lower()
-    return cast("NormalizedName", value)
+    return cast(NormalizedName, value)
 
 
 def canonicalize_version(version):
@@ -82,7 +86,7 @@ def canonicalize_version(version):
 
 
 def parse_wheel_filename(filename):
-    # type: (str) -> Tuple[NormalizedName, Version, Optional[str], FrozenSet[Tag]]
+    # type: (str) -> Tuple[NormalizedName, Version, BuildTag, FrozenSet[Tag]]
     if not filename.endswith(".whl"):
         raise InvalidWheelFilename(
             "Invalid wheel filename (extension must be '.whl'): {0}".format(filename)
@@ -103,15 +107,15 @@ def parse_wheel_filename(filename):
     name = canonicalize_name(name_part)
     version = Version(parts[1])
     if dashes == 5:
-        # Build number must start with a digit
         build_part = parts[2]
-        if not build_part[0].isdigit():
+        build_match = _build_tag_regex.match(build_part)
+        if build_match is None:
             raise InvalidWheelFilename(
                 "Invalid build number: {0} in '{1}'".format(build_part, filename)
             )
-        build = build_part  # type: Optional[str]
+        build = cast(BuildTag, (int(build_match.group(1)), build_match.group(2)))
     else:
-        build = None
+        build = ()
     tags = parse_tag(parts[-1])
     return (name, version, build, tags)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -64,14 +64,21 @@ def test_canonicalize_version(version, expected):
             "foo-1.0-py3-none-any.whl",
             "foo",
             Version("1.0"),
-            None,
+            (),
             {Tag("py3", "none", "any")},
         ),
         (
             "foo-1.0-1000-py3-none-any.whl",
             "foo",
             Version("1.0"),
-            "1000",
+            (1000, ""),
+            {Tag("py3", "none", "any")},
+        ),
+        (
+            "foo-1.0-1000abc-py3-none-any.whl",
+            "foo",
+            Version("1.0"),
+            (1000, "abc"),
             {Tag("py3", "none", "any")},
         ),
     ],
@@ -83,11 +90,13 @@ def test_parse_wheel_filename(filename, name, version, build, tags):
 @pytest.mark.parametrize(
     ("filename"),
     [
-        ("foo-1.0.wheel"),
-        ("foo__bar-1.0-py3-none-any.whl"),
-        ("foo#bar-1.0-py3-none-any.whl"),
+        ("foo-1.0.whl"),  # Missing tags
+        ("foo-1.0-py3-none-any.wheel"),  # Incorrect file extension (`.wheel`)
+        ("foo__bar-1.0-py3-none-any.whl"),  # Multiple underscores in name (`__`)
+        ("foo#bar-1.0-py3-none-any.whl"),  # Octothorpe (`#`)
+        # Build tag doesn't start with a digit (`abc`)
         ("foo-1.0-abc-py3-none-any.whl"),
-        ("foo-1.0-200-py3-none-any-junk.whl"),
+        ("foo-1.0-200-py3-none-any-junk.whl"),  # Too many dashes (e.g. `-junk`)
     ],
 )
 def test_parse_wheel_invalid_filename(filename):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -92,11 +92,11 @@ def test_parse_wheel_filename(filename, name, version, build, tags):
     [
         ("foo-1.0.whl"),  # Missing tags
         ("foo-1.0-py3-none-any.wheel"),  # Incorrect file extension (`.wheel`)
-        ("foo__bar-1.0-py3-none-any.whl"),  # Multiple underscores in name (`__`)
-        ("foo#bar-1.0-py3-none-any.whl"),  # Octothorpe (`#`)
-        # Build tag doesn't start with a digit (`abc`)
+        ("foo__bar-1.0-py3-none-any.whl"),  # Invalid name (`__`)
+        ("foo#bar-1.0-py3-none-any.whl"),  # Invalid name (`#`)
+        # Build number doesn't start with a digit (`abc`)
         ("foo-1.0-abc-py3-none-any.whl"),
-        ("foo-1.0-200-py3-none-any-junk.whl"),  # Too many dashes (e.g. `-junk`)
+        ("foo-1.0-200-py3-none-any-junk.whl"),  # Too many dashes (`-junk`)
     ],
 )
 def test_parse_wheel_invalid_filename(filename):


### PR DESCRIPTION
Switching to `()` or `(int, str)` aligns with what PEP 427 expects and allows for easier sorting by build number.

Closes #389