### PR TITLE
Always run GHA workflows when they change

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,9 +3,11 @@ name: Documentation
 on:
   pull_request:
     paths:
+      - ".github/workflows/docs.yml"
       - 'docs/**'
   push:
     paths:
+      - ".github/workflows/docs.yml"
       - 'docs/**'
 
 concurrency:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,9 +3,11 @@ name: Linting
 on:
   pull_request:
     paths:
+      - ".github/workflows/lint.yml"
       - "**.py"
   push:
     paths:
+      - ".github/workflows/lint.yml"
       - "**.py"
 
 concurrency:


### PR DESCRIPTION
The lint & docs workflows are not built when they changed.
Update them to run when they are modified (as is done in the test workflow).