### PR TITLE
CI: Add Python 3.11, update checkout to v3, weekly run

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,9 @@ on:
     paths:
       - ".github/workflows/test.yml"
       - "**.py"
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * 1'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
@@ -23,10 +26,10 @@ jobs:
       matrix:
         os: [Ubuntu, Windows, macOS]
         python_version:
-          ["3.7", "3.8", "3.9", "3.10", "pypy-3.7", "pypy-3.8", "pypy-3.9"]
+          ["3.7", "3.8", "3.9", "3.10", "3.11-dev", "pypy-3.7", "pypy-3.8", "pypy-3.9"]
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
 
       - uses: actions/setup-python@v3
         name: Install Python ${{ matrix.python_version }}


### PR DESCRIPTION
A bit of maintenance on the CI:
- Add Python 3.11 (which is currently in beta) to the build matrix of the CI test job
- A weekly scheduled run is also added to catch changes in dependencies and environments (each Monday at 06:00 UTC), and workflow_dispatch is added to be able to manually trigger the CI workflow
- The checkout actions is updated to v3