### PR TITLE
Use Cached _hash Attribute to short-circuit Equality Comparisons

### DIFF
--- a/packaging/tags.py
+++ b/packaging/tags.py
@@ -101,10 +101,10 @@ class Tag:
             return NotImplemented
 
         return (
-            (self._hash == other._hash)
-            and (self.platform == other.platform)
-            and (self.abi == other.abi)
-            and (self.interpreter == other.interpreter)
+            (self._hash == other._hash)  # Short-circuit ASAP for perf reasons.
+            and (self._platform == other._platform)
+            and (self._abi == other._abi)
+            and (self._interpreter == other._interpreter)
         )
 
     def __hash__(self) -> int:

--- a/packaging/tags.py
+++ b/packaging/tags.py
@@ -101,7 +101,8 @@ class Tag:
             return NotImplemented
 
         return (
-            (self.platform == other.platform)
+            (self._hash == other._hash)
+            and (self.platform == other.platform)
             and (self.abi == other.abi)
             and (self.interpreter == other.interpreter)
         )


### PR DESCRIPTION
I found that for some pip operations the tag `__eq__` operation is the most costly step.  Adding this check moves 10 invocations of pip's `package_finder.compute_best_candidate` (https://github.com/pypa/pip/blob/master/src/pip/_internal/index/package_finder.py#L550) on all the candidates of boto3 from 20.9s to 11.8s on my machine.  Another thing I tried was doing `hash(self) == hash(other)`, but that actually made performance worse in my case.

Current main branch: 
![image](https://user-images.githubusercontent.com/3237156/112541746-21fa7f00-8d8a-11eb-937f-619e214b0c06.png)

`hash(self) == hash(other)` (performance regression)
![image](https://user-images.githubusercontent.com/3237156/112541807-36d71280-8d8a-11eb-9ece-97ac8aacf949.png)

`self._hash == other._hash` (this pr)
![image](https://user-images.githubusercontent.com/3237156/112541860-46565b80-8d8a-11eb-8a74-26667ca3e968.png)