### PR TITLE
fix: macOS platform tags with old macOS SDK

### DIFF
--- a/packaging/tags.py
+++ b/packaging/tags.py
@@ -4,6 +4,7 @@
 
 import logging
 import platform
+import subprocess
 import sys
 import sysconfig
 from importlib.machinery import EXTENSION_SUFFIXES
@@ -356,6 +357,22 @@ def mac_platforms(
     version_str, _, cpu_arch = platform.mac_ver()
     if version is None:
         version = cast("MacVersion", tuple(map(int, version_str.split(".")[:2])))
+        if version == (10, 16):
+            # When built against an older macOS SDK, Python will report macOS 10.16
+            # instead of the real version.
+            version_str = subprocess.run(
+                [
+                    sys.executable,
+                    "-sS",
+                    "-c",
+                    "import platform; print(platform.mac_ver()[0])",
+                ],
+                check=True,
+                env={"SYSTEM_VERSION_COMPAT": "0"},
+                stdout=subprocess.PIPE,
+                universal_newlines=True,
+            ).stdout
+            version = cast("MacVersion", tuple(map(int, version_str.split(".")[:2])))
     else:
         version = version
     if arch is None:

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -4,6 +4,7 @@
 
 
 import collections.abc
+import subprocess
 
 try:
     import ctypes
@@ -230,11 +231,47 @@ class TestMacOSPlatforms:
         version = platform.mac_ver()[0].split(".")
         major = version[0]
         minor = version[1] if major == "10" else "0"
-        expected = f"macosx_{major}_{minor}"
+
+        platforms = list(tags.mac_platforms(arch="x86_64"))
+        if (major, minor) == ("10", "16"):
+            print(platforms, "macosx_11+")
+            # For 10.16, the real version is at least 11.0.
+            prefix, major, minor, _ = platforms[0].split("_", maxsplit=3)
+            assert prefix == "macosx"
+            assert int(major) >= 11
+            assert minor == "0"
+        else:
+            expected = f"macosx_{major}_{minor}_"
+            print(platforms, expected)
+            assert platforms[0].startswith(expected)
+
+    def test_version_detection_10_15(self, monkeypatch):
+        monkeypatch.setattr(
+            platform, "mac_ver", lambda: ("10.15", ("", "", ""), "x86_64")
+        )
+        expected = "macosx_10_15_"
 
         platforms = list(tags.mac_platforms(arch="x86_64"))
         print(platforms, expected)
         assert platforms[0].startswith(expected)
+
+    def test_version_detection_compatibility(self, monkeypatch):
+        if platform.system() != "Darwin":
+            monkeypatch.setattr(
+                subprocess,
+                "run",
+                lambda *args, **kwargs: subprocess.CompletedProcess(
+                    [], 0, stdout="10.15"
+                ),
+            )
+        monkeypatch.setattr(
+            platform, "mac_ver", lambda: ("10.16", ("", "", ""), "x86_64")
+        )
+        unexpected = "macosx_10_16_"
+
+        platforms = list(tags.mac_platforms(arch="x86_64"))
+        print(platforms, unexpected)
+        assert not platforms[0].startswith(unexpected)
 
     @pytest.mark.parametrize("arch", ["x86_64", "i386"])
     def test_arch_detection(self, arch, monkeypatch):


### PR DESCRIPTION
This retrieves the real macOS version to compute macOS platform tags when the python interpreter is built with an old macOS SDK.

fixes #497

There are no official docs from Apple on this. This is based on a couple blog posts linked in #497 and my own observations. Most notably, since there are no docs, I can't be sure that the only effect of Apple's trick is to change the version. There might be other (still undocumented...) side-effects.