### PR TITLE
Normalize extra comparison in markers for output

### DIFF
--- a/packaging/markers.py
+++ b/packaging/markers.py
@@ -6,7 +6,7 @@ import operator
 import os
 import platform
 import sys
-from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar, Union, overload
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 from pyparsing import (  # noqa: N817
     Forward,
@@ -139,20 +139,7 @@ MARKER_EXPR << MARKER_ATOM + ZeroOrMore(BOOLOP + MARKER_EXPR)
 MARKER = stringStart + MARKER_EXPR + stringEnd
 
 
-_T = TypeVar("_T")
-
-
-@overload
-def _coerce_parse_result(results: ParseResults) -> List[Any]:
-    ...
-
-
-@overload
-def _coerce_parse_result(results: _T) -> _T:
-    ...
-
-
-def _coerce_parse_result(results):
+def _coerce_parse_result(results: Any) -> Any:
     """
     Flatten the parse results into a list of results.
 

--- a/tests/test_markers.py
+++ b/tests/test_markers.py
@@ -362,3 +362,12 @@ class TestMarker:
         marker_string = "python_implementation=='Jython'"
         args = [{"platform_python_implementation": "CPython"}]
         assert Marker(marker_string).evaluate(*args) is False
+
+    def test_extra_str_normalization(self):
+        raw_name = "S_P__A_M"
+        normalized_name = "s-p-a-m"
+        lhs = f"{raw_name!r} == extra"
+        rhs = f"extra == {raw_name!r}"
+
+        assert str(Marker(lhs)) == f'"{normalized_name}" == extra'
+        assert str(Marker(rhs)) == f'extra == "{normalized_name}"'


### PR DESCRIPTION
This guarantees that getting the string representation of a marker is always normalized for extras.

Part of #526