### PR TITLE
Enfoce https://reuse.software compliance

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2014-2022 Donald Stufft and individual contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-2-Clause OR Apache-2.0
+
 [run]
 branch = True
 omit = packaging/_compat.py

--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,7 @@
+; SPDX-FileCopyrightText: 2014-2022 Donald Stufft and individual contributors. All rights reserved.
+;
+; SPDX-License-Identifier: BSD-2-Clause OR Apache-2.0
+
 [flake8]
 max-line-length = 88
 ignore = E203,W503,W504

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2014-2022 Donald Stufft and individual contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-2-Clause OR Apache-2.0
+
 name: Documentation
 
 on:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2014-2022 Donald Stufft and individual contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-2-Clause OR Apache-2.0
+
 name: Linting
 
 on:

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2022 Free Software Foundation Europe e.V. <https://fsfe.org>
+#
+# SPDX-License-Identifier: CC0-1.0
+
+# Copied from https://github.com/fsfe/reuse-action#example-usage
+
+name: REUSE Compliance Check
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps: 
+    - uses: actions/checkout@v2
+    - name: REUSE Compliance Check
+      uses: fsfe/reuse-action@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2014-2022 Donald Stufft and individual contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-2-Clause OR Apache-2.0
+
 name: Test
 
 on:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2014-2022 Donald Stufft and individual contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-2-Clause OR Apache-2.0
+
 *.egg-info/
 *.egg
 *.py[co]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2014-2022 Donald Stufft and individual contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-2-Clause OR Apache-2.0
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.4.0

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2014-2022 Donald Stufft and individual contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-2-Clause OR Apache-2.0
+
 version: 2
 
 build:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2014-2022 Donald Stufft and individual contributors. All rights reserved.
+..
+.. SPDX-License-Identifier: BSD-2-Clause OR Apache-2.0
+
 Changelog
 ---------
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2014-2022 Donald Stufft and individual contributors. All rights reserved.
+..
+.. SPDX-License-Identifier: BSD-2-Clause OR Apache-2.0
+
 Contributing to packaging
 =========================
 

--- a/LICENSES/Apache-2.0.txt
+++ b/LICENSES/Apache-2.0.txt
@@ -1,0 +1,73 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+
+     (a) You must give any other recipients of the Work or Derivative Works a copy of this License; and
+
+     (b) You must cause any modified files to carry prominent notices stating that You changed the files; and
+
+     (c) You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+
+     (d) If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License.
+
+     You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following boilerplate notice, with the fields enclosed by brackets "[]" replaced with your own identifying information. (Don't include the brackets!)  The text should be enclosed in the appropriate comment syntax for the file format. We also recommend that a file or class name and description of purpose be included on the same "printed page" as the copyright notice for easier identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/LICENSES/BSD-2-Clause.txt
+++ b/LICENSES/BSD-2-Clause.txt
@@ -1,0 +1,9 @@
+Copyright (c) <year> <owner> 
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/LICENSES/CC0-1.0.txt
+++ b/LICENSES/CC0-1.0.txt
@@ -1,0 +1,121 @@
+Creative Commons Legal Code
+
+CC0 1.0 Universal
+
+    CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
+    LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
+    ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
+    INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
+    REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS
+    PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
+    THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
+    HEREUNDER.
+
+Statement of Purpose
+
+The laws of most jurisdictions throughout the world automatically confer
+exclusive Copyright and Related Rights (defined below) upon the creator
+and subsequent owner(s) (each and all, an "owner") of an original work of
+authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work for
+the purpose of contributing to a commons of creative, cultural and
+scientific works ("Commons") that the public can reliably and without fear
+of later claims of infringement build upon, modify, incorporate in other
+works, reuse and redistribute as freely as possible in any form whatsoever
+and for any purposes, including without limitation commercial purposes.
+These owners may contribute to the Commons to promote the ideal of a free
+culture and the further production of creative, cultural and scientific
+works, or to gain reputation or greater distribution for their Work in
+part through the use and efforts of others.
+
+For these and/or other purposes and motivations, and without any
+expectation of additional consideration or compensation, the person
+associating CC0 with a Work (the "Affirmer"), to the extent that he or she
+is an owner of Copyright and Related Rights in the Work, voluntarily
+elects to apply CC0 to the Work and publicly distribute the Work under its
+terms, with knowledge of his or her Copyright and Related Rights in the
+Work and the meaning and intended legal effect of CC0 on those rights.
+
+1. Copyright and Related Rights. A Work made available under CC0 may be
+protected by copyright and related or neighboring rights ("Copyright and
+Related Rights"). Copyright and Related Rights include, but are not
+limited to, the following:
+
+  i. the right to reproduce, adapt, distribute, perform, display,
+     communicate, and translate a Work;
+ ii. moral rights retained by the original author(s) and/or performer(s);
+iii. publicity and privacy rights pertaining to a person's image or
+     likeness depicted in a Work;
+ iv. rights protecting against unfair competition in regards to a Work,
+     subject to the limitations in paragraph 4(a), below;
+  v. rights protecting the extraction, dissemination, use and reuse of data
+     in a Work;
+ vi. database rights (such as those arising under Directive 96/9/EC of the
+     European Parliament and of the Council of 11 March 1996 on the legal
+     protection of databases, and under any national implementation
+     thereof, including any amended or successor version of such
+     directive); and
+vii. other similar, equivalent or corresponding rights throughout the
+     world based on applicable law or treaty, and any national
+     implementations thereof.
+
+2. Waiver. To the greatest extent permitted by, but not in contravention
+of, applicable law, Affirmer hereby overtly, fully, permanently,
+irrevocably and unconditionally waives, abandons, and surrenders all of
+Affirmer's Copyright and Related Rights and associated claims and causes
+of action, whether now known or unknown (including existing as well as
+future claims and causes of action), in the Work (i) in all territories
+worldwide, (ii) for the maximum duration provided by applicable law or
+treaty (including future time extensions), (iii) in any current or future
+medium and for any number of copies, and (iv) for any purpose whatsoever,
+including without limitation commercial, advertising or promotional
+purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each
+member of the public at large and to the detriment of Affirmer's heirs and
+successors, fully intending that such Waiver shall not be subject to
+revocation, rescission, cancellation, termination, or any other legal or
+equitable action to disrupt the quiet enjoyment of the Work by the public
+as contemplated by Affirmer's express Statement of Purpose.
+
+3. Public License Fallback. Should any part of the Waiver for any reason
+be judged legally invalid or ineffective under applicable law, then the
+Waiver shall be preserved to the maximum extent permitted taking into
+account Affirmer's express Statement of Purpose. In addition, to the
+extent the Waiver is so judged Affirmer hereby grants to each affected
+person a royalty-free, non transferable, non sublicensable, non exclusive,
+irrevocable and unconditional license to exercise Affirmer's Copyright and
+Related Rights in the Work (i) in all territories worldwide, (ii) for the
+maximum duration provided by applicable law or treaty (including future
+time extensions), (iii) in any current or future medium and for any number
+of copies, and (iv) for any purpose whatsoever, including without
+limitation commercial, advertising or promotional purposes (the
+"License"). The License shall be deemed effective as of the date CC0 was
+applied by Affirmer to the Work. Should any part of the License for any
+reason be judged legally invalid or ineffective under applicable law, such
+partial invalidity or ineffectiveness shall not invalidate the remainder
+of the License, and in such case Affirmer hereby affirms that he or she
+will not (i) exercise any of his or her remaining Copyright and Related
+Rights in the Work or (ii) assert any associated claims and causes of
+action with respect to the Work, in either case contrary to Affirmer's
+express Statement of Purpose.
+
+4. Limitations and Disclaimers.
+
+ a. No trademark or patent rights held by Affirmer are waived, abandoned,
+    surrendered, licensed or otherwise affected by this document.
+ b. Affirmer offers the Work as-is and makes no representations or
+    warranties of any kind concerning the Work, express, implied,
+    statutory or otherwise, including without limitation warranties of
+    title, merchantability, fitness for a particular purpose, non
+    infringement, or the absence of latent or other defects, accuracy, or
+    the present or absence of errors, whether or not discoverable, all to
+    the greatest extent permissible under applicable law.
+ c. Affirmer disclaims responsibility for clearing rights of other persons
+    that may apply to the Work or any use thereof, including without
+    limitation any person's Copyright and Related Rights in the Work.
+    Further, Affirmer disclaims responsibility for obtaining any necessary
+    consents, permissions or other rights required for any use of the
+    Work.
+ d. Affirmer understands and acknowledges that Creative Commons is not a
+    party to this document and has no duty or obligation with respect to
+    this CC0 or use of the Work.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2014-2022 Donald Stufft and individual contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-2-Clause OR Apache-2.0
+
 include CHANGELOG.rst CONTRIBUTING.rst README.rst
 include LICENSE LICENSE.APACHE LICENSE.BSD
 

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2014-2022 Donald Stufft and individual contributors. All rights reserved.
+..
+.. SPDX-License-Identifier: BSD-2-Clause OR Apache-2.0
+
 packaging
 =========
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2014-2022 Donald Stufft and individual contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-2-Clause OR Apache-2.0
+
 # Makefile for Sphinx documentation
 #
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,1 +1,5 @@
+.. SPDX-FileCopyrightText: 2014-2022 Donald Stufft and individual contributors. All rights reserved.
+..
+.. SPDX-License-Identifier: BSD-2-Clause OR Apache-2.0
+
 .. include:: ../CHANGELOG.rst

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2014-2022 Donald Stufft and individual contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-2-Clause OR Apache-2.0
+
 # This file is dual licensed under the terms of the Apache License, Version
 # 2.0, and the BSD License. See the LICENSE file in the root of this repository
 # for complete details.

--- a/docs/development/getting-started.rst
+++ b/docs/development/getting-started.rst
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2014-2022 Donald Stufft and individual contributors. All rights reserved.
+..
+.. SPDX-License-Identifier: BSD-2-Clause OR Apache-2.0
+
 Getting started
 ===============
 

--- a/docs/development/index.rst
+++ b/docs/development/index.rst
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2014-2022 Donald Stufft and individual contributors. All rights reserved.
+..
+.. SPDX-License-Identifier: BSD-2-Clause OR Apache-2.0
+
 Development
 ===========
 

--- a/docs/development/release-process.rst
+++ b/docs/development/release-process.rst
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2014-2022 Donald Stufft and individual contributors. All rights reserved.
+..
+.. SPDX-License-Identifier: BSD-2-Clause OR Apache-2.0
+
 Release Process
 ===============
 

--- a/docs/development/reviewing-patches.rst
+++ b/docs/development/reviewing-patches.rst
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2014-2022 Donald Stufft and individual contributors. All rights reserved.
+..
+.. SPDX-License-Identifier: BSD-2-Clause OR Apache-2.0
+
 Reviewing and merging patches
 =============================
 

--- a/docs/development/submitting-patches.rst
+++ b/docs/development/submitting-patches.rst
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2014-2022 Donald Stufft and individual contributors. All rights reserved.
+..
+.. SPDX-License-Identifier: BSD-2-Clause OR Apache-2.0
+
 Submitting patches
 ==================
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2014-2022 Donald Stufft and individual contributors. All rights reserved.
+..
+.. SPDX-License-Identifier: BSD-2-Clause OR Apache-2.0
+
 Welcome to packaging
 ====================
 

--- a/docs/markers.rst
+++ b/docs/markers.rst
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2014-2022 Donald Stufft and individual contributors. All rights reserved.
+..
+.. SPDX-License-Identifier: BSD-2-Clause OR Apache-2.0
+
 Markers
 =======
 

--- a/docs/requirements.rst
+++ b/docs/requirements.rst
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2014-2022 Donald Stufft and individual contributors. All rights reserved.
+..
+.. SPDX-License-Identifier: BSD-2-Clause OR Apache-2.0
+
 Requirements
 ============
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,5 @@
+# SPDX-FileCopyrightText: 2014-2022 Donald Stufft and individual contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-2-Clause OR Apache-2.0
+
 furo

--- a/docs/security.rst
+++ b/docs/security.rst
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2014-2022 Donald Stufft and individual contributors. All rights reserved.
+..
+.. SPDX-License-Identifier: BSD-2-Clause OR Apache-2.0
+
 Security
 ========
 

--- a/docs/specifiers.rst
+++ b/docs/specifiers.rst
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2014-2022 Donald Stufft and individual contributors. All rights reserved.
+..
+.. SPDX-License-Identifier: BSD-2-Clause OR Apache-2.0
+
 Specifiers
 ==========
 

--- a/docs/tags.rst
+++ b/docs/tags.rst
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2014-2022 Donald Stufft and individual contributors. All rights reserved.
+..
+.. SPDX-License-Identifier: BSD-2-Clause OR Apache-2.0
+
 Tags
 ====
 

--- a/docs/utils.rst
+++ b/docs/utils.rst
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2014-2022 Donald Stufft and individual contributors. All rights reserved.
+..
+.. SPDX-License-Identifier: BSD-2-Clause OR Apache-2.0
+
 Utilities
 =========
 

--- a/docs/version.rst
+++ b/docs/version.rst
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2014-2022 Donald Stufft and individual contributors. All rights reserved.
+..
+.. SPDX-License-Identifier: BSD-2-Clause OR Apache-2.0
+
 Version Handling
 ================
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,3 +1,7 @@
+; SPDX-FileCopyrightText: 2014-2022 Donald Stufft and individual contributors. All rights reserved.
+;
+; SPDX-License-Identifier: BSD-2-Clause OR Apache-2.0
+
 [mypy]
 ignore_missing_imports = True
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2014-2022 Donald Stufft and individual contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-2-Clause OR Apache-2.0
+
 # mypy: disallow-untyped-defs=False, disallow-untyped-calls=False
 
 import contextlib

--- a/packaging/__about__.py
+++ b/packaging/__about__.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2014-2022 Donald Stufft and individual contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-2-Clause OR Apache-2.0
+
 # This file is dual licensed under the terms of the Apache License, Version
 # 2.0, and the BSD License. See the LICENSE file in the root of this repository
 # for complete details.

--- a/packaging/__init__.py
+++ b/packaging/__init__.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2014-2022 Donald Stufft and individual contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-2-Clause OR Apache-2.0
+
 # This file is dual licensed under the terms of the Apache License, Version
 # 2.0, and the BSD License. See the LICENSE file in the root of this repository
 # for complete details.

--- a/packaging/_manylinux.py
+++ b/packaging/_manylinux.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2014-2022 Donald Stufft and individual contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-2-Clause OR Apache-2.0
+
 import collections
 import functools
 import os

--- a/packaging/_musllinux.py
+++ b/packaging/_musllinux.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2014-2022 Donald Stufft and individual contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-2-Clause OR Apache-2.0
+
 """PEP 656 support.
 
 This module implements logic to detect if the currently running Python is

--- a/packaging/_structures.py
+++ b/packaging/_structures.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2014-2022 Donald Stufft and individual contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-2-Clause OR Apache-2.0
+
 # This file is dual licensed under the terms of the Apache License, Version
 # 2.0, and the BSD License. See the LICENSE file in the root of this repository
 # for complete details.

--- a/packaging/markers.py
+++ b/packaging/markers.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2014-2022 Donald Stufft and individual contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-2-Clause OR Apache-2.0
+
 # This file is dual licensed under the terms of the Apache License, Version
 # 2.0, and the BSD License. See the LICENSE file in the root of this repository
 # for complete details.

--- a/packaging/requirements.py
+++ b/packaging/requirements.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2014-2022 Donald Stufft and individual contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-2-Clause OR Apache-2.0
+
 # This file is dual licensed under the terms of the Apache License, Version
 # 2.0, and the BSD License. See the LICENSE file in the root of this repository
 # for complete details.

--- a/packaging/specifiers.py
+++ b/packaging/specifiers.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2014-2022 Donald Stufft and individual contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-2-Clause OR Apache-2.0
+
 # This file is dual licensed under the terms of the Apache License, Version
 # 2.0, and the BSD License. See the LICENSE file in the root of this repository
 # for complete details.

--- a/packaging/tags.py
+++ b/packaging/tags.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2014-2022 Donald Stufft and individual contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-2-Clause OR Apache-2.0
+
 # This file is dual licensed under the terms of the Apache License, Version
 # 2.0, and the BSD License. See the LICENSE file in the root of this repository
 # for complete details.

--- a/packaging/utils.py
+++ b/packaging/utils.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2014-2022 Donald Stufft and individual contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-2-Clause OR Apache-2.0
+
 # This file is dual licensed under the terms of the Apache License, Version
 # 2.0, and the BSD License. See the LICENSE file in the root of this repository
 # for complete details.

--- a/packaging/version.py
+++ b/packaging/version.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2014-2022 Donald Stufft and individual contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-2-Clause OR Apache-2.0
+
 # This file is dual licensed under the terms of the Apache License, Version
 # 2.0, and the BSD License. See the LICENSE file in the root of this repository
 # for complete details.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2014-2022 Donald Stufft and individual contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-2-Clause OR Apache-2.0
+
 [build-system]
 requires = ['setuptools >= 40.8.0', 'wheel']
 build-backend = 'setuptools.build_meta'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2014-2022 Donald Stufft and individual contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-2-Clause OR Apache-2.0
+
 [isort]
 profile = black
 combine_as_imports = true

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python
+
+# SPDX-FileCopyrightText: 2014-2022 Donald Stufft and individual contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-2-Clause OR Apache-2.0
+
 # This file is dual licensed under the terms of the Apache License, Version
 # 2.0, and the BSD License. See the LICENSE file in the root of this repository
 # for complete details.

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2014-2022 Donald Stufft and individual contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-2-Clause OR Apache-2.0
+
 # This file is dual licensed under the terms of the Apache License, Version
 # 2.0, and the BSD License. See the LICENSE file in the root of this repository
 # for complete details.

--- a/tasks/check.py
+++ b/tasks/check.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2014-2022 Donald Stufft and individual contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-2-Clause OR Apache-2.0
+
 # This file is dual licensed under the terms of the Apache License, Version
 # 2.0, and the BSD License. See the LICENSE file in the root of this repository
 # for complete details.

--- a/tasks/paths.py
+++ b/tasks/paths.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2014-2022 Donald Stufft and individual contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-2-Clause OR Apache-2.0
+
 # This file is dual licensed under the terms of the Apache License, Version
 # 2.0, and the BSD License. See the LICENSE file in the root of this repository
 # for complete details.

--- a/tasks/requirements.txt
+++ b/tasks/requirements.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2014-2022 Donald Stufft and individual contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-2-Clause OR Apache-2.0
+
 # The requirements required to invoke the tasks
 invoke
 progress

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2014-2022 Donald Stufft and individual contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-2-Clause OR Apache-2.0
+
 # This file is dual licensed under the terms of the Apache License, Version
 # 2.0, and the BSD License. See the LICENSE file in the root of this repository
 # for complete details.

--- a/tests/hello-world.c
+++ b/tests/hello-world.c
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2014-2022 Donald Stufft and individual contributors. All rights reserved.
+//
+// SPDX-License-Identifier: BSD-2-Clause OR Apache-2.0
+
 #include <stdio.h>
 
 int main(int argc, char* argv[])

--- a/tests/manylinux/build.sh
+++ b/tests/manylinux/build.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# SPDX-FileCopyrightText: 2014-2022 Donald Stufft and individual contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-2-Clause OR Apache-2.0
+
 set -x
 set -e
 

--- a/tests/manylinux/hello-world-armv7l-armel.license
+++ b/tests/manylinux/hello-world-armv7l-armel.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2014-2022 Donald Stufft and individual contributors. All rights reserved.
+
+SPDX-License-Identifier: BSD-2-Clause OR Apache-2.0

--- a/tests/manylinux/hello-world-armv7l-armhf.license
+++ b/tests/manylinux/hello-world-armv7l-armhf.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2014-2022 Donald Stufft and individual contributors. All rights reserved.
+
+SPDX-License-Identifier: BSD-2-Clause OR Apache-2.0

--- a/tests/manylinux/hello-world-invalid-class.license
+++ b/tests/manylinux/hello-world-invalid-class.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2014-2022 Donald Stufft and individual contributors. All rights reserved.
+
+SPDX-License-Identifier: BSD-2-Clause OR Apache-2.0

--- a/tests/manylinux/hello-world-invalid-data.license
+++ b/tests/manylinux/hello-world-invalid-data.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2014-2022 Donald Stufft and individual contributors. All rights reserved.
+
+SPDX-License-Identifier: BSD-2-Clause OR Apache-2.0

--- a/tests/manylinux/hello-world-invalid-magic.license
+++ b/tests/manylinux/hello-world-invalid-magic.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2014-2022 Donald Stufft and individual contributors. All rights reserved.
+
+SPDX-License-Identifier: BSD-2-Clause OR Apache-2.0

--- a/tests/manylinux/hello-world-s390x-s390x.license
+++ b/tests/manylinux/hello-world-s390x-s390x.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2014-2022 Donald Stufft and individual contributors. All rights reserved.
+
+SPDX-License-Identifier: BSD-2-Clause OR Apache-2.0

--- a/tests/manylinux/hello-world-too-short.license
+++ b/tests/manylinux/hello-world-too-short.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2014-2022 Donald Stufft and individual contributors. All rights reserved.
+
+SPDX-License-Identifier: BSD-2-Clause OR Apache-2.0

--- a/tests/manylinux/hello-world-x86_64-amd64.license
+++ b/tests/manylinux/hello-world-x86_64-amd64.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2014-2022 Donald Stufft and individual contributors. All rights reserved.
+
+SPDX-License-Identifier: BSD-2-Clause OR Apache-2.0

--- a/tests/manylinux/hello-world-x86_64-i386.license
+++ b/tests/manylinux/hello-world-x86_64-i386.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2014-2022 Donald Stufft and individual contributors. All rights reserved.
+
+SPDX-License-Identifier: BSD-2-Clause OR Apache-2.0

--- a/tests/manylinux/hello-world-x86_64-x32.license
+++ b/tests/manylinux/hello-world-x86_64-x32.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2014-2022 Donald Stufft and individual contributors. All rights reserved.
+
+SPDX-License-Identifier: BSD-2-Clause OR Apache-2.0

--- a/tests/musllinux/build.sh
+++ b/tests/musllinux/build.sh
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2014-2022 Donald Stufft and individual contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-2-Clause OR Apache-2.0
+
 # Build helper binaries for musllinux tests.
 # Usages:
 #   build.sh  # Build everything.

--- a/tests/musllinux/glibc-x86_64.license
+++ b/tests/musllinux/glibc-x86_64.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2014-2022 Donald Stufft and individual contributors. All rights reserved.
+
+SPDX-License-Identifier: BSD-2-Clause OR Apache-2.0

--- a/tests/musllinux/musl-aarch64.license
+++ b/tests/musllinux/musl-aarch64.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2014-2022 Donald Stufft and individual contributors. All rights reserved.
+
+SPDX-License-Identifier: BSD-2-Clause OR Apache-2.0

--- a/tests/musllinux/musl-i386.license
+++ b/tests/musllinux/musl-i386.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2014-2022 Donald Stufft and individual contributors. All rights reserved.
+
+SPDX-License-Identifier: BSD-2-Clause OR Apache-2.0

--- a/tests/musllinux/musl-x86_64.license
+++ b/tests/musllinux/musl-x86_64.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2014-2022 Donald Stufft and individual contributors. All rights reserved.
+
+SPDX-License-Identifier: BSD-2-Clause OR Apache-2.0

--- a/tests/test_manylinux.py
+++ b/tests/test_manylinux.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2014-2022 Donald Stufft and individual contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-2-Clause OR Apache-2.0
+
 try:
     import ctypes
 except ImportError:

--- a/tests/test_markers.py
+++ b/tests/test_markers.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2014-2022 Donald Stufft and individual contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-2-Clause OR Apache-2.0
+
 # This file is dual licensed under the terms of the Apache License, Version
 # 2.0, and the BSD License. See the LICENSE file in the root of this repository
 # for complete details.

--- a/tests/test_musllinux.py
+++ b/tests/test_musllinux.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2014-2022 Donald Stufft and individual contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-2-Clause OR Apache-2.0
+
 import collections
 import io
 import pathlib

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2014-2022 Donald Stufft and individual contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-2-Clause OR Apache-2.0
+
 # This file is dual licensed under the terms of the Apache License, Version
 # 2.0, and the BSD License. See the LICENSE file in the root of this repository
 # for complete details.

--- a/tests/test_specifiers.py
+++ b/tests/test_specifiers.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2014-2022 Donald Stufft and individual contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-2-Clause OR Apache-2.0
+
 # This file is dual licensed under the terms of the Apache License, Version
 # 2.0, and the BSD License. See the LICENSE file in the root of this repository
 # for complete details.

--- a/tests/test_structures.py
+++ b/tests/test_structures.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2014-2022 Donald Stufft and individual contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-2-Clause OR Apache-2.0
+
 # This file is dual licensed under the terms of the Apache License, Version
 # 2.0, and the BSD License. See the LICENSE file in the root of this repository
 # for complete details.

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2014-2022 Donald Stufft and individual contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-2-Clause OR Apache-2.0
+
 # This file is dual licensed under the terms of the Apache License, Version
 # 2.0, and the BSD License. See the LICENSE file in the root of this repository
 # for complete details.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2014-2022 Donald Stufft and individual contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-2-Clause OR Apache-2.0
+
 # This file is dual licensed under the terms of the Apache License, Version
 # 2.0, and the BSD License. See the LICENSE file in the root of this repository
 # for complete details.

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2014-2022 Donald Stufft and individual contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-2-Clause OR Apache-2.0
+
 # This file is dual licensed under the terms of the Apache License, Version
 # 2.0, and the BSD License. See the LICENSE file in the root of this repository
 # for complete details.


### PR DESCRIPTION
The https://reuse.software specification is the standard for providing machine-readable licensing and copyright information.

I believe:
* machine-readable metadata is a good thing.
* licensing and copyright matter
* automation is a good thing.

Therefore I propose we:
1. Make this repository compliant with the https://reuse.software specification
2. Enfoce compliance via a github action