### PR TITLE
chore: update pre-commit config to the latest repos' versions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,10 +4,12 @@ on:
   pull_request:
     paths:
       - ".github/workflows/lint.yml"
+      - ".pre-commit-config.yaml"
       - "**.py"
   push:
     paths:
       - ".github/workflows/lint.yml"
+      - ".pre-commit-config.yaml"
       - "**.py"
 
 concurrency:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+    rev: v4.2.0
     hooks:
       - id: check-toml
       - id: check-yaml
@@ -8,30 +8,30 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.812
+    rev: v0.942
     hooks:
       - id: mypy
         exclude: '^(docs|tasks|tests)|setup\.py'
         args: []
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.29.0
+    rev: v2.32.0
     hooks:
       - id: pyupgrade
         args: [--py36-plus]
 
   - repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 22.3.0
     hooks:
       - id: black
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.8.0
+    rev: 5.10.1
     hooks:
       - id: isort
 
   - repo: https://gitlab.com/PyCQA/flake8
-    rev: "3.9.0"
+    rev: "3.9.2"
     hooks:
       - id: flake8
         additional_dependencies: ["pep8-naming"]

--- a/packaging/tags.py
+++ b/packaging/tags.py
@@ -36,7 +36,7 @@ INTERPRETER_SHORT_NAMES: Dict[str, str] = {
 }
 
 
-_32_BIT_INTERPRETER = sys.maxsize <= 2 ** 32
+_32_BIT_INTERPRETER = sys.maxsize <= 2**32
 
 
 class Tag:


### PR DESCRIPTION
`nox -s lint` is currently failing due to `black` trying to import a removed private module from `click`.

Running `pre-commit autoupdate`  updates `black` to a version that does work properly with the latest `click`.