### PR TITLE
Run tests with all PyPy versions locally

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,10 +35,9 @@ jobs:
           cache: "pip"
 
       - name: Run nox
-        run: pipx run nox --error-on-missing-interpreters -s tests-${{ matrix.python_version }}
-        if: ${{ ! startsWith( matrix.python_version, 'pypy' ) }}
-
-      # Binary is named 'pypy3', but setup-python specifies it as 'pypy-3.x'.
-      - name: Run nox for pypy3
-        run: pipx run nox --error-on-missing-interpreters -s tests-pypy3
-        if: ${{ startsWith( matrix.python_version, 'pypy' ) }}
+        run: |
+          # Need to fix-up PyPy. This can be removed once https://github.com/actions/setup-python/issues/346 lands.
+          INTERPRETER=${{ matrix.python_version }}
+          INTERPRETER=${INTERPRETER/-/}  # remove the first '-' in "pypy-X.Y" -> "pypyX.Y" to match executable name
+          pipx run nox --error-on-missing-interpreters -s tests-${INTERPRETER}
+        shell: bash

--- a/noxfile.py
+++ b/noxfile.py
@@ -21,7 +21,7 @@ nox.options.sessions = ["lint"]
 nox.options.reuse_existing_virtualenvs = True
 
 
-@nox.session(python=["3.7", "3.8", "3.9", "3.10", "pypy3"])
+@nox.session(python=["3.7", "3.8", "3.9", "3.10", "pypy3.7", "pypy3.8", "pypy3.9"])
 def tests(session):
     def coverage(*args):
         session.run("python", "-m", "coverage", *args)


### PR DESCRIPTION
PyPy 7.3.9 added `pypy3.x.exe` for Windows packages and it's now possible to use this on every OS (was already possible on Linux & macOS).
This also allows to simplify the GHA test workflow.

The GHA workflow will be simplified even more once https://github.com/actions/setup-python/issues/346 lands.
c.f. https://github.com/mayeut/packaging/blob/update-pypy-tests/.github/workflows/test.yml