### PR TITLE
Move `metadata`, `versions` and `specifiers` API documentation to `sphinx.ext.autodoc`

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,14 +3,16 @@
 # for complete details.
 
 import os
-import sys
 
-# If extensions (or modules to document with autodoc) are in another directory,
-# add these directories to sys.path here. If the directory is relative to the
-# documentation root, use os.path.abspath to make it absolute, like shown here.
-sys.path.insert(0, os.path.abspath("."))
+# -- Project information loading ----------------------------------------------
+
+ABOUT = {}
+_BASE_DIR = os.path.join(os.path.dirname(__file__), os.pardir)
+with open(os.path.join(_BASE_DIR, "packaging", "__about__.py")) as f:
+    exec(f.read(), ABOUT)
 
 # -- General configuration ----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions  coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
@@ -19,93 +21,48 @@ extensions = [
     "sphinx.ext.doctest",
     "sphinx.ext.extlinks",
     "sphinx.ext.intersphinx",
-    "sphinx.ext.viewcode",
 ]
-
-# Add any paths that contain templates here, relative to this directory.
-templates_path = ["_templates"]
-
-# The suffix of source filenames.
-source_suffix = ".rst"
-
-# The master toctree document.
-master_doc = "index"
 
 # General information about the project.
 project = "Packaging"
+version = ABOUT["__version__"]
+release = ABOUT["__version__"]
+copyright = ABOUT["__copyright__"]
 
-# The version info for the project you're documenting, acts as replacement for
-# |version| and |release|, also used in various other places throughout the
-# built documents.
-#
-
-base_dir = os.path.join(os.path.dirname(__file__), os.pardir)
-about = {}
-with open(os.path.join(base_dir, "packaging", "__about__.py")) as f:
-    exec(f.read(), about)
-
-version = release = about["__version__"]
-copyright = about["__copyright__"]
-
-# List of patterns, relative to source directory, that match files and
-# directories to ignore when looking for source files.
-exclude_patterns = ["_build"]
-
-extlinks = {
-    "issue": ("https://github.com/pypa/packaging/issues/%s", "#%s"),
-    "pull": ("https://github.com/pypa/packaging/pull/%s", "PR #%s"),
-}
 # -- Options for HTML output --------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 
 html_theme = "furo"
-html_title = "packaging"
+html_title = project
 
-# Add any paths that contain custom static files (such as style sheets) here,
-# relative to this directory. They are copied after the builtin static files,
-# so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ["_static"]
+# -- Options for autodoc ----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#configuration
 
-# Output file base name for HTML help builder.
-htmlhelp_basename = "packagingdoc"
+autodoc_member_order = "bysource"
+autodoc_preserve_defaults = True
 
+# Automatically extract typehints when specified and place them in
+# descriptions of the relevant function/method.
+autodoc_typehints = "description"
 
-# -- Options for LaTeX output -------------------------------------------------
+# Don't show class signature with the class' name.
+autodoc_class_signature = "separated"
 
-latex_elements = {}
+# -- Options for extlinks -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/extensions/extlinks.html#configuration
 
-# Grouping the document tree into LaTeX files. List of tuples
-# (source start file, target name, title, author, documentclass [howto/manual])
-latex_documents = [
-    ("index", "packaging.tex", "Packaging Documentation", "Donald Stufft", "manual")
-]
+extlinks = {
+    "issue": ("https://github.com/pypa/packaging/issues/%s", "#%s"),
+    "pull": ("https://github.com/pypa/packaging/pull/%s", "PR #%s"),
+}
 
-# -- Options for manual page output -------------------------------------------
+# -- Options for intersphinx ----------------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html#configuration
 
-# One entry per manual page. List of tuples
-# (source start file, name, description, authors, manual section).
-man_pages = [("index", "packaging", "Packaging Documentation", ["Donald Stufft"], 1)]
-
-# -- Options for Texinfo output -----------------------------------------------
-
-# Grouping the document tree into Texinfo files. List of tuples
-# (source start file, target name, title, author,
-#  dir menu entry, description, category)
-texinfo_documents = [
-    (
-        "index",
-        "packaging",
-        "Packaging Documentation",
-        "Donald Stufft",
-        "packaging",
-        "Core utilities for Python packages",
-        "Miscellaneous",
-    )
-]
-
-# Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {"https://docs.python.org/": None}
-
-epub_theme = "epub"
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3/", None),
+    "pypug": ("https://packaging.python.org/", None),
+}

--- a/docs/metadata.rst
+++ b/docs/metadata.rst
@@ -1,86 +1,14 @@
 Metadata
 ==========
 
-.. currentmodule:: packaging.metadata
-
 A data representation for `core metadata`_.
+
+.. _`core metadata`: https://packaging.python.org/en/latest/specifications/core-metadata/
 
 
 Reference
 ---------
 
-.. class:: DynamicField
-
-    An :class:`enum.Enum` representing fields which can be listed in
-    the ``Dynamic`` field of `core metadata`_. Every valid field is
-    a name on this enum, upper-cased with any ``-`` replaced with ``_``.
-    Each value is the field name lower-cased (``-`` are kept). For
-    example, the ``Home-page`` field has a name of ``HOME_PAGE`` and a
-    value of ``home-page``.
-
-
-.. class:: Metadata(name, version, *, platforms=None, summary=None, description=None, keywords=None, home_page=None, author=None, author_emails=None, license=None, supported_platforms=None, download_url=None, classifiers=None, maintainer=None, maintainer_emails=None, requires_dists=None, requires_python=None, requires_externals=None, project_urls=None, provides_dists= None, obsoletes_dists= None, description_content_type=None, provides_extras=None, dynamic_fields=None)
-
-    A class representing the `core metadata`_ for a project.
-
-    Every potential metadata field except for ``Metadata-Version`` is
-    represented by a parameter to the class' constructor. The required
-    metadata can be passed in positionally or via keyword, while all
-    optional metadata can only be passed in via keyword.
-
-    Every parameter has a matching attribute on instances,
-    except for *name* (see :attr:`display_name` and
-    :attr:`canonical_name`). Any parameter that accepts an
-    :class:`~collections.abc.Iterable` is represented as a
-    :class:`list` on the corresponding attribute.
-
-    :param str name: ``Name``.
-    :param packaging.version.Version version: ``Version`` (note
-        that this is different than ``Metadata-Version``).
-    :param Iterable[str] platforms: ``Platform``.
-    :param str summary: ``Summary``.
-    :param str description: ``Description``.
-    :param Iterable[str] keywords: ``Keywords``.
-    :param str home_page: ``Home-Page``.
-    :param str author: ``Author``.
-    :param Iterable[tuple[str | None, str]] author_emails: ``Author-Email``
-        where the two-item tuple represents the name and email of the author,
-        respectively.
-    :param str license: ``License``.
-    :param Iterable[str] supported_platforms: ``Supported-Platform``.
-    :param str download_url: ``Download-URL``.
-    :param Iterable[str] classifiers: ``Classifier``.
-    :param str maintainer: ``Maintainer``.
-    :param Iterable[tuple[str | None, str]] maintainer_emails: ``Maintainer-Email``,
-        where the two-item tuple represents the name and email of the maintainer,
-        respectively.
-    :param Iterable[packaging.requirements.Requirement] requires_dists: ``Requires-Dist``.
-    :param packaging.specifiers.SpecifierSet requires_python: ``Requires-Python``.
-    :param Iterable[str] requires_externals: ``Requires-External``.
-    :param tuple[str, str] project_urls: ``Project-URL``.
-    :param Iterable[str] provides_dists: ``Provides-Dist``.
-    :param Iterable[str] obsoletes_dists: ``Obsoletes-Dist``.
-    :param str description_content_type: ``Description-Content-Type``.
-    :param Iterable[packaging.utils.NormalizedName] provides_extras: ``Provides-Extra``.
-    :param Iterable[DynamicField] dynamic_fields: ``Dynamic``.
-
-    Attributes not directly corresponding to a parameter are:
-
-    .. attribute:: display_name
-
-        The project name to be displayed to users (i.e. not normalized).
-        Initially set based on the *name* parameter.
-        Setting this attribute will also update :attr:`canonical_name`.
-
-    .. attribute:: canonical_name
-
-        The normalized project name as per
-        :func:`packaging.utils.canonicalize_name`. The attribute is
-        read-only and automatically calculated based on the value of
-        :attr:`display_name`.
-
-
-.. _`core metadata`: https://packaging.python.org/en/latest/specifications/core-metadata/
-.. _`project metadata`: https://packaging.python.org/en/latest/specifications/declaring-project-metadata/
-.. _`source distribution`: https://packaging.python.org/en/latest/specifications/source-distribution-format/
-.. _`binary distrubtion`: https://packaging.python.org/en/latest/specifications/binary-distribution-format/
+.. automodule:: packaging.metadata
+    :members:
+    :undoc-members:

--- a/docs/specifiers.rst
+++ b/docs/specifiers.rst
@@ -1,11 +1,13 @@
 Specifiers
 ==========
 
-.. currentmodule:: packaging.specifiers
+A core requirement of dealing with dependencies is the ability to
+specify what versions of a dependency are acceptable for you.
 
-A core requirement of dealing with dependencies is the ability to specify what
-versions of a dependency are acceptable for you. `PEP 440`_ defines the
-standard specifier scheme which has been implemented by this module.
+See `Version Specifiers Specification`_ for more details on the exact
+format implemented in this module, for use in Python Packaging tooling.
+
+.. _Version Specifiers Specification: https://packaging.python.org/en/latest/specifications/version-specifiers/
 
 Usage
 -----
@@ -48,127 +50,6 @@ Usage
 Reference
 ---------
 
-.. class:: SpecifierSet(specifiers="", prereleases=None)
-
-    This class abstracts handling specifying the dependencies of a project. It
-    can be passed a single specifier (``>=3.0``), a comma-separated list of
-    specifiers (``>=3.0,!=3.1``), or no specifier at all. Each individual
-    specifier will be attempted to be parsed as a PEP 440 specifier
-    (:class:`Specifier`). You may combine :class:`SpecifierSet` instances using
-    the ``&`` operator (``SpecifierSet(">2") & SpecifierSet("<4")``).
-
-    Both the membership tests and the combination support using raw strings
-    in place of already instantiated objects.
-
-    :param str specifiers: The string representation of a specifier or a
-                           comma-separated list of specifiers which will
-                           be parsed and normalized before use.
-    :param bool prereleases: This tells the SpecifierSet if it should accept
-                             prerelease versions if applicable or not. The
-                             default of ``None`` will autodetect it from the
-                             given specifiers.
-    :raises InvalidSpecifier: If the given ``specifiers`` are not parseable
-                              than this exception will be raised.
-
-    .. attribute:: prereleases
-
-        A boolean value indicating whether this :class:`SpecifierSet`
-        represents a specifier that includes a pre-release versions. This can be
-        set to either ``True`` or ``False`` to explicitly enable or disable
-        prereleases or it can be set to ``None`` (the default) to enable
-        autodetection.
-
-    .. method:: __contains__(version)
-
-        This is the more Pythonic version of :meth:`contains()`, but does
-        not allow you to override the ``prereleases`` argument.  If you
-        need that, use :meth:`contains()`.
-
-        See :meth:`contains()`.
-
-    .. method:: contains(version, prereleases=None)
-
-        Determines if ``version``, which can be either a version string, a
-        :class:`Version` is contained within this set of specifiers.
-
-        This will either match or not match prereleases based on the
-        ``prereleases`` parameter. When ``prereleases`` is set to ``None``
-        (the default) it will use the ``Specifier().prereleases`` attribute to
-        determine if to allow them. Otherwise it will use the boolean value of
-        the passed in value to determine if to allow them or not.
-
-    .. method:: __len__()
-
-        Returns the number of specifiers in this specifier set.
-
-    .. method:: __iter__()
-
-        Returns an iterator over all the underlying :class:`Specifier` instances
-        in this specifier set.
-
-    .. method:: filter(iterable, prereleases=None)
-
-        Takes an iterable that can contain version strings, :class:`~.Version`,
-        instances and will then filter them, returning an iterable that contains
-        only items which match the rules of this specifier object.
-
-        This method is smarter than just
-        ``filter(Specifier().contains, [...])`` because it implements the rule
-        from PEP 440 where a prerelease item SHOULD be accepted if no other
-        versions match the given specifier.
-
-        The ``prereleases`` parameter functions similarly to that of the same
-        parameter in ``contains``. If the value is ``None`` (the default) then
-        it will intelligently decide if to allow prereleases based on the
-        specifier, the ``Specifier().prereleases`` value, and the PEP 440
-        rules. Otherwise it will act as a boolean which will enable or disable
-        all prerelease versions from being included.
-
-
-.. class:: Specifier(specifier, prereleases=None)
-
-    This class abstracts the handling of a single `PEP 440`_ compatible
-    specifier. It is generally not required to instantiate this manually,
-    preferring instead to work with :class:`SpecifierSet`.
-
-    :param str specifier: The string representation of a specifier which will
-                          be parsed and normalized before use.
-    :param bool prereleases: This tells the specifier if it should accept
-                             prerelease versions if applicable or not. The
-                             default of ``None`` will autodetect it from the
-                             given specifiers.
-    :raises InvalidSpecifier: If the ``specifier`` does not conform to PEP 440
-                              in any way then this exception will be raised.
-
-    .. attribute:: operator
-
-        The string value of the operator part of this specifier.
-
-    .. attribute:: version
-
-        The string version of the version part of this specifier.
-
-    .. attribute:: prereleases
-
-        See :attr:`SpecifierSet.prereleases`.
-
-    .. method:: __contains__(version)
-
-        See :meth:`SpecifierSet.__contains__()`.
-
-    .. method:: contains(version, prereleases=None)
-
-        See :meth:`SpecifierSet.contains()`.
-
-    .. method:: filter(iterable, prereleases=None)
-
-        See :meth:`SpecifierSet.filter()`.
-
-
-.. exception:: InvalidSpecifier
-
-    Raised when attempting to create a :class:`Specifier` with a specifier
-    string that does not conform to `PEP 440`_.
-
-
-.. _`PEP 440`: https://www.python.org/dev/peps/pep-0440/
+.. automodule:: packaging.specifiers
+    :members:
+    :special-members:

--- a/docs/version.rst
+++ b/docs/version.rst
@@ -1,11 +1,13 @@
 Version Handling
 ================
 
-.. currentmodule:: packaging.version
-
 A core requirement of dealing with packages is the ability to work with
-versions. `PEP 440`_ defines the standard version scheme for Python packages
-which has been implemented by this module.
+versions.
+
+See `Version Specifiers Specification`_ for more details on the exact
+format implemented in this module, for use in Python Packaging tooling.
+
+.. _Version Specifiers Specification: https://packaging.python.org/en/latest/specifications/version-specifiers/
 
 Usage
 -----
@@ -47,112 +49,6 @@ Usage
 Reference
 ---------
 
-.. function:: parse(version)
-
-    This function takes a version string and will parse it as a
-    :class:`Version` if the version is a valid PEP 440 version.
-    Otherwise, raises :class:`InvalidVersion`.
-
-
-.. class:: Version(version)
-
-    This class abstracts handling of a project's versions. It implements the
-    scheme defined in `PEP 440`_. A :class:`Version` instance is comparison
-    aware and can be compared and sorted using the standard Python interfaces.
-
-    :param str version: The string representation of a version which will be
-                        parsed and normalized before use.
-    :raises InvalidVersion: If the ``version`` does not conform to PEP 440 in
-                            any way then this exception will be raised.
-
-    .. attribute:: public
-
-        A string representing the public version portion of this ``Version()``.
-
-    .. attribute:: base_version
-
-        A string representing the base version of this :class:`Version`
-        instance. The base version is the public version of the project without
-        any pre or post release markers.
-
-    .. attribute:: epoch
-
-        An integer giving the version epoch of this :class:`Version` instance
-
-    .. attribute:: release
-
-        A tuple of integers giving the components of the release segment of
-        this :class:`Version` instance; that is, the ``1.2.3`` part of the
-        version number, including trailing zeroes but not including the epoch
-        or any prerelease/development/postrelease suffixes
-
-    .. attribute:: major
-
-        An integer representing the first item of :attr:`release` or ``0`` if unavailable.
-
-    .. attribute:: minor
-
-        An integer representing the second item of :attr:`release` or ``0`` if unavailable.
-
-    .. attribute:: micro
-
-        An integer representing the third item of :attr:`release` or ``0`` if unavailable.
-
-    .. attribute:: local
-
-        A string representing the local version portion of this ``Version()``
-        if it has one, or ``None`` otherwise.
-
-    .. attribute:: pre
-
-        If this :class:`Version` instance represents a prerelease, this
-        attribute will be a pair of the prerelease phase (the string ``"a"``,
-        ``"b"``, or ``"rc"``) and the prerelease number (an integer).  If this
-        instance is not a prerelease, the attribute will be `None`.
-
-    .. attribute:: is_prerelease
-
-        A boolean value indicating whether this :class:`Version` instance
-        represents a prerelease and/or development release.
-
-    .. attribute:: dev
-
-        If this :class:`Version` instance represents a development release,
-        this attribute will be the development release number (an integer);
-        otherwise, it will be `None`.
-
-    .. attribute:: is_devrelease
-
-        A boolean value indicating whether this :class:`Version` instance
-        represents a development release.
-
-    .. attribute:: post
-
-        If this :class:`Version` instance represents a postrelease, this
-        attribute will be the postrelease number (an integer); otherwise, it
-        will be `None`.
-
-    .. attribute:: is_postrelease
-
-        A boolean value indicating whether this :class:`Version` instance
-        represents a post-release.
-
-
-.. exception:: InvalidVersion
-
-    Raised when attempting to create a :class:`Version` with a version string
-    that does not conform to `PEP 440`_.
-
-
-.. data:: VERSION_PATTERN
-
-    A string containing the regular expression used to match a valid version.
-    The pattern is not anchored at either end, and is intended for embedding
-    in larger expressions (for example, matching a version number as part of
-    a file name). The regular expression should be compiled with the
-    ``re.VERBOSE`` and ``re.IGNORECASE`` flags set.
-
-
-.. _PEP 440: https://www.python.org/dev/peps/pep-0440/
-.. _Pre-release spelling : https://www.python.org/dev/peps/pep-0440/#pre-release-spelling
-.. _Post-release spelling : https://www.python.org/dev/peps/pep-0440/#post-release-spelling
+.. automodule:: packaging.version
+    :members:
+    :special-members:


### PR DESCRIPTION
Toward #567.

At the time of opening this PR, only three modules have been converted over -- `metadata`, `version` and `specifiers`. I'd like to get a round of feedback on this, before moving forward on the other modules (I'm adding example usage to make the various concepts clearer and that is taking a decent amount of time!).

I think it's reasonable to do this incrementally, so we can handle the other modules once we have agreement that this is a positive direction to take things. :)

PS: Some code moved up-and-down in the class bodies, since I've configured autodoc ordering to be `"bysource"`. It might make sense to do `"groupwise"` instead, but I prefer this since it gives us more control on ordering.
