### PR TITLE
Fix type hints for Version.post and Version.dev

### DIFF
--- a/packaging/version.py
+++ b/packaging/version.py
@@ -372,12 +372,12 @@ class Version(_BaseVersion):
 
     @property
     def post(self):
-        # type: () -> Optional[Tuple[str, int]]
+        # type: () -> Optional[int]
         return self._version.post[1] if self._version.post else None
 
     @property
     def dev(self):
-        # type: () -> Optional[Tuple[str, int]]
+        # type: () -> Optional[int]
         return self._version.dev[1] if self._version.dev else None
 
     @property


### PR DESCRIPTION
Minor fix to the type hints of Version.post and Version.dev properties
Previous type hint was Optional[str, int] but I believe Optional[int] is correct for these two