### PR TITLE
tags: make _platform_tags public

### DIFF
--- a/docs/tags.rst
+++ b/docs/tags.rst
@@ -152,7 +152,7 @@ to the implementation to provide.
 
 .. function:: platform_tags(version=None, arch=None)
 
-    Yields the :attr:`~Tag.platform` tags for current installation.
+    Yields the :attr:`~Tag.platform` tags for the running interpreter.
 
 
 .. function:: compatible_tags(python_version=None, interpreter=None, platforms=None)

--- a/docs/tags.rst
+++ b/docs/tags.rst
@@ -150,6 +150,11 @@ to the implementation to provide.
           compatibility
 
 
+.. function:: platform_tags(version=None, arch=None)
+
+    Yields the :attr:`~Tag.platform` tags for current installation.
+
+
 .. function:: compatible_tags(python_version=None, interpreter=None, platforms=None)
 
     Yields the tags for an interpreter compatible with the Python version

--- a/packaging/tags.py
+++ b/packaging/tags.py
@@ -207,7 +207,7 @@ def cpython_tags(
         except ValueError:
             pass
 
-    platforms = list(platforms or _platform_tags())
+    platforms = list(platforms or platform_tags())
     for abi in abis:
         for platform_ in platforms:
             yield Tag(interpreter, abi, platform_)
@@ -251,7 +251,7 @@ def generic_tags(
         interpreter = "".join([interp_name, interp_version])
     if abis is None:
         abis = _generic_abi()
-    platforms = list(platforms or _platform_tags())
+    platforms = list(platforms or platform_tags())
     abis = list(abis)
     if "none" not in abis:
         abis.append("none")
@@ -290,7 +290,7 @@ def compatible_tags(
     """
     if not python_version:
         python_version = sys.version_info[:2]
-    platforms = list(platforms or _platform_tags())
+    platforms = list(platforms or platform_tags())
     for version in _py_interpreter_range(python_version):
         for platform_ in platforms:
             yield Tag(version, "none", platform_)
@@ -431,7 +431,7 @@ def _generic_platforms() -> Iterator[str]:
     yield _normalize_string(sysconfig.get_platform())
 
 
-def _platform_tags() -> Iterator[str]:
+def platform_tags() -> Iterator[str]:
     """
     Provides the platform tags for this installation.
     """

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -561,11 +561,11 @@ class TestManylinuxPlatform:
         ("Generic", "_generic_platforms"),
     ],
 )
-def test__platform_tags(platform_name, dispatch_func, monkeypatch):
+def test_platform_tags(platform_name, dispatch_func, monkeypatch):
     expected = ["sillywalk"]
     monkeypatch.setattr(platform, "system", lambda: platform_name)
     monkeypatch.setattr(tags, dispatch_func, lambda: expected)
-    assert tags._platform_tags() == expected
+    assert tags.platform_tags() == expected
 
 
 class TestCPythonABI:
@@ -730,12 +730,12 @@ class TestCPythonTags:
         assert tags.Tag("cp311", "none", "any") in result
 
     def test_platforms_defaults(self, monkeypatch):
-        monkeypatch.setattr(tags, "_platform_tags", lambda: ["plat1"])
+        monkeypatch.setattr(tags, "platform_tags", lambda: ["plat1"])
         result = list(tags.cpython_tags((3, 8), abis=["whatever"]))
         assert tags.Tag("cp38", "whatever", "plat1") in result
 
     def test_platforms_defaults_needs_underscore(self, monkeypatch):
-        monkeypatch.setattr(tags, "_platform_tags", lambda: ["plat1"])
+        monkeypatch.setattr(tags, "platform_tags", lambda: ["plat1"])
         result = list(tags.cpython_tags((3, 11), abis=["whatever"]))
         assert tags.Tag("cp311", "whatever", "plat1") in result
 
@@ -847,7 +847,7 @@ class TestGenericTags:
         ]
 
     def test_platforms_default(self, monkeypatch):
-        monkeypatch.setattr(tags, "_platform_tags", lambda: ["plat"])
+        monkeypatch.setattr(tags, "platform_tags", lambda: ["plat"])
         result = list(tags.generic_tags(interpreter="sillywalk", abis=["none"]))
         assert result == [tags.Tag("sillywalk", "none", "plat")]
 
@@ -985,7 +985,7 @@ class TestCompatibleTags:
         ]
 
     def test_default_platforms(self, monkeypatch):
-        monkeypatch.setattr(tags, "_platform_tags", lambda: iter(["plat", "plat2"]))
+        monkeypatch.setattr(tags, "platform_tags", lambda: iter(["plat", "plat2"]))
         result = list(tags.compatible_tags((3, 1), "cp31"))
         assert result == [
             tags.Tag("py31", "none", "plat"),


### PR DESCRIPTION
There are situations where we may need to look at the compatible
platform versions. The best workaround for this would be using
compatible_tags and striping down the unnecessary fields. There is
already a precedent for this, mac_platforms.