### PR TITLE
musslinux: Always (un)pack structs as little endian

### DIFF
--- a/packaging/_musllinux.py
+++ b/packaging/_musllinux.py
@@ -27,7 +27,7 @@ def _parse_ld_musl_from_elf(f: IO[bytes]) -> Optional[str]:
     """
     f.seek(0)
     try:
-        ident = _read_unpacked(f, "16B")
+        ident = _read_unpacked(f, "<16B")
     except struct.error:
         return None
     if ident[:4] != tuple(b"\x7fELF"):  # Invalid magic, not ELF.
@@ -39,8 +39,8 @@ def _parse_ld_musl_from_elf(f: IO[bytes]) -> Optional[str]:
         # p_fmt: Format for section header.
         # p_idx: Indexes to find p_type, p_offset, and p_filesz.
         e_fmt, p_fmt, p_idx = {
-            1: ("IIIIHHH", "IIIIIIII", (0, 1, 4)),  # 32-bit.
-            2: ("QQQIHHH", "IIQQQQQQ", (0, 2, 5)),  # 64-bit.
+            1: ("<IIIIHHH", "<IIIIIIII", (0, 1, 4)),  # 32-bit.
+            2: ("<QQQIHHH", "<IIQQQQQQ", (0, 2, 5)),  # 64-bit.
         }[ident[4]]
     except KeyError:
         return None

--- a/tests/test_musllinux.py
+++ b/tests/test_musllinux.py
@@ -102,13 +102,13 @@ def test_parse_ld_musl_from_elf_no_interpreter_section():
         data = f.read()
 
     # Change all sections to *not* PT_INTERP.
-    unpacked = struct.unpack("16BHHIQQQIHHH", data[:58])
+    unpacked = struct.unpack("<16BHHIQQQIHHH", data[:58])
     *_, e_phoff, _, _, _, e_phentsize, e_phnum = unpacked
     for i in range(e_phnum + 1):
         sb = e_phoff + e_phentsize * i
         se = sb + 56
-        section = struct.unpack("IIQQQQQQ", data[sb:se])
-        data = data[:sb] + struct.pack("IIQQQQQQ", 0, *section[1:]) + data[se:]
+        section = struct.unpack("<IIQQQQQQ", data[sb:se])
+        data = data[:sb] + struct.pack("<IIQQQQQQ", 0, *section[1:]) + data[se:]
 
     assert _parse_ld_musl_from_elf(io.BytesIO(data)) is None
 


### PR DESCRIPTION
Fixes problems on big endian architectures --
native order is used by default otherwise.

Fixes https://github.com/pypa/packaging/issues/472