### PR TITLE
Remove __future__ import from developer docs

### DIFF
--- a/docs/development/submitting-patches.rst
+++ b/docs/development/submitting-patches.rst
@@ -32,13 +32,6 @@ Every code file must start with the boilerplate licensing notice:
     # 2.0, and the BSD License. See the LICENSE file in the root of this repository
     # for complete details.
 
-Additionally, every Python code file must contain
-
-.. code-block:: python
-
-    from __future__ import absolute_import, division, print_function
-
-
 Tests
 -----
 


### PR DESCRIPTION
Python 2 support was recently dropped, therefore this is no longer necessary.