### PR TITLE
release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,15 @@
+name: Release
+
+on: 
+  workflow_dispatch:
+    inputs:
+      tags:
+        description: 'description tag'
+
+jobs:
+  printInputs:
+    runs-on: ubuntu-latest
+    steps:
+    - run: |
+        echo "Tags: ${{ github.event.inputs.tags }}"
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,15 +30,17 @@ jobs:
     #  run nox --session release -- ${{ secrets.RELEASE_VERSION }}
     - name: Autobump version
       run: |
-        # from refs/tags/v1.2.3 get 1.2.3
+        # from GITHUB_REF refs/tags/v1.2.3 extract 1.2.3
         VERSION=$(echo $GITHUB_REF | sed 's#.*/v##')
         # there's probably a regexp that will reliably find __version__ in __about__.py
         PLACEHOLDER='__version__ = "20.10.dev0"'
         VERSION_FILE='packaging/__about__.py'
-        # ensure the placeholder is there. If grep doesn't find the placeholder
-        # it exits with exit code 1 and github actions aborts the build.
+        # Ensure the placeholder is there. If grep doesn't find the placeholder,
+        # it exits with exit code 1 and GitHub Actions aborts the build.
         grep "$PLACEHOLDER" "$VERSION_FILE"
         sed -i "s/$PLACEHOLDER/__version__ = \"${VERSION}\"/g" "$VERSION_FILE"
+        # Optionally, we could git push here, similar to what the nox session does,
+        # though that means git push from GitHub Actions.
       shell: bash
     - name: Publish to test.pypi.org
       uses: pypa/gh-action-pypi-publish@master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,7 @@ jobs:
         sed -i "s/$PLACEHOLDER/__version__ = \"${VERSION}\"/g" "$VERSION_FILE"
         # Optionally, we could git push here, similar to what the nox session does,
         # though that means git push from GitHub Actions.
+        # https://github.com/ad-m/github-push-action
       shell: bash
     - name: Publish to test.pypi.org
       uses: pypa/gh-action-pypi-publish@master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,4 +52,3 @@ jobs:
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,10 +26,27 @@ jobs:
       shell: bash
     - name: Build package
       run: python -m build
-    - name: nox release
-      run: nox --session release -- ${{ secrets.RELEASE_VERSION }}
+    # - name nox release
+    #  run nox --session release -- ${{ secrets.RELEASE_VERSION }}
+    - name: Autobump version
+      run: |
+        # from refs/tags/v1.2.3 get 1.2.3
+        VERSION=$(echo $GITHUB_REF | sed 's#.*/v##')
+        # there's probably a regexp that will reliably find __version__ in __about__.py
+        PLACEHOLDER='__version__ = "20.10.dev0"'
+        VERSION_FILE='packaging/__about__.py'
+        # ensure the placeholder is there. If grep doesn't find the placeholder
+        # it exits with exit code 1 and github actions aborts the build.
+        grep "$PLACEHOLDER" "$VERSION_FILE"
+        sed -i "s/$PLACEHOLDER/__version__ = \"${VERSION}\"/g" "$VERSION_FILE"
+      shell: bash
+    - name: Publish to test.pypi.org
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        repository_url: https://test.pypi.org/legacy/
     - name: Publish package
-      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+      uses: pypa/gh-action-pypi-publish@master
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,15 +1,36 @@
 name: Release
 
-on: 
-  workflow_dispatch:
-    inputs:
-      tags:
-        description: 'description tag'
+# This workflow will upload a Python Package using Twine when a release is created
+# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+
+on:
+  release:
+    types: [published]
 
 jobs:
-  printInputs:
+  deploy:
+
     runs-on: ubuntu-latest
+
     steps:
-    - run: |
-        echo "Tags: ${{ github.event.inputs.tags }}"
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install nox
+        python -m pip install build
+      shell: bash
+    - name: Build package
+      run: python -m build
+    - name: nox release
+      run: nox --session release -- ${{ secrets.RELEASE_VERSION }}
+    - name: Publish package
+      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -165,6 +165,11 @@ def release(session):
     # Upload the distribution.
     session.run("twine", "upload", *files)
 
+    # If we have GitHub Actions hook onto https://github.com/pypa/packaging/releases,
+    # then https://github.com/pypa/packaging/releases will actually be the *first*
+    # step that triggers this nox session to be run.
+    # But it looks like a release-initiated process would tend to absorb everything
+    # from this nox session, except _bump() which cannot be accomplished that way.
     # Open up the GitHub release page.
     webbrowser.open("https://github.com/pypa/packaging/releases")
 


### PR DESCRIPTION
The original plan for https://github.com/pypa/packaging/issues/339 was to use `workflow_dispatch` to manually trigger the release, but it looks like in the meantime it's become possible to hook onto creating a release on https://github.com/pypa/packaging/releases, so I'm guessing we'll want to do that.

That raises an interesting question, though. If the process is initiated from https://github.com/pypa/packaging/releases, then the tag will be applied to the current head of the branch, meaning no matter what shenanigans we pull in the actions, `_bump` cannot change the `__version__` on the commit that will get tagged...because that commit has already been selected, on https://github.com/pypa/packaging/releases.
We can do what https://github.com/grst/python-ci-versioneer does and rewrite the `__version__` on the fly when publishing, but that still requires a manual call of `_bump` to update the version in the source repository (whether through `nox` or any other way). That *could* be done from GitHub Actions too, though that would mean GitHub Actions simultaneously making-a-change-and-pushing-to-PyPI and making-the-change-and-pushing-to-GitHub.