### PR TITLE
Test: Add coverage for wheel filename normalization.

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -67,6 +67,13 @@ def test_canonicalize_version(version, expected):
             {Tag("py3", "none", "any")},
         ),
         (
+            "some_PACKAGE-1.0-py3-none-any.whl",
+            "some-package",
+            Version("1.0"),
+            (),
+            {Tag("py3", "none", "any")},
+        ),
+        (
             "foo-1.0-1000-py3-none-any.whl",
             "foo",
             Version("1.0"),


### PR DESCRIPTION
I noticed that #387 did not include a test for ``_`` in the wheel name, nor for anything with upper case characters. This kind of filename can be generated with ``python -m build`` and ``pip wheel --no-deps``.

cc @pfmoore as the author of the original PR