### PR TITLE
style: add pyupgrade to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,12 @@ repos:
         exclude: '^(docs|tasks|tests)|setup\.py'
         args: []
 
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v2.29.0
+    hooks:
+      - id: pyupgrade
+        args: [--py36-plus]
+
   - repo: https://github.com/psf/black
     rev: 20.8b1
     hooks:

--- a/tests/test_markers.py
+++ b/tests/test_markers.py
@@ -68,7 +68,7 @@ class TestNode:
 
     @pytest.mark.parametrize("value", ["one", "two", None, 3, 5, []])
     def test_repr(self, value):
-        assert repr(Node(value)) == "<Node({!r})>".format(str(value))
+        assert repr(Node(value)) == f"<Node({str(value)!r})>"
 
     def test_base_class(self):
         with pytest.raises(NotImplementedError):
@@ -205,7 +205,7 @@ class TestMarker:
     def test_str_and_repr(self, marker_string, expected):
         m = Marker(marker_string)
         assert str(m) == expected
-        assert repr(m) == "<Marker({!r})>".format(str(m))
+        assert repr(m) == f"<Marker({str(m)!r})>"
 
     def test_extra_with_no_extra_in_environment(self):
         # We can't evaluate an extra if no extra is passed into the environment

--- a/tests/test_specifiers.py
+++ b/tests/test_specifiers.py
@@ -227,7 +227,7 @@ class TestSpecifier:
         spec = Specifier(specifier)
 
         assert str(spec) == expected
-        assert repr(spec) == "<Specifier({!r})>".format(expected)
+        assert repr(spec) == f"<Specifier({expected!r})>"
 
     @pytest.mark.parametrize("specifier", SPECIFIERS)
     def test_specifiers_hash(self, specifier):
@@ -873,7 +873,7 @@ class TestSpecifierSet:
         spec = SpecifierSet(specifier)
 
         assert str(spec) == expected
-        assert repr(spec) == "<SpecifierSet({!r})>".format(expected)
+        assert repr(spec) == f"<SpecifierSet({expected!r})>"
 
     @pytest.mark.parametrize("specifier", SPECIFIERS + LEGACY_SPECIFIERS)
     def test_specifiers_hash(self, specifier):

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -228,12 +228,10 @@ class TestMacOSPlatforms:
                 platform, "mac_ver", lambda: ("10.14", ("", "", ""), "x86_64")
             )
         version = platform.mac_ver()[0].split(".")
-        if version[0] == "10":
-            expected = "macosx_{major}_{minor}".format(
-                major=version[0], minor=version[1]
-            )
-        else:
-            expected = "macosx_{major}_{minor}".format(major=version[0], minor=0)
+        major = version[0]
+        minor = version[1] if major == "10" else "0"
+        expected = f"macosx_{major}_{minor}"
+
         platforms = list(tags.mac_platforms(arch="x86_64"))
         print(platforms, expected)
         assert platforms[0].startswith(expected)
@@ -608,7 +606,7 @@ class TestCPythonABI:
     def test_pymalloc(self, pymalloc, version, result, monkeypatch):
         config = {"Py_DEBUG": 0, "WITH_PYMALLOC": pymalloc, "Py_UNICODE_SIZE": 2}
         monkeypatch.setattr(sysconfig, "get_config_var", config.__getitem__)
-        base_abi = "cp{}{}".format(version[0], version[1])
+        base_abi = f"cp{version[0]}{version[1]}"
         expected = [base_abi + "m" if result else base_abi]
         assert tags._cpython_abis(version) == expected
 

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -277,7 +277,7 @@ class TestVersion:
     )
     def test_version_str_repr(self, version, expected):
         assert str(Version(version)) == expected
-        assert repr(Version(version)) == "<Version({!r})>".format(expected)
+        assert repr(Version(version)) == f"<Version({expected!r})>"
 
     def test_version_rc_and_c_equals(self):
         assert Version("1.0rc1") == Version("1.0c1")


### PR DESCRIPTION
Adding pyupgrade to pre-commit picks up a couple of places f-strings can be used.
