### PR TITLE
Add support for sdists with .zip extension

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Changelog
 ~~~~~~~~~~~~
 
 * `packaging` is now only compatible with Python 3.6 and above.
+* Add support for zip files in ``parse_sdist_filename`` (:issue:`429`)
 
 20.9 - 2021-01-29
 ~~~~~~~~~~~~~~~~~

--- a/packaging/utils.py
+++ b/packaging/utils.py
@@ -115,14 +115,19 @@ def parse_wheel_filename(
 
 
 def parse_sdist_filename(filename: str) -> Tuple[NormalizedName, Version]:
-    if not filename.endswith(".tar.gz"):
+    if filename.endswith(".tar.gz"):
+        file_stem = filename[: -len(".tar.gz")]
+    elif filename.endswith(".zip"):
+        file_stem = filename[: -len(".zip")]
+    else:
         raise InvalidSdistFilename(
-            f"Invalid sdist filename (extension must be '.tar.gz'): {filename}"
+            f"Invalid sdist filename (extension must be '.tar.gz' or '.zip'):"
+            f" {filename}"
         )
 
     # We are requiring a PEP 440 version, which cannot contain dashes,
     # so we split on the last dash.
-    name_part, sep, version_part = filename[:-7].rpartition("-")
+    name_part, sep, version_part = file_stem.rpartition("-")
     if not sep:
         raise InvalidSdistFilename(f"Invalid sdist filename: {filename}")
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -111,13 +111,14 @@ def test_parse_wheel_invalid_filename(filename):
 
 
 @pytest.mark.parametrize(
-    ("filename", "name", "version"), [("foo-1.0.tar.gz", "foo", Version("1.0"))]
+    ("filename", "name", "version"),
+    [("foo-1.0.tar.gz", "foo", Version("1.0")), ("foo-1.0.zip", "foo", Version("1.0"))],
 )
 def test_parse_sdist_filename(filename, name, version):
     assert parse_sdist_filename(filename) == (name, version)
 
 
-@pytest.mark.parametrize(("filename"), [("foo-1.0.zip"), ("foo1.0.tar.gz")])
+@pytest.mark.parametrize(("filename"), [("foo-1.0.xz"), ("foo1.0.tar.gz")])
 def test_parse_sdist_invalid_filename(filename):
     with pytest.raises(InvalidSdistFilename):
         parse_sdist_filename(filename)


### PR DESCRIPTION
Closes: #429

There are some existing sdists with `.zip` extension on PyPI. Add
support for it in `parse_wheel_filename` to properly handle these files.