### PR TITLE
added the ability to compare Version objects with version strings.

### DIFF
--- a/packaging/version.py
+++ b/packaging/version.py
@@ -68,7 +68,10 @@ class _BaseVersion:
     # unless you find a way to avoid adding overhead function calls.
     def __lt__(self, other: "_BaseVersion") -> bool:
         if isinstance(other, str):
-            other = self.__class__(other)
+            try:
+                other = self.__class__(other)
+            except InvalidVersion:
+                return NotImplemented
         elif not isinstance(other, _BaseVersion):
             return NotImplemented
 
@@ -76,7 +79,10 @@ class _BaseVersion:
 
     def __le__(self, other: "_BaseVersion") -> bool:
         if isinstance(other, str):
-            other = self.__class__(other)
+            try:
+                other = self.__class__(other)
+            except InvalidVersion:
+                return NotImplemented
         elif not isinstance(other, _BaseVersion):
             return NotImplemented
 
@@ -84,7 +90,10 @@ class _BaseVersion:
 
     def __eq__(self, other: object) -> bool:
         if isinstance(other, str):
-            other = self.__class__(other)
+            try:
+                other = self.__class__(other)
+            except InvalidVersion:
+                return NotImplemented
         elif not isinstance(other, _BaseVersion):
             return NotImplemented
 
@@ -92,7 +101,10 @@ class _BaseVersion:
 
     def __ge__(self, other: "_BaseVersion") -> bool:
         if isinstance(other, str):
-            other = self.__class__(other)
+            try:
+                other = self.__class__(other)
+            except InvalidVersion:
+                return NotImplemented
         elif not isinstance(other, _BaseVersion):
             return NotImplemented
 
@@ -100,7 +112,10 @@ class _BaseVersion:
 
     def __gt__(self, other: "_BaseVersion") -> bool:
         if isinstance(other, str):
-            other = self.__class__(other)
+            try:
+                other = self.__class__(other)
+            except InvalidVersion:
+                return NotImplemented
         elif not isinstance(other, _BaseVersion):
             return NotImplemented
 
@@ -108,7 +123,10 @@ class _BaseVersion:
 
     def __ne__(self, other: object) -> bool:
         if isinstance(other, str):
-            other = self.__class__(other)
+            try:
+                other = self.__class__(other)
+            except InvalidVersion:
+                return NotImplemented
         elif not isinstance(other, _BaseVersion):
             return NotImplemented
 

--- a/packaging/version.py
+++ b/packaging/version.py
@@ -67,37 +67,49 @@ class _BaseVersion:
     # in the six comparisons hereunder
     # unless you find a way to avoid adding overhead function calls.
     def __lt__(self, other: "_BaseVersion") -> bool:
-        if not isinstance(other, _BaseVersion):
+        if isinstance(other, str):
+            other = self.__class__(other)
+        elif not isinstance(other, _BaseVersion):
             return NotImplemented
 
         return self._key < other._key
 
     def __le__(self, other: "_BaseVersion") -> bool:
-        if not isinstance(other, _BaseVersion):
+        if isinstance(other, str):
+            other = self.__class__(other)
+        elif not isinstance(other, _BaseVersion):
             return NotImplemented
 
         return self._key <= other._key
 
     def __eq__(self, other: object) -> bool:
-        if not isinstance(other, _BaseVersion):
+        if isinstance(other, str):
+            other = self.__class__(other)
+        elif not isinstance(other, _BaseVersion):
             return NotImplemented
 
         return self._key == other._key
 
     def __ge__(self, other: "_BaseVersion") -> bool:
-        if not isinstance(other, _BaseVersion):
+        if isinstance(other, str):
+            other = self.__class__(other)
+        elif not isinstance(other, _BaseVersion):
             return NotImplemented
 
         return self._key >= other._key
 
     def __gt__(self, other: "_BaseVersion") -> bool:
-        if not isinstance(other, _BaseVersion):
+        if isinstance(other, str):
+            other = self.__class__(other)
+        elif not isinstance(other, _BaseVersion):
             return NotImplemented
 
         return self._key > other._key
 
     def __ne__(self, other: object) -> bool:
-        if not isinstance(other, _BaseVersion):
+        if isinstance(other, str):
+            other = self.__class__(other)
+        elif not isinstance(other, _BaseVersion):
             return NotImplemented
 
         return self._key != other._key

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -759,6 +759,25 @@ class TestVersion:
 
         assert getattr(operator, op)(Version("1"), other) is expected
 
+    def test_eq_with_string(self):
+        assert Version("1.2.3") == "1.2.3"
+
+    def test_gt_with_string(self):
+        assert Version("1.2.3") > "1.2.2"
+
+    def test_lt_with_string(self):
+        assert Version("1.2.2") < "1.2.3"
+
+    def test_eq_with_string_rev(self):
+        assert "1.2.3" == Version("1.2.3")
+
+    def test_gt_with_string_rev(self):
+        assert "1.2.3" > Version("1.2.2")
+
+    def test_lt_with_string_rev(self):
+        assert "1.2.2" < Version("1.2.3")
+
+
     def test_compare_legacyversion_version(self):
         result = sorted([Version("0"), LegacyVersion("1")])
         assert result == [LegacyVersion("1"), Version("0")]

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -765,8 +765,16 @@ class TestVersion:
     def test_gt_with_string(self):
         assert Version("1.2.3") > "1.2.2"
 
+    def test_gteq_with_string(self):
+        assert Version("1.2.3") >= "1.2.2"
+        assert Version("1.2.2") >= "1.2.2"
+
     def test_lt_with_string(self):
         assert Version("1.2.2") < "1.2.3"
+
+    def test_lteq_with_string(self):
+        assert Version("1.2.2") <= "1.2.3"
+        assert Version("1.2.3") <= "1.2.3"
 
     def test_eq_with_string_rev(self):
         assert "1.2.3" == Version("1.2.3")
@@ -774,9 +782,16 @@ class TestVersion:
     def test_gt_with_string_rev(self):
         assert "1.2.3" > Version("1.2.2")
 
+    def test_gteq_with_string_rev(self):
+        assert "1.2.3" >= Version("1.2.2")
+        assert "1.2.2" >= Version("1.2.2")
+
     def test_lt_with_string_rev(self):
         assert "1.2.2" < Version("1.2.3")
 
+    def test_lteq_with_string_rev(self):
+        assert "1.2.1" <= Version("1.2.2")
+        assert "1.2.2" <= Version("1.2.2")
 
     def test_compare_legacyversion_version(self):
         result = sorted([Version("0"), LegacyVersion("1")])

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -759,6 +759,14 @@ class TestVersion:
 
         assert getattr(operator, op)(Version("1"), other) is expected
 
+    @pytest.mark.parametrize("op", ["lt", "le", "eq", "ge", "gt", "ne"])
+    def test_compare_invalid_string_return_false(self, op):
+        """
+        a comparison with an invalid string shoudl return False
+        """
+        method = getattr(Version, f"__{op}__")
+        assert method(Version("1"), "xyz,tuv-34") is NotImplemented
+
     def test_eq_with_string(self):
         assert Version("1.2.3") == "1.2.3"
 


### PR DESCRIPTION
During a conversation over on python-dev:

https://mail.python.org/archives/list/python-dev@python.org/thread/EY44EMZ2R4RUMUUIVEFFVOXM2H3L427Z/#3QHBGEIDDJEHZP5Q2I3ZGQ73FZ6SPDAQ

It dawned on me that it would be handy to be able to compare Version objects directly with compliant version strings.

And it was not hard to do.

Here is an implementation, with not quite complete tests.

 *  >= and <= are not tested
 * not test for what happens wtih non-compliant strings

If y'all think this would be a good feature, i'm happy to flesh it out some more.

BTW: any reason to not use functools.total_ordering? -- a lot of boilerplate code in there :-)

 
