### PR TITLE
Forbid prefix version matching on pre-release/post-release segments

### DIFF
--- a/packaging/specifiers.py
+++ b/packaging/specifiers.py
@@ -130,21 +130,21 @@ class Specifier(BaseSpecifier):
                 v?
                 (?:[0-9]+!)?          # epoch
                 [0-9]+(?:\.[0-9]+)*   # release
-                (?:                   # pre release
-                    [-_\.]?
-                    (a|b|c|rc|alpha|beta|pre|preview)
-                    [-_\.]?
-                    [0-9]*
-                )?
-                (?:                   # post release
-                    (?:-[0-9]+)|(?:[-_\.]?(post|rev|r)[-_\.]?[0-9]*)
-                )?
 
-                # You cannot use a wild card and a dev or local version
-                # together so group them with a | and make them optional.
+                # You cannot use a wild card and a pre-release, post-release, a dev or
+                # local version together so group them with a | and make them optional.
                 (?:
                     \.\*  # Wild card syntax of .*
                     |
+                    (?:                                  # pre release
+                        [-_\.]?
+                        (a|b|c|rc|alpha|beta|pre|preview)
+                        [-_\.]?
+                        [0-9]*
+                    )?
+                    (?:                                  # post release
+                        (?:-[0-9]+)|(?:[-_\.]?(post|rev|r)[-_\.]?[0-9]*)
+                    )?
                     (?:[-_\.]?dev[-_\.]?[0-9]*)?         # dev release
                     (?:\+[a-z0-9]+(?:[-_\.][a-z0-9]+)*)? # local
                 )?

--- a/tests/test_specifiers.py
+++ b/tests/test_specifiers.py
@@ -64,7 +64,14 @@ class TestSpecifier:
             # support one or the other
             "==1.0.*+5",
             "!=1.0.*+deadbeef",
-            # Prefix matching cannot be used inside of a local version
+            # Prefix matching cannot be used with a pre-release, post-release,
+            # dev or local version
+            "==2.0a1.*",
+            "!=2.0a1.*",
+            "==2.0.post1.*",
+            "!=2.0.post1.*",
+            "==2.0.dev1.*",
+            "!=2.0.dev1.*",
             "==1.0+5.*",
             "!=1.0+deadbeef.*",
             # Prefix matching must appear at the end
@@ -304,8 +311,6 @@ class TestSpecifier:
                 ("2", "==2.*"),
                 ("2.0", "==2.*"),
                 ("2.0.0", "==2.*"),
-                ("2.0.post1", "==2.0.post1.*"),
-                ("2.0.post1.dev1", "==2.0.post1.*"),
                 ("2.1+local.version", "==2.1.*"),
                 # Test the in-equality operation
                 ("2.1", "!=2"),
@@ -401,8 +406,6 @@ class TestSpecifier:
                 ("2", "!=2.*"),
                 ("2.0", "!=2.*"),
                 ("2.0.0", "!=2.*"),
-                ("2.0.post1", "!=2.0.post1.*"),
-                ("2.0.post1.dev1", "!=2.0.post1.*"),
                 # Test the greater than equal operation
                 ("2.0.dev1", ">=2"),
                 ("2.0a1", ">=2"),
@@ -526,7 +529,6 @@ class TestSpecifier:
             (">=1.0", "2.0.dev1", False),
             (">=2.0.dev1", "2.0a1", True),
             ("==2.0.*", "2.0a1.dev1", False),
-            ("==2.0a1.*", "2.0a1.dev1", True),
             ("<=2.0", "1.0.dev1", False),
             ("<=2.0.dev1", "1.0a1", True),
         ],


### PR DESCRIPTION
It does not make much sense to have this.
Let's forbid it.

Per https://discuss.python.org/t/pep-440-clarification-on-prefix-version-matching-with-pre-release-post-release-segments/16622/3

closes #425 
closes #562