### PR TITLE
update pypy ci specifier

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,12 +19,7 @@ jobs:
       matrix:
         os: [Ubuntu, Windows, macOS]
         python_version:
-          ["3.6", "3.7", "3.8", "3.9", "3.10", "pypy3"]
-        exclude:
-          # This is failing due to pip not being in the virtual environment.
-          # https://github.com/pypa/packaging/runs/424785871#step:7:9
-          - os: windows
-            python_version: pypy3
+          ["3.6", "3.7", "3.8", "3.9", "3.10", "pypy-3.7"]
 
     steps:
       - uses: actions/checkout@v1
@@ -44,7 +39,7 @@ jobs:
         run: |
           python -m nox --error-on-missing-interpreters -s tests-${{ matrix.python_version }}
         shell: bash
-        if: matrix.python_version != 'pypy2'
+        if: ${{ ! startsWith( matrix.python_version, 'pypy' ) }}
 
       # Binary is named 'pypy', but setup-python specifies it as 'pypy2'.
       - name: Run nox for pypy2
@@ -52,3 +47,10 @@ jobs:
           python -m nox --error-on-missing-interpreters -s tests-pypy
         shell: bash
         if: matrix.python_version == 'pypy2'
+
+      # Binary is named 'pypy3', but setup-python specifies it as 'pypy-3.7'.
+      - name: Run nox for pypy3
+        run: |
+          python -m nox --error-on-missing-interpreters -s tests-pypy3
+        shell: bash
+        if: matrix.python_version == 'pypy-3.7'

--- a/docs/development/getting-started.rst
+++ b/docs/development/getting-started.rst
@@ -34,7 +34,7 @@ each supported Python version and run the tests. For example:
     nox > * tests-3.7: success
     nox > * tests-3.8: success
     nox > * tests-3.9: success
-    nox > * tests-pypy3.7: skipped
+    nox > * tests-pypy3: skipped
 
 You may not have all the required Python versions installed, in which case you
 will see one or more ``InterpreterNotFound`` errors.

--- a/docs/development/getting-started.rst
+++ b/docs/development/getting-started.rst
@@ -34,7 +34,7 @@ each supported Python version and run the tests. For example:
     nox > * tests-3.7: success
     nox > * tests-3.8: success
     nox > * tests-3.9: success
-    nox > * tests-pypy3: skipped
+    nox > * tests-pypy3.7: skipped
 
 You may not have all the required Python versions installed, in which case you
 will see one or more ``InterpreterNotFound`` errors.


### PR DESCRIPTION
`pypy3` is being deprecated as a specifier, see https://github.com/actions/setup-python/issues/244. Right now this affects macos-latest, but I imagine it will percolate through the other os images as well. The current CI here has not failed, I think because the image is cached.