### PR TITLE
Fix failing parse action 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,20 +37,20 @@ jobs:
 
       - name: Run nox
         run: |
-          python -m nox --error-on-missing-interpreters -s tests-${{ matrix.python_version }}
+          python -m nox -v --error-on-missing-interpreters -s tests-${{ matrix.python_version }}
         shell: bash
         if: ${{ ! startsWith( matrix.python_version, 'pypy' ) }}
 
       # Binary is named 'pypy', but setup-python specifies it as 'pypy2'.
       - name: Run nox for pypy2
         run: |
-          python -m nox --error-on-missing-interpreters -s tests-pypy
+          python -m nox -v --error-on-missing-interpreters -s tests-pypy
         shell: bash
         if: matrix.python_version == 'pypy2'
 
       # Binary is named 'pypy3', but setup-python specifies it as 'pypy-3.7'.
       - name: Run nox for pypy3
         run: |
-          python -m nox --error-on-missing-interpreters -s tests-pypy3
+          python -m nox -v --error-on-missing-interpreters -s tests-pypy3
         shell: bash
         if: matrix.python_version == 'pypy-3.7'

--- a/noxfile.py
+++ b/noxfile.py
@@ -27,8 +27,7 @@ def tests(session):
         session.run("python", "-m", "coverage", *args)
 
     # Once coverage 5 is used then `.coverage` can move into `pyproject.toml`.
-    session.install("coverage<5.0.0", "pretend", "pytest>=6.2.0", "pip>=9.0.2")
-    session.install(".")
+    session.install(".", "coverage<5.0.0", "pretend", "pytest>=6.2.0", "pip>=9.0.2")
 
     if "pypy" not in session.python:
         coverage(

--- a/packaging/requirements.py
+++ b/packaging/requirements.py
@@ -67,9 +67,7 @@ VERSION_SPEC = originalTextFor(_VERSION_SPEC)("specifier")
 VERSION_SPEC.setParseAction(lambda s, l, t: t[1])
 
 MARKER_EXPR = originalTextFor(MARKER_EXPR())("marker")
-MARKER_EXPR.setParseAction(
-    lambda s, l, t: Marker(s[t._original_start : t._original_end])
-)
+MARKER_EXPR.addParseAction(lambda t: Marker(t.marker))
 MARKER_SEPARATOR = SEMICOLON
 MARKER = MARKER_SEPARATOR + MARKER_EXPR
 


### PR DESCRIPTION
Closes #486

pyparsing 3.0.5 renamed the two private attributes that are used
here.  This exact same transformation is performed by
`originalTextFor`'s default action, and assuming the intention
was simply to construct a `Marker` from the matched string, I've
restored the default action and added a secondary action for
constructing the `Marker` object.