### PR TITLE
Revert pyparsing constraint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -50,7 +50,7 @@ jobs:
         run: python -m pip install --upgrade build
 
       - name: Build
-        run: python -m build
+        run: pyproject-build
 
       - name: Archive files
         uses: actions/upload-artifact@v1

--- a/noxfile.py
+++ b/noxfile.py
@@ -61,7 +61,7 @@ def lint(session):
 
     # Check the distribution
     session.install("build", "twine")
-    session.run("python", "-m", "build")
+    session.run("pyproject-build")
     session.run("twine", "check", *glob.glob("dist/*"))
 
 

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     author=about["__author__"],
     author_email=about["__email__"],
     python_requires=">=3.6",
-    install_requires=["pyparsing>=2.0.2,<3"],  # Needed to avoid issue #91
+    install_requires=["pyparsing>=2.0.2"],  # Needed to avoid issue #91
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -192,4 +192,6 @@ class TestRequirements:
     def test_parseexception_error_msg(self):
         with pytest.raises(InvalidRequirement) as e:
             Requirement("toto 42")
-        assert "Expected stringEnd" in str(e.value)
+        assert "Expected stringEnd" in str(e.value) or (
+            "Expected string_end" in str(e.value)  # pyparsing>=3.0.0
+        )


### PR DESCRIPTION
See:
https://github.com/pypa/packaging/pull/471
https://github.com/pypa/packaging/pull/480

This PR removes the upper limit on `pyparsing` version and fixes the unit test to accept the exception message of either version 2 or 3. This seem to be the minimal change needed to support both major versions for now (until the camel case synonyms will be removed).