### PR TITLE
Fix compatible version specifier incorrectly strip trailing '0'

### DIFF
--- a/packaging/specifiers.py
+++ b/packaging/specifiers.py
@@ -119,7 +119,10 @@ class _IndividualSpecifier(BaseSpecifier):
 
     @property
     def _canonical_spec(self) -> Tuple[str, str]:
-        return self._spec[0], canonicalize_version(self._spec[1])
+        strip_zeros = self._spec[0] != "~="
+        return self._spec[0], canonicalize_version(
+            self._spec[1], strip_trailing_zero=strip_zeros
+        )
 
     def __hash__(self) -> int:
         return hash(self._canonical_spec)

--- a/packaging/specifiers.py
+++ b/packaging/specifiers.py
@@ -120,9 +120,11 @@ class _IndividualSpecifier(BaseSpecifier):
     @property
     def _canonical_spec(self) -> Tuple[str, str]:
         strip_zeros = self._spec[0] != "~="
-        return self._spec[0], canonicalize_version(
-            self._spec[1], strip_trailing_zero=strip_zeros
+        canonical_version = canonicalize_version(
+            self._spec[1],
+            strip_trailing_zero=(self._spec[0] != "~="),
         )
+        return self._spec[0], canonical_version
 
     def __hash__(self) -> int:
         return hash(self._canonical_spec)

--- a/packaging/specifiers.py
+++ b/packaging/specifiers.py
@@ -119,7 +119,6 @@ class _IndividualSpecifier(BaseSpecifier):
 
     @property
     def _canonical_spec(self) -> Tuple[str, str]:
-        strip_zeros = self._spec[0] != "~="
         canonical_version = canonicalize_version(
             self._spec[1],
             strip_trailing_zero=(self._spec[0] != "~="),

--- a/packaging/utils.py
+++ b/packaging/utils.py
@@ -36,7 +36,7 @@ def canonicalize_name(name: str) -> NormalizedName:
 
 
 def canonicalize_version(
-    version: Union[Version, str], strip_trailing_zero: bool = True
+    version: Union[Version, str], *, strip_trailing_zero: bool = True
 ) -> str:
     """
     This is very similar to Version.__str__, but has one subtle difference

--- a/packaging/utils.py
+++ b/packaging/utils.py
@@ -61,9 +61,8 @@ def canonicalize_version(
     release_segment = ".".join(str(x) for x in parsed.release)
     if strip_trailing_zero:
         # NB: This strips trailing '.0's to normalize
-        parts.append(re.sub(r"(\.0)+$", "", release_segment))
-    else:
-        parts.append(release_segment)
+        release_segment = re.sub(r"(\.0)+$", "", release_segment)
+    parts.append(release_segment)
 
     # Pre-release
     if parsed.pre is not None:

--- a/packaging/utils.py
+++ b/packaging/utils.py
@@ -35,7 +35,9 @@ def canonicalize_name(name: str) -> NormalizedName:
     return cast(NormalizedName, value)
 
 
-def canonicalize_version(version: Union[Version, str]) -> str:
+def canonicalize_version(
+    version: Union[Version, str], strip_trailing_zero: bool = True
+) -> str:
     """
     This is very similar to Version.__str__, but has one subtle difference
     with the way it handles the release segment.
@@ -56,8 +58,12 @@ def canonicalize_version(version: Union[Version, str]) -> str:
         parts.append(f"{parsed.epoch}!")
 
     # Release segment
-    # NB: This strips trailing '.0's to normalize
-    parts.append(re.sub(r"(\.0)+$", "", ".".join(str(x) for x in parsed.release)))
+    release_segment = ".".join(str(x) for x in parsed.release)
+    if strip_trailing_zero:
+        # NB: This strips trailing '.0's to normalize
+        parts.append(re.sub(r"(\.0)+$", "", release_segment))
+    else:
+        parts.append(release_segment)
 
     # Pre-release
     if parsed.pre is not None:

--- a/tests/test_specifiers.py
+++ b/tests/test_specifiers.py
@@ -1002,3 +1002,8 @@ class TestSpecifierSet:
     )
     def test_comparison_ignores_local(self, version, specifier, expected):
         assert (Version(version) in SpecifierSet(specifier)) == expected
+
+    def test_contains_with_compatible_operator(self):
+        combination = SpecifierSet("~=1.18.0") & SpecifierSet("~=1.18")
+        assert "1.19.5" not in combination
+        assert "1.18.0" in combination

--- a/tests/test_specifiers.py
+++ b/tests/test_specifiers.py
@@ -633,6 +633,9 @@ class TestSpecifier:
     def test_specifier_equal_for_compatible_operator(self):
         assert Specifier("~=1.18.0") != Specifier("~=1.18")
 
+    def test_specifier_hash_for_compatible_operator(self):
+        assert hash(Specifier("~=1.18.0")) != hash(Specifier("~=1.18"))
+
 
 class TestLegacySpecifier:
     def test_legacy_specifier_is_deprecated(self):

--- a/tests/test_specifiers.py
+++ b/tests/test_specifiers.py
@@ -630,6 +630,9 @@ class TestSpecifier:
         items = {str(item) for item in spec}
         assert items == set(expected_items)
 
+    def test_specifier_equal_for_compatible_operator(self):
+        assert Specifier("~=1.18.0") != Specifier("~=1.18")
+
 
 class TestLegacySpecifier:
     def test_legacy_specifier_is_deprecated(self):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -56,6 +56,11 @@ def test_canonicalize_version(version, expected):
     assert canonicalize_version(version) == expected
 
 
+@pytest.mark.parametrize(("version"), ["1.4.0", "1.0"])
+def test_canonicalize_version_no_strip_trailing_zero(version):
+    assert canonicalize_version(version, strip_trailing_zero=False) == version
+
+
 @pytest.mark.parametrize(
     ("filename", "name", "version", "build", "tags"),
     [


### PR DESCRIPTION
When comparing two specifier with the compatible operator, tailing zeros are incorrectly stripped.

Closes #421