### PR TITLE
Add copy constructors for Version and similar classes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,8 @@ Changelog
 *unreleased*
 ~~~~~~~~~~~~
 
-No unreleased changes.
+* Classes ``Version``, ``Requirement``, ``Specifier`` and ``SpecifierSet`` now accept
+  a value of the corresponding type and return a copy (:issue:`454`)
 
 21.3 - 2021-11-17
 ~~~~~~~~~~~~~~~~~

--- a/packaging/version.py
+++ b/packaging/version.py
@@ -258,7 +258,12 @@ class Version(_BaseVersion):
 
     _regex = re.compile(r"^\s*" + VERSION_PATTERN + r"\s*$", re.VERBOSE | re.IGNORECASE)
 
-    def __init__(self, version: str) -> None:
+    def __init__(self, version: Union[str, "Version"]) -> None:
+
+        if isinstance(version, Version):
+            self._version: _Version = version._version
+            self._key = version._key
+            return
 
         # Validate the version and parse it into pieces
         match = self._regex.search(version)

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -15,6 +15,11 @@ class TestRequirements:
         req = Requirement(requirement)
         assert str(req) == requirement
 
+    def test_requirement_accepts_requirement(self):
+        requirement = 'name[bar]>=3; python_version == "2.7"'
+        req = Requirement(requirement)
+        assert Requirement(req) == req
+
     def test_string_url(self):
         requirement = "name@ http://foo.com"
         req = Requirement(requirement)

--- a/tests/test_specifiers.py
+++ b/tests/test_specifiers.py
@@ -636,6 +636,10 @@ class TestSpecifier:
     def test_specifier_hash_for_compatible_operator(self):
         assert hash(Specifier("~=1.18.0")) != hash(Specifier("~=1.18"))
 
+    def test_specifier_accepts_specifier(self):
+        spec = Specifier("~=1.18.0")
+        assert Specifier(spec) == spec
+
 
 class TestLegacySpecifier:
     def test_legacy_specifier_is_deprecated(self):
@@ -1016,3 +1020,7 @@ class TestSpecifierSet:
         combination = SpecifierSet("~=1.18.0") & SpecifierSet("~=1.18")
         assert "1.19.5" not in combination
         assert "1.18.0" in combination
+
+    def test_specifier_set_accepts_specifier_set(self):
+        spec = SpecifierSet("~=1.18.0")
+        assert SpecifierSet(spec) == spec

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -662,6 +662,10 @@ class TestVersion:
     def test_version_is_postrelease(self, version, expected):
         assert Version(version).is_postrelease is expected
 
+    def test_version_accepts_version(self):
+        v = Version("1.0")
+        assert Version(v) == v
+
     @pytest.mark.parametrize(
         ("left", "right", "op"),
         # Below we'll generate every possible combination of VERSIONS that


### PR DESCRIPTION
Fixes #454.

Adds constructors for `Version`, `Requirement`, `Specifier` and `SpecifierSet` which return a copy of the supplied argument if it is already of the appropriate class.