### PR TITLE
fix: avoid pyparsing version 3.0.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     author=about["__author__"],
     author_email=about["__email__"],
     python_requires=">=3.6",
-    install_requires=["pyparsing>=2.0.2"],  # Needed to avoid issue #91
+    install_requires=["pyparsing>=2.0.2,!=3.0.5"],  # 2.0.2 + needed to avoid issue #91
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",


### PR DESCRIPTION
Fixes #486 by avoiding the version of pyparsing that broke packaging. Needed for release, see #483.