### PR TITLE
Prevent Duplicate Version Object Creation

### DIFF
--- a/packaging/version.py
+++ b/packaging/version.py
@@ -6,7 +6,7 @@ import collections
 import itertools
 import re
 import warnings
-from typing import Callable, Iterator, List, Optional, SupportsInt, Tuple, Union
+from typing import Callable, Dict, Iterator, List, Optional, SupportsInt, Tuple, Union
 
 from ._structures import Infinity, InfinityType, NegativeInfinity, NegativeInfinityType
 
@@ -257,8 +257,18 @@ VERSION_PATTERN = r"""
 class Version(_BaseVersion):
 
     _regex = re.compile(r"^\s*" + VERSION_PATTERN + r"\s*$", re.VERBOSE | re.IGNORECASE)
+    _obj_cache: Dict[str, "Version"] = {}
+
+    def __new__(cls, version: str) -> "Version":
+        try:
+            cached = cls._obj_cache[version]
+        except KeyError:
+            cached = super(Version, cls).__new__(cls)
+        return cached
 
     def __init__(self, version: str) -> None:
+        if version in Version._obj_cache:
+            return
 
         # Validate the version and parse it into pieces
         match = self._regex.search(version)
@@ -286,6 +296,7 @@ class Version(_BaseVersion):
             self._version.dev,
             self._version.local,
         )
+        Version._obj_cache[version] = self
 
     def __repr__(self) -> str:
         return f"<Version('{self}')>"


### PR DESCRIPTION
During pip resolution sometimes 10's of millions of version objects are created, each of which requires a regex search as well as some other parsing.  This object creation ends up being a pretty significant cost of some code paths (~25% for my test case), after this change that time essentially evaporates (<<1%).

I will say this isn't the easiest for me to test in pip right now because of:
1. the vendoring (though that may in fact be a me problem)
2. my test case actually hasn't ever finished resolving (at least so far), but it depends on a private pip repository so I can't share a reproduction example