### PR TITLE
Update to pyparsing>=3.0.0

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -49,11 +49,8 @@ jobs:
       - name: Install dependencies
         run: python -m pip install --upgrade build
 
-      - name: Install package and dependencies
-        run: python -m pip install -e .
-
       - name: Build
-        run: python -m build
+        run: pyproject-build
 
       - name: Archive files
         uses: actions/upload-artifact@v1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Install dependencies
         run: python -m pip install --upgrade build
 
+      - name: Install package and dependencies
+        run: python -m pip install -e .
+
       - name: Build
         run: python -m build
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -59,6 +59,9 @@ def lint(session):
     session.install("pre-commit")
     session.run("pre-commit", "run", "--all-files")
 
+    # Install current package and dependencies
+    session.install(".")
+
     # Check the distribution
     session.install("build", "twine")
     session.run("python", "-m", "build")

--- a/noxfile.py
+++ b/noxfile.py
@@ -59,12 +59,9 @@ def lint(session):
     session.install("pre-commit")
     session.run("pre-commit", "run", "--all-files")
 
-    # Install current package and dependencies
-    session.install(".")
-
     # Check the distribution
     session.install("build", "twine")
-    session.run("python", "-m", "build")
+    session.run("pyproject-build")
     session.run("twine", "check", *glob.glob("dist/*"))
 
 

--- a/packaging/markers.py
+++ b/packaging/markers.py
@@ -16,8 +16,8 @@ from pyparsing import (  # noqa: N817
     ParseResults,
     QuotedString,
     ZeroOrMore,
-    stringEnd,
-    stringStart,
+    string_end,
+    string_start,
 )
 
 from .specifiers import InvalidSpecifier, Specifier
@@ -135,7 +135,7 @@ MARKER_EXPR = Forward()
 MARKER_ATOM = MARKER_ITEM | Group(LPAREN + MARKER_EXPR + RPAREN)
 MARKER_EXPR << MARKER_ATOM + ZeroOrMore(BOOLOP + MARKER_EXPR)
 
-MARKER = stringStart + MARKER_EXPR + stringEnd
+MARKER = string_start + MARKER_EXPR + string_end
 
 
 def _coerce_parse_result(results: Union[ParseResults, List[Any]]) -> List[Any]:

--- a/packaging/requirements.py
+++ b/packaging/requirements.py
@@ -15,9 +15,9 @@ from pyparsing import (  # noqa
     Regex,
     Word,
     ZeroOrMore,
-    originalTextFor,
-    stringEnd,
-    stringStart,
+    original_text_for,
+    string_end,
+    string_start,
 )
 
 from .markers import MARKER_EXPR, Marker
@@ -63,10 +63,10 @@ VERSION_MANY = Combine(
 _VERSION_SPEC = Optional((LPAREN + VERSION_MANY + RPAREN) | VERSION_MANY)
 _VERSION_SPEC.setParseAction(lambda s, l, t: t._raw_spec or "")
 
-VERSION_SPEC = originalTextFor(_VERSION_SPEC)("specifier")
+VERSION_SPEC = original_text_for(_VERSION_SPEC)("specifier")
 VERSION_SPEC.setParseAction(lambda s, l, t: t[1])
 
-MARKER_EXPR = originalTextFor(MARKER_EXPR())("marker")
+MARKER_EXPR = original_text_for(MARKER_EXPR())("marker")
 MARKER_EXPR.setParseAction(
     lambda s, l, t: Marker(s[t._original_start : t._original_end])
 )
@@ -78,7 +78,7 @@ URL_AND_MARKER = URL + Optional(MARKER)
 
 NAMED_REQUIREMENT = NAME + Optional(EXTRAS) + (URL_AND_MARKER | VERSION_AND_MARKER)
 
-REQUIREMENT = stringStart + NAMED_REQUIREMENT + stringEnd
+REQUIREMENT = string_start + NAMED_REQUIREMENT + string_end
 # pyparsing isn't thread safe during initialization, so we do it eagerly, see
 # issue #104
 REQUIREMENT.parseString("x[]")

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     author=about["__author__"],
     author_email=about["__email__"],
     python_requires=">=3.6",
-    install_requires=["pyparsing>=2.0.2,<3"],  # Needed to avoid issue #91
+    install_requires=["pyparsing>=3.0.0"],
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -192,4 +192,4 @@ class TestRequirements:
     def test_parseexception_error_msg(self):
         with pytest.raises(InvalidRequirement) as e:
             Requirement("toto 42")
-        assert "Expected stringEnd" in str(e.value)
+        assert "Expected string_end" in str(e.value)


### PR DESCRIPTION
As pointed out by @henryiii in the previous PR (#471), the package should be updated and not capped.
I removed the capping restriction, set minimum version to be `3.0.0`, updated usages and said UT.