### PR TITLE
chore: run pre-commit autoupdate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
+    rev: v3.4.0
     hooks:
       - id: check-toml
       - id: check-yaml
@@ -8,24 +8,24 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.790
+    rev: v0.812
     hooks:
       - id: mypy
         exclude: '^(docs|tasks|tests)|setup\.py'
         args: []
 
   - repo: https://github.com/psf/black
-    rev: 19.3b0
+    rev: 20.8b1
     hooks:
       - id: black
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.6.4
+    rev: 5.8.0
     hooks:
       - id: isort
 
   - repo: https://gitlab.com/PyCQA/flake8
-    rev: "3.7.8"
+    rev: "3.9.0"
     hooks:
       - id: flake8
         additional_dependencies: ["pep8-naming"]

--- a/packaging/tags.py
+++ b/packaging/tags.py
@@ -60,7 +60,7 @@ _LEGACY_MANYLINUX_MAP = {
 # be 50 for testing. Once this actually happens, update the dictionary
 # with the actual value.
 _LAST_GLIBC_MINOR: Dict[int, int] = collections.defaultdict(lambda: 50)
-glibcVersion = collections.namedtuple("Version", ["major", "minor"])
+glibcVersion = collections.namedtuple("glibcVersion", ["major", "minor"])
 
 
 class Tag:

--- a/packaging/utils.py
+++ b/packaging/utils.py
@@ -79,7 +79,7 @@ def canonicalize_version(version: Union[Version, str]) -> str:
 
 
 def parse_wheel_filename(
-    filename: str
+    filename: str,
 ) -> Tuple[NormalizedName, Version, BuildTag, FrozenSet[Tag]]:
     if not filename.endswith(".whl"):
         raise InvalidWheelFilename(


### PR DESCRIPTION
Runs pre-commit autoupdate, black changed slightly, and mypy now complains if a namedtuple's name does not match the variable it gets saved to.
