### PR TITLE
Update extlinks strings to use a format string

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -52,8 +52,8 @@ copyright = about["__copyright__"]
 exclude_patterns = ["_build"]
 
 extlinks = {
-    "issue": ("https://github.com/pypa/packaging/issues/%s", "#"),
-    "pull": ("https://github.com/pypa/packaging/pull/%s", "PR #"),
+    "issue": ("https://github.com/pypa/packaging/issues/%s", "#%s"),
+    "pull": ("https://github.com/pypa/packaging/pull/%s", "PR #%s"),
 }
 # -- Options for HTML output --------------------------------------------------
 


### PR DESCRIPTION
Sphinx 4 added a new way of specifying extlinks "caption string" (instead of "prefix string")
Sphinx 5 added a deprecation warning when still using the "prefix string" notation which fails the build:
```
Running Sphinx v5.0.1
Warning, treated as error:
extlinks: Sphinx-6.0 will require a caption string to contain exactly one '%s' and all other '%' need to be escaped as '%%'.
```