### PR TITLE
add a `pp3-none-any` tag

### DIFF
--- a/packaging/tags.py
+++ b/packaging/tags.py
@@ -481,4 +481,7 @@ def sys_tags(*, warn: bool = False) -> Iterator[Tag]:
     else:
         yield from generic_tags()
 
-    yield from compatible_tags()
+    if interp_name == "pp":
+        yield from compatible_tags(interpreter="pp3")
+    else:
+        yield from compatible_tags()

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -1187,7 +1187,7 @@ class TestSysTags:
         monkeypatch.setattr(tags, "interpreter_name", lambda: "pp")
 
         for tag in tags.sys_tags():
-            if tag.platform == "any":
+            if tag.abi == "none" and tag.platform == "any":
                 break
 
         assert tag == tags.Tag("pp3", "none", "any")

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -1180,3 +1180,14 @@ class TestSysTags:
             "linux_x86_64",
         ]
         assert platforms == expected
+
+    def test_pypy_first_tag(self, monkeypatch):
+        # When building the complete list of pypy tags, make sure the first
+        # <interpreter>-none-any one is pp3-none-any
+        monkeypatch.setattr(tags, "interpreter_name", lambda: "pp")
+
+        for tag in tags.sys_tags():
+            if tag.platform == "any":
+                break
+
+        assert tag == tags.Tag("pp3", "none", "any")

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -1181,7 +1181,7 @@ class TestSysTags:
         ]
         assert platforms == expected
 
-    def test_pypy_first_tag(self, monkeypatch):
+    def test_pypy_first_none_any_tag(self, monkeypatch):
         # When building the complete list of pypy tags, make sure the first
         # <interpreter>-none-any one is pp3-none-any
         monkeypatch.setattr(tags, "interpreter_name", lambda: "pp")


### PR DESCRIPTION
Closes #311. Now that this project is used by pip and wheel, the discussion there about where to make the change is less relevant, I hope that reading the description below convinces the maintainers that the change is justified.

This inserts a pp3-none-any tag as the first any-platform tag.

This subject came up again for the [vmprof project](https://github.com/vmprof/vmprof-python), which is a statistical profiler for cpython/pypy. The project has two parts: a pure-python front end, and a backend. On CPython, the backend is a c-extension module. On PyPy, the backend is built into the interpreter and understands the JIT. So when making wheels for the project, we want c-extension binary wheels for CPython and a pure-python wheel for PyPy.


Here is  a snippet of the output of `tags.sys_tags()` using PyPy 3.7 on ubuntu 20.04/x86_64.
```
...
 <py30-none-manylinux_2_7_x86_64 @ 140603724368544>,
 <py30-none-manylinux_2_6_x86_64 @ 140603724368600>,
 <py30-none-manylinux_2_5_x86_64 @ 140603724368656>,
 <py30-none-manylinux1_x86_64 @ 140603724368712>,
 <py30-none-linux_x86_64 @ 140603724368768>,
 <pp3-none-any @ 140603724368824>,    # <---------- here
 <py37-none-any @ 140603724368880>,
 <py3-none-any @ 140603724368936>,
 <py36-none-any @ 140603724369440>,
 <py35-none-any @ 140603724369496>,
 <py34-none-any @ 140603724369552>,
...
```