### PR TITLE
Do not set extra in default_environment()

### DIFF
--- a/packaging/markers.py
+++ b/packaging/markers.py
@@ -269,7 +269,6 @@ def default_environment() -> Dict[str, str]:
     iver = format_full_version(sys.implementation.version)
     implementation_name = sys.implementation.name
     return {
-        "extra": "",
         "implementation_name": implementation_name,
         "implementation_version": iver,
         "os_name": os.name,
@@ -335,6 +334,7 @@ class Marker:
         The environment is determined from the current Python process.
         """
         current_environment = default_environment()
+        current_environment["extra"] = ""
         if environment is not None:
             current_environment.update(environment)
 

--- a/tests/test_markers.py
+++ b/tests/test_markers.py
@@ -109,7 +109,6 @@ class TestDefaultEnvironment:
             )
 
         assert environment == {
-            "extra": "",
             "implementation_name": sys.implementation.name,
             "implementation_version": iver,
             "os_name": os.name,


### PR DESCRIPTION
PEP 508 says explicitly that the presence of the `extra` key in an environment is an error except in special cases.

This PR tweaks #550. cc/ @MrMino @uranusjr @pradyunsg 