### PR TITLE
Remove support for Python 3.6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         os: [Ubuntu, Windows, macOS]
         python_version:
-          ["3.6", "3.7", "3.8", "3.9", "3.10", "pypy-3.7"]
+          ["3.7", "3.8", "3.9", "3.10", "pypy-3.7"]
 
     steps:
       - uses: actions/checkout@v1

--- a/docs/development/getting-started.rst
+++ b/docs/development/getting-started.rst
@@ -30,10 +30,10 @@ each supported Python version and run the tests. For example:
     $ nox -s tests
     ...
     nox > Ran multiple sessions:
-    nox > * tests-3.6: success
     nox > * tests-3.7: success
     nox > * tests-3.8: success
     nox > * tests-3.9: success
+    nox > * tests-3.10: success
     nox > * tests-pypy3: skipped
 
 You may not have all the required Python versions installed, in which case you

--- a/noxfile.py
+++ b/noxfile.py
@@ -21,7 +21,7 @@ nox.options.sessions = ["lint"]
 nox.options.reuse_existing_virtualenvs = True
 
 
-@nox.session(python=["3.6", "3.7", "3.8", "3.9", "3.10", "pypy3"])
+@nox.session(python=["3.7", "3.8", "3.9", "3.10", "pypy3"])
 def tests(session):
     def coverage(*args):
         session.run("python", "-m", "coverage", *args)

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     url=about["__uri__"],
     author=about["__author__"],
     author_email=about["__email__"],
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     install_requires=["pyparsing>=2.0.2,!=3.0.5"],  # 2.0.2 + needed to avoid issue #91
     classifiers=[
         "Development Status :: 5 - Production/Stable",
@@ -57,7 +57,6 @@ setup(
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
Based on the comment in https://github.com/pypa/packaging/issues/383#issuecomment-1014187802, it seems that packaging will eventually drop support for Python 3.6, after the EoS.

Whenever the maintainers decide it is the right moment, I hope this PR helps 😄 (it is very trivial, but maybe it helps to make the work as easy as to press some buttons).

I went through the files checking that there was no conditional import and I also run pyugrade to double check something was missing.