### PR TITLE
Error out from workflow on missing interpreter

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,4 +34,4 @@ jobs:
           python -m pip install --upgrade nox
 
       - name: Build documentation
-        run: python -m nox -s docs
+        run: python -m nox --error-on-missing-interpreters -s docs

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,7 +34,7 @@ jobs:
           python -m pip install --upgrade nox
 
       - name: Run `nox -s lint`
-        run: python -m nox -s lint
+        run: python -m nox --error-on-missing-interpreters -s lint
 
   build:
     name: Build sdist and wheel


### PR DESCRIPTION
The `lint` and `docs` workflow will fail silently if there's a
mismatch between the python version setup in the workflow and
the one required in `noxfile.py`.

Run nox with `--error-on-missing-interpreters` to error out rather
than silently skipping the session.
