### PR TITLE
Document exceptions raised by functions in utils

### DIFF
--- a/docs/utils.rst
+++ b/docs/utils.rst
@@ -63,7 +63,7 @@ Reference
     instance of :class:`~packaging.tags.Tag`.
 
     :param str filename: The name of the wheel file.
-    :raises packaging.utils.InvalidWheelFilename: If the filename in question
+    :raises InvalidWheelFilename: If the filename in question
         does not follow conventions outlined in `PEP 427`_.
 
     .. doctest::
@@ -89,7 +89,7 @@ Reference
     represented by an instance of :class:`~packaging.version.Version`.
 
     :param str filename: The name of the sdist file.
-    :raises packaging.utils.InvalidSdistFilename: If the filename does not end
+    :raises InvalidSdistFilename: If the filename does not end
         with an sdist extension (``.zip`` or ``.tar.gz``), or if it does not
         contain a dash separating the name and the version of the distribution.
 
@@ -102,6 +102,15 @@ Reference
         'foo'
         >>> ver == Version('1.0')
         True
+
+
+.. exception:: InvalidWheelFilename
+
+    Raised when a file name for a wheel is invalid.
+
+.. exception:: InvalidSdistFilename
+
+    Raised when a source distribution file name is considered invalid.
 
 .. _Source distribution format: https://packaging.python.org/specifications/source-distribution-format/#source-distribution-file-name
 .. _`PEP 427`: https://peps.python.org/pep-0427/#file-name-convention

--- a/docs/utils.rst
+++ b/docs/utils.rst
@@ -63,6 +63,8 @@ Reference
     instance of :class:`~packaging.tags.Tag`.
 
     :param str filename: The name of the wheel file.
+    :raises packaging.utils.InvalidWheelFilename: If the filename in question
+        does not follow conventions outlined in `PEP 427`_.
 
     .. doctest::
 
@@ -87,6 +89,9 @@ Reference
     represented by an instance of :class:`~packaging.version.Version`.
 
     :param str filename: The name of the sdist file.
+    :raises packaging.utils.InvalidSdistFilename: If the filename does not end
+        with an sdist extension (``.zip`` or ``.tar.gz``), or if it does not
+        contain a dash separating the name and the version of the distribution.
 
     .. doctest::
 
@@ -99,3 +104,4 @@ Reference
         True
 
 .. _Source distribution format: https://packaging.python.org/specifications/source-distribution-format/#source-distribution-file-name
+.. _`PEP 427`: https://peps.python.org/pep-0427/#file-name-convention


### PR DESCRIPTION
Closes #543.

Added `:raises ...:` clauses to documentation of functions from `packaging.utils`.
~~Class names have been given by their full import path, since they are not mentioned anywhere else in the documentation.~~

![image](https://user-images.githubusercontent.com/6691643/167147830-c78d2178-0fc8-4b27-a915-edfe096a003a.png)

![image](https://user-images.githubusercontent.com/6691643/167147928-9e63d661-7e7f-4392-bd8c-6a6b464de912.png)
