### PR TITLE
Add `__hash__`/`__eq__` to requirements

### DIFF
--- a/docs/markers.rst
+++ b/docs/markers.rst
@@ -48,7 +48,7 @@ Usage
     >>> # You can do simple comparisons between marker objects:
     >>> Marker("python_version > '3.6'") == Marker("python_version > '3.6'")
     True
-    >>> # You can also do simple comparissons between sets of markers:
+    >>> # You can also perform simple comparisons between sets of markers:
     >>> markers1 = {Marker("python_version > '3.6'"), Marker('os_name == "unix"')}
     >>> markers2 = {Marker('os_name == "unix"'), Marker("python_version > '3.6'")}
     >>> markers1 == markers2

--- a/docs/markers.rst
+++ b/docs/markers.rst
@@ -45,6 +45,14 @@ Usage
     >>> extra_environment['extra'] = 'bar'
     >>> extra.evaluate(environment=extra_environment)
     True
+    >>> # You can do simple comparisons between marker objects:
+    >>> Marker("python_version > '3.6'") == Marker("python_version > '3.6'")
+    True
+    >>> # You can also do simple comparissons between sets of markers:
+    >>> markers1 = {Marker("python_version > '3.6'"), Marker('os_name == "unix"')}
+    >>> markers2 = {Marker('os_name == "unix"'), Marker("python_version > '3.6'")}
+    >>> markers1 == markers2
+    True
 
 
 Reference

--- a/docs/requirements.rst
+++ b/docs/requirements.rst
@@ -50,7 +50,7 @@ Usage
     >>> # You can do simple comparisons between requirement objects:
     >>> Requirement("packaging") == Requirement("packaging")
     True
-    >>> # You can also do simple comparissons between sets of requirements:
+    >>> # You can also perform simple comparisons between sets of requirements:
     >>> requirements1 = {Requirement("packaging"), Requirement("pip")}
     >>> requirements2 = {Requirement("pip"), Requirement("packaging")}
     >>> requirements1 == requirements2

--- a/docs/requirements.rst
+++ b/docs/requirements.rst
@@ -47,7 +47,7 @@ Usage
     set()
     >>> url_req.marker
     <Marker('os_name == "a"')>
-    >>> # You can do simple comparissons between requirement objects:
+    >>> # You can do simple comparisons between requirement objects:
     >>> Requirement("packaging") == Requirement("packaging")
     True
     >>> # You can also do simple comparissons between sets of requirements:

--- a/docs/requirements.rst
+++ b/docs/requirements.rst
@@ -47,6 +47,14 @@ Usage
     set()
     >>> url_req.marker
     <Marker('os_name == "a"')>
+    >>> # You can do simple comparissons between requirement objects:
+    >>> Requirement("packaging") == Requirement("packaging")
+    True
+    >>> # You can also do simple comparissons between sets of requirements:
+    >>> requirements1 = {Requirement("packaging"), Requirement("pip")}
+    >>> requirements2 = {Requirement("pip"), Requirement("packaging")}
+    >>> requirements1 == requirements2
+    True
 
 
 Reference

--- a/packaging/markers.py
+++ b/packaging/markers.py
@@ -279,7 +279,7 @@ class Marker:
             # The attribute `_markers` can be described in terms of a recursive type:
             # MarkerList = List[Union[Tuple[Node, ...], str, MarkerList]]
             #
-            # For example the following expression:
+            # For example, the following expression:
             # python_version > "3.6" or (python_version == "3.6" and os_name == "unix")
             #
             # is parsed into:

--- a/packaging/markers.py
+++ b/packaging/markers.py
@@ -62,9 +62,6 @@ class Node:
     def __repr__(self) -> str:
         return f"<{self.__class__.__name__}('{self}')>"
 
-    def __eq__(self, other: Any) -> bool:
-        return bool(self.value == other.value)
-
     def serialize(self) -> str:
         raise NotImplementedError
 
@@ -175,21 +172,6 @@ def _format_marker(
         return " ".join([m.serialize() for m in marker])
     else:
         return marker
-
-
-def _flatten_marker(
-    marker: Union[List[Any], Tuple[Node, ...]]
-) -> Union[List[Any], Tuple[Node, ...]]:
-    """Un-nest the parsed-equivalent of parenthesis with a single expression."""
-    assert isinstance(marker, (list, tuple))
-
-    if isinstance(marker, tuple):
-        return marker
-
-    if len(marker) == 1:
-        return _flatten_marker(marker[0])
-
-    return [_flatten_marker(e) if isinstance(e, list) else e for e in marker]
 
 
 _operators: Dict[str, Operator] = {
@@ -329,7 +311,7 @@ class Marker:
         if not isinstance(other, Marker):
             return NotImplemented
 
-        return _flatten_marker(self._markers) == _flatten_marker(other._markers)
+        return str(self) == str(other)
 
     def evaluate(self, environment: Optional[Dict[str, str]] = None) -> bool:
         """Evaluate a marker.

--- a/packaging/markers.py
+++ b/packaging/markers.py
@@ -326,7 +326,7 @@ class Marker:
         return hash((self.__class__.__name__, str(self)))
 
     def __eq__(self, other: Any) -> bool:
-        if self.__class__ != other.__class__:
+        if not isinstance(other, Marker):
             return NotImplemented
 
         return _flatten_marker(self._markers) == _flatten_marker(other._markers)

--- a/packaging/requirements.py
+++ b/packaging/requirements.py
@@ -149,4 +149,13 @@ class Requirement:
         return hash((self.__class__.__name__, str(self)))
 
     def __eq__(self, other: Any) -> bool:
-        return bool(self.__class__ == other.__class__ and str(self) == str(other))
+        if self.__class__ != other.__class__:
+            return NotImplemented
+
+        return bool(
+            self.name == other.name
+            and self.extras == other.extras
+            and self.specifier == other.specifier
+            and self.url == other.url
+            and self.marker == other.marker
+        )

--- a/packaging/requirements.py
+++ b/packaging/requirements.py
@@ -149,7 +149,7 @@ class Requirement:
         return hash((self.__class__.__name__, str(self)))
 
     def __eq__(self, other: Any) -> bool:
-        if self.__class__ != other.__class__:
+        if not isinstance(other, Requirement):
             return NotImplemented
 
         return bool(

--- a/packaging/requirements.py
+++ b/packaging/requirements.py
@@ -152,7 +152,7 @@ class Requirement:
         if not isinstance(other, Requirement):
             return NotImplemented
 
-        return bool(
+        return (
             self.name == other.name
             and self.extras == other.extras
             and self.specifier == other.specifier

--- a/packaging/requirements.py
+++ b/packaging/requirements.py
@@ -5,7 +5,7 @@
 import re
 import string
 import urllib.parse
-from typing import List, Optional as TOptional, Set
+from typing import Any, List, Optional as TOptional, Set
 
 from pyparsing import (  # noqa
     Combine,
@@ -144,3 +144,9 @@ class Requirement:
 
     def __repr__(self) -> str:
         return f"<Requirement('{self}')>"
+
+    def __hash__(self) -> int:
+        return hash((self.__class__.__name__, str(self)))
+
+    def __eq__(self, other: Any) -> bool:
+        return bool(self.__class__ == other.__class__ and str(self) == str(other))

--- a/tests/test_markers.py
+++ b/tests/test_markers.py
@@ -218,7 +218,7 @@ class TestMarker:
     @pytest.mark.parametrize(
         ("example1", "example2"),
         [
-            # Test trivial comparisons
+            # Test trivial comparisons.
             ('python_version == "2.7"', 'python_version == "3.7"'),
             (
                 'python_version == "2.7"',
@@ -228,7 +228,7 @@ class TestMarker:
                 'python_version == "2.7"',
                 '(python_version == "2.7" and os_name == "linux")',
             ),
-            # Test different precedence
+            # Test different precedence.
             (
                 'python_version == "2.7" and (os_name == "linux" or '
                 'sys_platform == "win32")',

--- a/tests/test_markers.py
+++ b/tests/test_markers.py
@@ -241,10 +241,12 @@ class TestMarker:
         marker1, marker2 = Marker(example1), Marker(example2)
         # Markers created from strings that are not equivalent should differ.
         assert marker1 != marker2
-        # Markers should not be comparable with other kinds of objects.
-        assert marker1 != example1
         # Different Marker objects should have different hashes.
         assert hash(marker1) != hash(marker2)
+
+    def test_compare_markers_to_other_objects(self):
+        # Markers should not be comparable to other kinds of objects.
+        assert Marker("os_name == 'nt'") != "os_name == 'nt'"
 
     def test_extra_with_no_extra_in_environment(self):
         # We can't evaluate an extra if no extra is passed into the environment

--- a/tests/test_markers.py
+++ b/tests/test_markers.py
@@ -206,9 +206,14 @@ class TestMarker:
         m = Marker(marker_string)
         assert str(m) == expected
         assert repr(m) == f"<Marker({str(m)!r})>"
+        # Objects created from the same string should be equal.
         assert m == Marker(marker_string)
+        # Objects created from the equivalent strings should also be equal.
         assert m == Marker(expected)
-        assert {m} == {Marker(expected)}
+        # Objects created from the same string should have the same hash.
+        assert hash(Marker(marker_string)) == hash(Marker(marker_string))
+        # Objects created from equivalent strings should also have the same hash.
+        assert hash(Marker(marker_string)) == hash(Marker(expected))
 
     @pytest.mark.parametrize(
         ("example1", "example2"),
@@ -232,12 +237,14 @@ class TestMarker:
             ),
         ],
     )
-    def test_not_eq_not_same_hash(self, example1, example2):
+    def test_different_markers_different_hashes(self, example1, example2):
         marker1, marker2 = Marker(example1), Marker(example2)
+        # Markers created from strings that are not equivalent should differ.
         assert marker1 != marker2
-        assert {marker1} != {marker2}
-        # Test comparison with another object type:
+        # Markers should not be comparable with other kinds of objects.
         assert marker1 != example1
+        # Different Marker objects should have different hashes.
+        assert hash(marker1) != hash(marker2)
 
     def test_extra_with_no_extra_in_environment(self):
         # We can't evaluate an extra if no extra is passed into the environment

--- a/tests/test_markers.py
+++ b/tests/test_markers.py
@@ -202,10 +202,42 @@ class TestMarker:
             ),
         ],
     )
-    def test_str_and_repr(self, marker_string, expected):
+    def test_str_repr_eq_hash(self, marker_string, expected):
         m = Marker(marker_string)
         assert str(m) == expected
         assert repr(m) == f"<Marker({str(m)!r})>"
+        assert m == Marker(marker_string)
+        assert m == Marker(expected)
+        assert {m} == {Marker(expected)}
+
+    @pytest.mark.parametrize(
+        ("example1", "example2"),
+        [
+            # Test trivial comparisons
+            ('python_version == "2.7"', 'python_version == "3.7"'),
+            (
+                'python_version == "2.7"',
+                'python_version == "2.7" and os_name == "linux"',
+            ),
+            (
+                'python_version == "2.7"',
+                '(python_version == "2.7" and os_name == "linux")',
+            ),
+            # Test different precedence
+            (
+                'python_version == "2.7" and (os_name == "linux" or '
+                'sys_platform == "win32")',
+                'python_version == "2.7" and os_name == "linux" or '
+                'sys_platform == "win32"',
+            ),
+        ],
+    )
+    def test_not_eq_not_same_hash(self, example1, example2):
+        marker1, marker2 = Marker(example1), Marker(example2)
+        assert marker1 != marker2
+        assert {marker1} != {marker2}
+        # Test comparison with another object type:
+        assert marker1 != example1
 
     def test_extra_with_no_extra_in_environment(self):
         # We can't evaluate an extra if no extra is passed into the environment

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -240,6 +240,10 @@ class TestRequirements:
         req1, req2 = Requirement(dep1), Requirement(dep2)
         assert req1 != req2
 
+        # Test comparison with different type of objects:
+        assert req1 != dep1
+        assert req2 != dep2
+
     def test_hashable_equal(self):
         group1 = frozenset(Requirement(pair[0]) for pair in self.EQUAL_DEPENDENCIES)
         group2 = frozenset(Requirement(pair[1]) for pair in self.EQUAL_DEPENDENCIES)

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -195,3 +195,65 @@ class TestRequirements:
         assert "Expected stringEnd" in str(e.value) or (
             "Expected string_end" in str(e.value)  # pyparsing>=3.0.0
         )
+
+    EQUAL_DEPENDENCIES = [
+        ("packaging>20.1", "packaging>20.1"),
+        (
+            'requests[security, tests]>=2.8.1,==2.8.*;python_version<"2.7"',
+            'requests [security,tests] >= 2.8.1, == 2.8.* ; python_version < "2.7"',
+        ),
+        (
+            'importlib-metadata; python_version<"3.8"',
+            "importlib-metadata; python_version<'3.8'",
+        ),
+        (
+            'appdirs>=1.4.4,<2; os_name=="posix" and extra=="testing"',
+            "appdirs>=1.4.4,<2; os_name == 'posix' and extra == 'testing'",
+        ),
+    ]
+
+    DIFFERENT_DEPENDENCIES = [
+        ("packaging>20.1", "packaging>=20.1"),
+        ("packaging>20.1", "packaging>21.1"),
+        ("packaging>20.1", "package>20.1"),
+        (
+            'requests[security,tests]>=2.8.1,==2.8.*;python_version<"2.7"',
+            'requests [security,tests] >= 2.8.1 ; python_version < "2.7"',
+        ),
+        (
+            'importlib-metadata; python_version<"3.8"',
+            "importlib-metadata; python_version<'3.7'",
+        ),
+        (
+            'appdirs>=1.4.4,<2; os_name=="posix" and extra=="testing"',
+            "appdirs>=1.4.4,<2; os_name == 'posix' and extra == 'docs'",
+        ),
+    ]
+
+    @pytest.mark.parametrize("dep1, dep2", EQUAL_DEPENDENCIES)
+    def test_comparable_equal(self, dep1, dep2):
+        req1, req2 = Requirement(dep1), Requirement(dep2)
+        assert req1 == req2
+
+    @pytest.mark.parametrize("dep1, dep2", DIFFERENT_DEPENDENCIES)
+    def test_comparable_different(self, dep1, dep2):
+        req1, req2 = Requirement(dep1), Requirement(dep2)
+        assert req1 != req2
+
+    def test_hashable_equal(self):
+        group1 = frozenset(Requirement(pair[0]) for pair in self.EQUAL_DEPENDENCIES)
+        group2 = frozenset(Requirement(pair[1]) for pair in self.EQUAL_DEPENDENCIES)
+        assert group1 == group2
+
+        values1 = {r: r.name for r in group1}
+        values2 = {r: r.name for r in group2}
+        assert values1 == values2
+
+    def test_hashable_different(self):
+        group1 = frozenset(Requirement(pair[0]) for pair in self.DIFFERENT_DEPENDENCIES)
+        group2 = frozenset(Requirement(pair[1]) for pair in self.DIFFERENT_DEPENDENCIES)
+        assert group1 != group2
+
+        values1 = {r: r.name for r in group1}
+        values2 = {r: r.name for r in group2}
+        assert values1 != values2

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -231,33 +231,20 @@ class TestRequirements:
     ]
 
     @pytest.mark.parametrize("dep1, dep2", EQUAL_DEPENDENCIES)
-    def test_comparable_equal(self, dep1, dep2):
+    def test_equal_reqs_equal_hashes(self, dep1, dep2):
+        # Requirement objects created from equivalent strings should be equal.
         req1, req2 = Requirement(dep1), Requirement(dep2)
         assert req1 == req2
+        # Equal Requirement objects should have the same hash.
+        assert hash(req1) == hash(req2)
 
     @pytest.mark.parametrize("dep1, dep2", DIFFERENT_DEPENDENCIES)
-    def test_comparable_different(self, dep1, dep2):
+    def test_different_reqs_different_hashes(self, dep1, dep2):
+        # Requirement objects created from non-equivalent strings should differ.
         req1, req2 = Requirement(dep1), Requirement(dep2)
         assert req1 != req2
-
-        # Test comparison with different type of objects:
+        # Requirement objects should not be comparable with other kinds of objects.
         assert req1 != dep1
         assert req2 != dep2
-
-    def test_hashable_equal(self):
-        group1 = frozenset(Requirement(pair[0]) for pair in self.EQUAL_DEPENDENCIES)
-        group2 = frozenset(Requirement(pair[1]) for pair in self.EQUAL_DEPENDENCIES)
-        assert group1 == group2
-
-        values1 = {r: r.name for r in group1}
-        values2 = {r: r.name for r in group2}
-        assert values1 == values2
-
-    def test_hashable_different(self):
-        group1 = frozenset(Requirement(pair[0]) for pair in self.DIFFERENT_DEPENDENCIES)
-        group2 = frozenset(Requirement(pair[1]) for pair in self.DIFFERENT_DEPENDENCIES)
-        assert group1 != group2
-
-        values1 = {r: r.name for r in group1}
-        values2 = {r: r.name for r in group2}
-        assert values1 != values2
+        # Different Requirement objects should have different hashes.
+        assert hash(req1) != hash(req2)

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -243,8 +243,9 @@ class TestRequirements:
         # Requirement objects created from non-equivalent strings should differ.
         req1, req2 = Requirement(dep1), Requirement(dep2)
         assert req1 != req2
-        # Requirement objects should not be comparable with other kinds of objects.
-        assert req1 != dep1
-        assert req2 != dep2
         # Different Requirement objects should have different hashes.
         assert hash(req1) != hash(req2)
+
+    def test_compare_reqs_to_other_objects(self):
+        # Requirement objects should not be comparable to other kinds of objects.
+        assert Requirement("packaging>=21.3") != "packaging>=21.3"


### PR DESCRIPTION
Hello, this PR is a feature request that started as a conversation in https://github.com/pypa/packaging/pull/498#discussion_r786691387. I also believe it might close #453.

The idea here is to be able to compare requirement objects as well as be able to compare sets containing those objects, e.g.:
```python
Requirement("packaging") == Requirement("packaging")
{Requirement("packaging"), Requirement("appdirs")} == {Requirement("packaging"), Requirement("appdirs")} 
```

The approach I used was to rely on the normalization that happens when the requirement object is converted to string to implement both `__eq__` and `__hash__`.