### PR TITLE
Fix issue link in changelog.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -116,7 +116,7 @@ No unreleased changes.
 
 * Officially support Python 3.8 (:issue:`232`)
 
-* Add ``major``, ``minor``, and ``micro`` aliases to ``packaging.version.Version`` (:issue:`226`)
+* Add ``major``, ``minor``, and ``micro`` aliases to ``packaging.version.Version`` (:issue:`225`)
 
 * Properly mark ``packaging`` has being fully typed by adding a `py.typed` file (:issue:`226`)
 


### PR DESCRIPTION
This fixes a tiny error in the changelog. Issue #226 was linked, but it should point to issue #225.

I verified that the ReadTheDocs build looks correct for this PR: https://packaging--509.org.readthedocs.build/en/509/changelog.html#id14

Thank you very much for maintaining this package! 👍