### PR TITLE
Move `metadata`, `versions` and `specifiers` API documentation to `sphinx.ext.autodoc`

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,14 +3,16 @@
 # for complete details.
 
 import os
-import sys
 
-# If extensions (or modules to document with autodoc) are in another directory,
-# add these directories to sys.path here. If the directory is relative to the
-# documentation root, use os.path.abspath to make it absolute, like shown here.
-sys.path.insert(0, os.path.abspath("."))
+# -- Project information loading ----------------------------------------------
+
+ABOUT = {}
+_BASE_DIR = os.path.join(os.path.dirname(__file__), os.pardir)
+with open(os.path.join(_BASE_DIR, "packaging", "__about__.py")) as f:
+    exec(f.read(), ABOUT)
 
 # -- General configuration ----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions  coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
@@ -19,93 +21,48 @@ extensions = [
     "sphinx.ext.doctest",
     "sphinx.ext.extlinks",
     "sphinx.ext.intersphinx",
-    "sphinx.ext.viewcode",
 ]
-
-# Add any paths that contain templates here, relative to this directory.
-templates_path = ["_templates"]
-
-# The suffix of source filenames.
-source_suffix = ".rst"
-
-# The master toctree document.
-master_doc = "index"
 
 # General information about the project.
 project = "Packaging"
+version = ABOUT["__version__"]
+release = ABOUT["__version__"]
+copyright = ABOUT["__copyright__"]
 
-# The version info for the project you're documenting, acts as replacement for
-# |version| and |release|, also used in various other places throughout the
-# built documents.
-#
-
-base_dir = os.path.join(os.path.dirname(__file__), os.pardir)
-about = {}
-with open(os.path.join(base_dir, "packaging", "__about__.py")) as f:
-    exec(f.read(), about)
-
-version = release = about["__version__"]
-copyright = about["__copyright__"]
-
-# List of patterns, relative to source directory, that match files and
-# directories to ignore when looking for source files.
-exclude_patterns = ["_build"]
-
-extlinks = {
-    "issue": ("https://github.com/pypa/packaging/issues/%s", "#%s"),
-    "pull": ("https://github.com/pypa/packaging/pull/%s", "PR #%s"),
-}
 # -- Options for HTML output --------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 
 html_theme = "furo"
-html_title = "packaging"
+html_title = project
 
-# Add any paths that contain custom static files (such as style sheets) here,
-# relative to this directory. They are copied after the builtin static files,
-# so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ["_static"]
+# -- Options for autodoc ----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#configuration
 
-# Output file base name for HTML help builder.
-htmlhelp_basename = "packagingdoc"
+autodoc_member_order = "bysource"
+autodoc_preserve_defaults = True
 
+# Automatically extract typehints when specified and place them in
+# descriptions of the relevant function/method.
+autodoc_typehints = "description"
 
-# -- Options for LaTeX output -------------------------------------------------
+# Don't show class signature with the class' name.
+autodoc_class_signature = "separated"
 
-latex_elements = {}
+# -- Options for extlinks -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/extensions/extlinks.html#configuration
 
-# Grouping the document tree into LaTeX files. List of tuples
-# (source start file, target name, title, author, documentclass [howto/manual])
-latex_documents = [
-    ("index", "packaging.tex", "Packaging Documentation", "Donald Stufft", "manual")
-]
+extlinks = {
+    "issue": ("https://github.com/pypa/packaging/issues/%s", "#%s"),
+    "pull": ("https://github.com/pypa/packaging/pull/%s", "PR #%s"),
+}
 
-# -- Options for manual page output -------------------------------------------
+# -- Options for intersphinx ----------------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html#configuration
 
-# One entry per manual page. List of tuples
-# (source start file, name, description, authors, manual section).
-man_pages = [("index", "packaging", "Packaging Documentation", ["Donald Stufft"], 1)]
-
-# -- Options for Texinfo output -----------------------------------------------
-
-# Grouping the document tree into Texinfo files. List of tuples
-# (source start file, target name, title, author,
-#  dir menu entry, description, category)
-texinfo_documents = [
-    (
-        "index",
-        "packaging",
-        "Packaging Documentation",
-        "Donald Stufft",
-        "packaging",
-        "Core utilities for Python packages",
-        "Miscellaneous",
-    )
-]
-
-# Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {"https://docs.python.org/": None}
-
-epub_theme = "epub"
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3/", None),
+    "pypug": ("https://packaging.python.org/", None),
+}

--- a/docs/metadata.rst
+++ b/docs/metadata.rst
@@ -1,86 +1,14 @@
 Metadata
 ==========
 
-.. currentmodule:: packaging.metadata
-
 A data representation for `core metadata`_.
+
+.. _`core metadata`: https://packaging.python.org/en/latest/specifications/core-metadata/
 
 
 Reference
 ---------
 
-.. class:: DynamicField
-
-    An :class:`enum.Enum` representing fields which can be listed in
-    the ``Dynamic`` field of `core metadata`_. Every valid field is
-    a name on this enum, upper-cased with any ``-`` replaced with ``_``.
-    Each value is the field name lower-cased (``-`` are kept). For
-    example, the ``Home-page`` field has a name of ``HOME_PAGE`` and a
-    value of ``home-page``.
-
-
-.. class:: Metadata(name, version, *, platforms=None, summary=None, description=None, keywords=None, home_page=None, author=None, author_emails=None, license=None, supported_platforms=None, download_url=None, classifiers=None, maintainer=None, maintainer_emails=None, requires_dists=None, requires_python=None, requires_externals=None, project_urls=None, provides_dists= None, obsoletes_dists= None, description_content_type=None, provides_extras=None, dynamic_fields=None)
-
-    A class representing the `core metadata`_ for a project.
-
-    Every potential metadata field except for ``Metadata-Version`` is
-    represented by a parameter to the class' constructor. The required
-    metadata can be passed in positionally or via keyword, while all
-    optional metadata can only be passed in via keyword.
-
-    Every parameter has a matching attribute on instances,
-    except for *name* (see :attr:`display_name` and
-    :attr:`canonical_name`). Any parameter that accepts an
-    :class:`~collections.abc.Iterable` is represented as a
-    :class:`list` on the corresponding attribute.
-
-    :param str name: ``Name``.
-    :param packaging.version.Version version: ``Version`` (note
-        that this is different than ``Metadata-Version``).
-    :param Iterable[str] platforms: ``Platform``.
-    :param str summary: ``Summary``.
-    :param str description: ``Description``.
-    :param Iterable[str] keywords: ``Keywords``.
-    :param str home_page: ``Home-Page``.
-    :param str author: ``Author``.
-    :param Iterable[tuple[str | None, str]] author_emails: ``Author-Email``
-        where the two-item tuple represents the name and email of the author,
-        respectively.
-    :param str license: ``License``.
-    :param Iterable[str] supported_platforms: ``Supported-Platform``.
-    :param str download_url: ``Download-URL``.
-    :param Iterable[str] classifiers: ``Classifier``.
-    :param str maintainer: ``Maintainer``.
-    :param Iterable[tuple[str | None, str]] maintainer_emails: ``Maintainer-Email``,
-        where the two-item tuple represents the name and email of the maintainer,
-        respectively.
-    :param Iterable[packaging.requirements.Requirement] requires_dists: ``Requires-Dist``.
-    :param packaging.specifiers.SpecifierSet requires_python: ``Requires-Python``.
-    :param Iterable[str] requires_externals: ``Requires-External``.
-    :param tuple[str, str] project_urls: ``Project-URL``.
-    :param Iterable[str] provides_dists: ``Provides-Dist``.
-    :param Iterable[str] obsoletes_dists: ``Obsoletes-Dist``.
-    :param str description_content_type: ``Description-Content-Type``.
-    :param Iterable[packaging.utils.NormalizedName] provides_extras: ``Provides-Extra``.
-    :param Iterable[DynamicField] dynamic_fields: ``Dynamic``.
-
-    Attributes not directly corresponding to a parameter are:
-
-    .. attribute:: display_name
-
-        The project name to be displayed to users (i.e. not normalized).
-        Initially set based on the *name* parameter.
-        Setting this attribute will also update :attr:`canonical_name`.
-
-    .. attribute:: canonical_name
-
-        The normalized project name as per
-        :func:`packaging.utils.canonicalize_name`. The attribute is
-        read-only and automatically calculated based on the value of
-        :attr:`display_name`.
-
-
-.. _`core metadata`: https://packaging.python.org/en/latest/specifications/core-metadata/
-.. _`project metadata`: https://packaging.python.org/en/latest/specifications/declaring-project-metadata/
-.. _`source distribution`: https://packaging.python.org/en/latest/specifications/source-distribution-format/
-.. _`binary distrubtion`: https://packaging.python.org/en/latest/specifications/binary-distribution-format/
+.. automodule:: packaging.metadata
+    :members:
+    :undoc-members:

--- a/docs/specifiers.rst
+++ b/docs/specifiers.rst
@@ -1,11 +1,13 @@
 Specifiers
 ==========
 
-.. currentmodule:: packaging.specifiers
+A core requirement of dealing with dependencies is the ability to
+specify what versions of a dependency are acceptable for you.
 
-A core requirement of dealing with dependencies is the ability to specify what
-versions of a dependency are acceptable for you. `PEP 440`_ defines the
-standard specifier scheme which has been implemented by this module.
+See `Version Specifiers Specification`_ for more details on the exact
+format implemented in this module, for use in Python Packaging tooling.
+
+.. _Version Specifiers Specification: https://packaging.python.org/en/latest/specifications/version-specifiers/
 
 Usage
 -----
@@ -48,127 +50,6 @@ Usage
 Reference
 ---------
 
-.. class:: SpecifierSet(specifiers="", prereleases=None)
-
-    This class abstracts handling specifying the dependencies of a project. It
-    can be passed a single specifier (``>=3.0``), a comma-separated list of
-    specifiers (``>=3.0,!=3.1``), or no specifier at all. Each individual
-    specifier will be attempted to be parsed as a PEP 440 specifier
-    (:class:`Specifier`). You may combine :class:`SpecifierSet` instances using
-    the ``&`` operator (``SpecifierSet(">2") & SpecifierSet("<4")``).
-
-    Both the membership tests and the combination support using raw strings
-    in place of already instantiated objects.
-
-    :param str specifiers: The string representation of a specifier or a
-                           comma-separated list of specifiers which will
-                           be parsed and normalized before use.
-    :param bool prereleases: This tells the SpecifierSet if it should accept
-                             prerelease versions if applicable or not. The
-                             default of ``None`` will autodetect it from the
-                             given specifiers.
-    :raises InvalidSpecifier: If the given ``specifiers`` are not parseable
-                              than this exception will be raised.
-
-    .. attribute:: prereleases
-
-        A boolean value indicating whether this :class:`SpecifierSet`
-        represents a specifier that includes a pre-release versions. This can be
-        set to either ``True`` or ``False`` to explicitly enable or disable
-        prereleases or it can be set to ``None`` (the default) to enable
-        autodetection.
-
-    .. method:: __contains__(version)
-
-        This is the more Pythonic version of :meth:`contains()`, but does
-        not allow you to override the ``prereleases`` argument.  If you
-        need that, use :meth:`contains()`.
-
-        See :meth:`contains()`.
-
-    .. method:: contains(version, prereleases=None)
-
-        Determines if ``version``, which can be either a version string, a
-        :class:`Version` is contained within this set of specifiers.
-
-        This will either match or not match prereleases based on the
-        ``prereleases`` parameter. When ``prereleases`` is set to ``None``
-        (the default) it will use the ``Specifier().prereleases`` attribute to
-        determine if to allow them. Otherwise it will use the boolean value of
-        the passed in value to determine if to allow them or not.
-
-    .. method:: __len__()
-
-        Returns the number of specifiers in this specifier set.
-
-    .. method:: __iter__()
-
-        Returns an iterator over all the underlying :class:`Specifier` instances
-        in this specifier set.
-
-    .. method:: filter(iterable, prereleases=None)
-
-        Takes an iterable that can contain version strings, :class:`~.Version`,
-        instances and will then filter them, returning an iterable that contains
-        only items which match the rules of this specifier object.
-
-        This method is smarter than just
-        ``filter(Specifier().contains, [...])`` because it implements the rule
-        from PEP 440 where a prerelease item SHOULD be accepted if no other
-        versions match the given specifier.
-
-        The ``prereleases`` parameter functions similarly to that of the same
-        parameter in ``contains``. If the value is ``None`` (the default) then
-        it will intelligently decide if to allow prereleases based on the
-        specifier, the ``Specifier().prereleases`` value, and the PEP 440
-        rules. Otherwise it will act as a boolean which will enable or disable
-        all prerelease versions from being included.
-
-
-.. class:: Specifier(specifier, prereleases=None)
-
-    This class abstracts the handling of a single `PEP 440`_ compatible
-    specifier. It is generally not required to instantiate this manually,
-    preferring instead to work with :class:`SpecifierSet`.
-
-    :param str specifier: The string representation of a specifier which will
-                          be parsed and normalized before use.
-    :param bool prereleases: This tells the specifier if it should accept
-                             prerelease versions if applicable or not. The
-                             default of ``None`` will autodetect it from the
-                             given specifiers.
-    :raises InvalidSpecifier: If the ``specifier`` does not conform to PEP 440
-                              in any way then this exception will be raised.
-
-    .. attribute:: operator
-
-        The string value of the operator part of this specifier.
-
-    .. attribute:: version
-
-        The string version of the version part of this specifier.
-
-    .. attribute:: prereleases
-
-        See :attr:`SpecifierSet.prereleases`.
-
-    .. method:: __contains__(version)
-
-        See :meth:`SpecifierSet.__contains__()`.
-
-    .. method:: contains(version, prereleases=None)
-
-        See :meth:`SpecifierSet.contains()`.
-
-    .. method:: filter(iterable, prereleases=None)
-
-        See :meth:`SpecifierSet.filter()`.
-
-
-.. exception:: InvalidSpecifier
-
-    Raised when attempting to create a :class:`Specifier` with a specifier
-    string that does not conform to `PEP 440`_.
-
-
-.. _`PEP 440`: https://www.python.org/dev/peps/pep-0440/
+.. automodule:: packaging.specifiers
+    :members:
+    :special-members:

--- a/docs/version.rst
+++ b/docs/version.rst
@@ -1,11 +1,13 @@
 Version Handling
 ================
 
-.. currentmodule:: packaging.version
-
 A core requirement of dealing with packages is the ability to work with
-versions. `PEP 440`_ defines the standard version scheme for Python packages
-which has been implemented by this module.
+versions.
+
+See `Version Specifiers Specification`_ for more details on the exact
+format implemented in this module, for use in Python Packaging tooling.
+
+.. _Version Specifiers Specification: https://packaging.python.org/en/latest/specifications/version-specifiers/
 
 Usage
 -----
@@ -47,112 +49,6 @@ Usage
 Reference
 ---------
 
-.. function:: parse(version)
-
-    This function takes a version string and will parse it as a
-    :class:`Version` if the version is a valid PEP 440 version.
-    Otherwise, raises :class:`InvalidVersion`.
-
-
-.. class:: Version(version)
-
-    This class abstracts handling of a project's versions. It implements the
-    scheme defined in `PEP 440`_. A :class:`Version` instance is comparison
-    aware and can be compared and sorted using the standard Python interfaces.
-
-    :param str version: The string representation of a version which will be
-                        parsed and normalized before use.
-    :raises InvalidVersion: If the ``version`` does not conform to PEP 440 in
-                            any way then this exception will be raised.
-
-    .. attribute:: public
-
-        A string representing the public version portion of this ``Version()``.
-
-    .. attribute:: base_version
-
-        A string representing the base version of this :class:`Version`
-        instance. The base version is the public version of the project without
-        any pre or post release markers.
-
-    .. attribute:: epoch
-
-        An integer giving the version epoch of this :class:`Version` instance
-
-    .. attribute:: release
-
-        A tuple of integers giving the components of the release segment of
-        this :class:`Version` instance; that is, the ``1.2.3`` part of the
-        version number, including trailing zeroes but not including the epoch
-        or any prerelease/development/postrelease suffixes
-
-    .. attribute:: major
-
-        An integer representing the first item of :attr:`release` or ``0`` if unavailable.
-
-    .. attribute:: minor
-
-        An integer representing the second item of :attr:`release` or ``0`` if unavailable.
-
-    .. attribute:: micro
-
-        An integer representing the third item of :attr:`release` or ``0`` if unavailable.
-
-    .. attribute:: local
-
-        A string representing the local version portion of this ``Version()``
-        if it has one, or ``None`` otherwise.
-
-    .. attribute:: pre
-
-        If this :class:`Version` instance represents a prerelease, this
-        attribute will be a pair of the prerelease phase (the string ``"a"``,
-        ``"b"``, or ``"rc"``) and the prerelease number (an integer).  If this
-        instance is not a prerelease, the attribute will be `None`.
-
-    .. attribute:: is_prerelease
-
-        A boolean value indicating whether this :class:`Version` instance
-        represents a prerelease and/or development release.
-
-    .. attribute:: dev
-
-        If this :class:`Version` instance represents a development release,
-        this attribute will be the development release number (an integer);
-        otherwise, it will be `None`.
-
-    .. attribute:: is_devrelease
-
-        A boolean value indicating whether this :class:`Version` instance
-        represents a development release.
-
-    .. attribute:: post
-
-        If this :class:`Version` instance represents a postrelease, this
-        attribute will be the postrelease number (an integer); otherwise, it
-        will be `None`.
-
-    .. attribute:: is_postrelease
-
-        A boolean value indicating whether this :class:`Version` instance
-        represents a post-release.
-
-
-.. exception:: InvalidVersion
-
-    Raised when attempting to create a :class:`Version` with a version string
-    that does not conform to `PEP 440`_.
-
-
-.. data:: VERSION_PATTERN
-
-    A string containing the regular expression used to match a valid version.
-    The pattern is not anchored at either end, and is intended for embedding
-    in larger expressions (for example, matching a version number as part of
-    a file name). The regular expression should be compiled with the
-    ``re.VERBOSE`` and ``re.IGNORECASE`` flags set.
-
-
-.. _PEP 440: https://www.python.org/dev/peps/pep-0440/
-.. _Pre-release spelling : https://www.python.org/dev/peps/pep-0440/#pre-release-spelling
-.. _Post-release spelling : https://www.python.org/dev/peps/pep-0440/#post-release-spelling
+.. automodule:: packaging.version
+    :members:
+    :special-members:

--- a/packaging/metadata.py
+++ b/packaging/metadata.py
@@ -1,15 +1,10 @@
-from __future__ import annotations
-
 import enum
-from collections.abc import Iterable
-from typing import Optional, Tuple
+from typing import Iterable, List, Optional, Tuple
 
-from . import (  # Alt name avoids shadowing.
-    requirements,
-    specifiers,
-    utils,
-    version as packaging_version,
-)
+from .requirements import Requirement
+from .specifiers import SpecifierSet
+from .utils import NormalizedName, canonicalize_name
+from .version import Version
 
 # Type aliases.
 _NameAndEmail = Tuple[Optional[str], str]
@@ -18,11 +13,13 @@ _LabelAndURL = Tuple[str, str]
 
 @enum.unique
 class DynamicField(enum.Enum):
-
     """
-    Field names for the `dynamic` field.
+    An :class:`enum.Enum` representing fields which can be listed in the ``Dynamic``
+    field of `core metadata`_.
 
-    All values are lower-cased for easy comparison.
+    Every valid field is a name on this enum, upper-cased with any ``-`` replaced with
+    ``_``. Each value is the field name lower-cased (``-`` are kept). For example, the
+    ``Home-page`` field has a name of ``HOME_PAGE`` and a value of ``home-page``.
     """
 
     # `Name`, `Version`, and `Metadata-Version` are invalid in `Dynamic`.
@@ -54,77 +51,112 @@ class DynamicField(enum.Enum):
 
 
 class Metadata:
+    """A class representing the `Core Metadata`_ for a project.
 
-    """
-    A representation of core metadata.
+    Every potential metadata field except for ``Metadata-Version`` is represented by a
+    parameter to the class' constructor. The required metadata can be passed in
+    positionally or via keyword, while all optional metadata can only be passed in via
+    keyword.
+
+    Every parameter has a matching attribute on instances, except for *name* (see
+    :attr:`display_name` and :attr:`canonical_name`). Any parameter that accepts an
+    :class:`~collections.abc.Iterable` is represented as a :class:`list` on the
+    corresponding attribute.
     """
 
     # A property named `display_name` exposes the value.
     _display_name: str
     # A property named `canonical_name` exposes the value.
-    _canonical_name: utils.NormalizedName
-    version: packaging_version.Version
-    platforms: list[str]
+    _canonical_name: NormalizedName
+    version: Version
+    platforms: List[str]
     summary: str
     description: str
-    keywords: list[str]
+    keywords: List[str]
     home_page: str
     author: str
-    author_emails: list[_NameAndEmail]
+    author_emails: List[_NameAndEmail]
     license: str
-    supported_platforms: list[str]
+    supported_platforms: List[str]
     download_url: str
-    classifiers: list[str]
+    classifiers: List[str]
     maintainer: str
-    maintainer_emails: list[_NameAndEmail]
-    requires_dists: list[requirements.Requirement]
-    requires_python: specifiers.SpecifierSet
-    requires_externals: list[str]
-    project_urls: list[_LabelAndURL]
-    provides_dists: list[str]
-    obsoletes_dists: list[str]
+    maintainer_emails: List[_NameAndEmail]
+    requires_dists: List[Requirement]
+    requires_python: SpecifierSet
+    requires_externals: List[str]
+    project_urls: List[_LabelAndURL]
+    provides_dists: List[str]
+    obsoletes_dists: List[str]
     description_content_type: str
-    provides_extras: list[utils.NormalizedName]
-    dynamic_fields: list[DynamicField]
+    provides_extras: List[NormalizedName]
+    dynamic_fields: List[DynamicField]
 
     def __init__(
         self,
         name: str,
-        version: packaging_version.Version,
+        version: Version,
         *,
         # 1.0
-        platforms: Iterable[str] | None = None,
-        summary: str | None = None,
-        description: str | None = None,
-        keywords: Iterable[str] | None = None,
-        home_page: str | None = None,
-        author: str | None = None,
-        author_emails: Iterable[_NameAndEmail] | None = None,
-        license: str | None = None,
+        platforms: Optional[Iterable[str]] = None,
+        summary: Optional[str] = None,
+        description: Optional[str] = None,
+        keywords: Optional[Iterable[str]] = None,
+        home_page: Optional[str] = None,
+        author: Optional[str] = None,
+        author_emails: Optional[Iterable[_NameAndEmail]] = None,
+        license: Optional[str] = None,
         # 1.1
-        supported_platforms: Iterable[str] | None = None,
-        download_url: str | None = None,
-        classifiers: Iterable[str] | None = None,
+        supported_platforms: Optional[Iterable[str]] = None,
+        download_url: Optional[str] = None,
+        classifiers: Optional[Iterable[str]] = None,
         # 1.2
-        maintainer: str | None = None,
-        maintainer_emails: Iterable[_NameAndEmail] | None = None,
-        requires_dists: Iterable[requirements.Requirement] | None = None,
-        requires_python: specifiers.SpecifierSet | None = None,
-        requires_externals: Iterable[str] | None = None,
-        project_urls: Iterable[_LabelAndURL] | None = None,
-        provides_dists: Iterable[str] | None = None,
-        obsoletes_dists: Iterable[str] | None = None,
+        maintainer: Optional[str] = None,
+        maintainer_emails: Optional[Iterable[_NameAndEmail]] = None,
+        requires_dists: Optional[Iterable[Requirement]] = None,
+        requires_python: Optional[SpecifierSet] = None,
+        requires_externals: Optional[Iterable[str]] = None,
+        project_urls: Optional[Iterable[_LabelAndURL]] = None,
+        provides_dists: Optional[Iterable[str]] = None,
+        obsoletes_dists: Optional[Iterable[str]] = None,
         # 2.1
-        description_content_type: str | None = None,
-        provides_extras: Iterable[utils.NormalizedName] | None = None,
+        description_content_type: Optional[str] = None,
+        provides_extras: Optional[Iterable[NormalizedName]] = None,
         # 2.2
-        dynamic_fields: Iterable[DynamicField] | None = None,
+        dynamic_fields: Optional[Iterable[DynamicField]] = None,
     ) -> None:
-        """
-        Set all attributes on the instance.
+        """Initialize a Metadata object.
 
-        An argument of `None` will be converted to an appropriate, false-y value
-        (e.g. the empty string).
+        The parameters all correspond to fields in `Core Metadata`_.
+
+        :param name: ``Name``
+        :param version: ``Version``
+        :param platforms: ``Platform``
+        :param summary: ``Summary``
+        :param description: ``Description``
+        :param keywords: ``Keywords``
+        :param home_page: ``Home-Page``
+        :param author: ``Author``
+        :param author_emails:
+            ``Author-Email`` (two-item tuple represents the name and email of the
+            author)
+        :param license: ``License``
+        :param supported_platforms: ``Supported-Platform``
+        :param download_url: ``Download-URL``
+        :param classifiers: ``Classifier``
+        :param maintainer: ``Maintainer``
+        :param maintainer_emails:
+            ``Maintainer-Email`` (two-item tuple represent the name and email of the
+            maintainer)
+        :param requires_dists: ``Requires-Dist``
+        :param SpecifierSet requires_python: ``Requires-Python``
+        :param requires_externals: ``Requires-External``
+        :param project_urls: ``Project-URL``
+        :param provides_dists: ``Provides-Dist``
+        :param obsoletes_dists: ``Obsoletes-Dist``
+        :param description_content_type: ``Description-Content-Type``
+        :param provides_extras: ``Provides-Extra``
+        :param dynamic_fields: ``Dynamic``
         """
         self.display_name = name
         self.version = version
@@ -142,7 +174,7 @@ class Metadata:
         self.maintainer = maintainer or ""
         self.maintainer_emails = list(maintainer_emails or [])
         self.requires_dists = list(requires_dists or [])
-        self.requires_python = requires_python or specifiers.SpecifierSet()
+        self.requires_python = requires_python or SpecifierSet()
         self.requires_externals = list(requires_externals or [])
         self.project_urls = list(project_urls or [])
         self.provides_dists = list(provides_dists or [])
@@ -153,18 +185,27 @@ class Metadata:
 
     @property
     def display_name(self) -> str:
+        """
+        The project name to be displayed to users (i.e. not normalized). Initially
+        set based on the `name` parameter.
+
+        Setting this attribute will also update :attr:`canonical_name`.
+        """
         return self._display_name
 
     @display_name.setter
     def display_name(self, value: str) -> None:
-        """
-        Set the value for self.display_name and self.canonical_name.
-        """
         self._display_name = value
-        self._canonical_name = utils.canonicalize_name(value)
+        self._canonical_name = canonicalize_name(value)
 
     # Use functools.cached_property once Python 3.7 support is dropped.
     # Value is set by self.display_name.setter to keep in sync with self.display_name.
     @property
-    def canonical_name(self) -> utils.NormalizedName:
+    def canonical_name(self) -> NormalizedName:
+        """
+        The normalized project name as per :func:`packaging.utils.canonicalize_name`.
+
+        The attribute is read-only and automatically calculated based on the value of
+        :attr:`display_name`.
+        """
         return self._canonical_name

--- a/packaging/specifiers.py
+++ b/packaging/specifiers.py
@@ -1,6 +1,12 @@
 # This file is dual licensed under the terms of the Apache License, Version
 # 2.0, and the BSD License. See the LICENSE file in the root of this repository
 # for complete details.
+"""
+.. testsetup::
+
+    from packaging.specifiers import Specifier, SpecifierSet, InvalidSpecifier
+    from packaging.version import Version
+"""
 
 import abc
 import itertools
@@ -22,7 +28,13 @@ def _coerce_version(version: UnparsedVersion) -> Version:
 
 class InvalidSpecifier(ValueError):
     """
-    An invalid specifier was found, users should refer to PEP 440.
+    Raised when attempting to create a :class:`Specifier` with a specifier
+    string that is invalid.
+
+    >>> Specifier("lolwat")
+    Traceback (most recent call last):
+        ...
+    packaging.specifiers.InvalidSpecifier: Invalid specifier: 'lolwat'
     """
 
 
@@ -30,36 +42,39 @@ class BaseSpecifier(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def __str__(self) -> str:
         """
-        Returns the str representation of this Specifier like object. This
+        Returns the str representation of this Specifier-like object. This
         should be representative of the Specifier itself.
         """
 
     @abc.abstractmethod
     def __hash__(self) -> int:
         """
-        Returns a hash value for this Specifier like object.
+        Returns a hash value for this Specifier-like object.
         """
 
     @abc.abstractmethod
     def __eq__(self, other: object) -> bool:
         """
-        Returns a boolean representing whether or not the two Specifier like
+        Returns a boolean representing whether or not the two Specifier-like
         objects are equal.
+
+        :param other: The other object to check against.
         """
 
     @property
     @abc.abstractmethod
     def prereleases(self) -> Optional[bool]:
-        """
-        Returns whether or not pre-releases as a whole are allowed by this
-        specifier.
+        """Whether or not pre-releases as a whole are allowed.
+
+        This can be set to either ``True`` or ``False`` to explicitly enable or disable
+        prereleases or it can be set to ``None`` (the default) to use default semantics.
         """
 
     @prereleases.setter
     def prereleases(self, value: bool) -> None:
-        """
-        Sets whether or not pre-releases as a whole are allowed by this
-        specifier.
+        """Setter for :attr:`prereleases`.
+
+        :param value: The value to set.
         """
 
     @abc.abstractmethod
@@ -79,6 +94,14 @@ class BaseSpecifier(metaclass=abc.ABCMeta):
 
 
 class Specifier(BaseSpecifier):
+    """This class abstracts handling of version specifiers.
+
+    .. tip::
+
+        It is generally not required to instantiate this manually. You should instead
+        prefer to work with :class:`SpecifierSet` instead, which can parse
+        comma-separated version specifiers (which is what package metadata contains).
+    """
 
     _regex_str = r"""
         (?P<operator>(~=|==|!=|<=|>=|<|>|===))
@@ -187,6 +210,18 @@ class Specifier(BaseSpecifier):
     }
 
     def __init__(self, spec: str = "", prereleases: Optional[bool] = None) -> None:
+        """Initialize a Specifier instance.
+
+        :param spec:
+            The string representation of a specifier which will be parsed and
+            normalized before use.
+        :param prereleases:
+            This tells the specifier if it should accept prerelease versions if
+            applicable or not. The default of ``None`` will autodetect it from the
+            given specifiers.
+        :raises InvalidSpecifier:
+            If the given specifier is invalid (i.e. bad syntax).
+        """
         match = self._regex.search(spec)
         if not match:
             raise InvalidSpecifier(f"Invalid specifier: '{spec}'")
@@ -199,7 +234,62 @@ class Specifier(BaseSpecifier):
         # Store whether or not this Specifier should accept prereleases
         self._prereleases = prereleases
 
+    @property
+    def prereleases(self) -> bool:
+        # If there is an explicit prereleases set for this, then we'll just
+        # blindly use that.
+        if self._prereleases is not None:
+            return self._prereleases
+
+        # Look at all of our specifiers and determine if they are inclusive
+        # operators, and if they are if they are including an explicit
+        # prerelease.
+        operator, version = self._spec
+        if operator in ["==", ">=", "<=", "~=", "==="]:
+            # The == specifier can include a trailing .*, if it does we
+            # want to remove before parsing.
+            if operator == "==" and version.endswith(".*"):
+                version = version[:-2]
+
+            # Parse the version, and if it is a pre-release than this
+            # specifier allows pre-releases.
+            if Version(version).is_prerelease:
+                return True
+
+        return False
+
+    @prereleases.setter
+    def prereleases(self, value: bool) -> None:
+        self._prereleases = value
+
+    @property
+    def operator(self) -> str:
+        """The operator of this specifier.
+
+        >>> Specifier("==1.2.3").operator
+        '=='
+        """
+        return self._spec[0]
+
+    @property
+    def version(self) -> str:
+        """The version of this specifier.
+
+        >>> Specifier("==1.2.3").version
+        '1.2.3'
+        """
+        return self._spec[1]
+
     def __repr__(self) -> str:
+        """A representation of the Specifier that shows all internal state.
+
+        >>> Specifier('>=1.0.0')
+        <Specifier('>=1.0.0')>
+        >>> Specifier('>=1.0.0', prereleases=False)
+        <Specifier('>=1.0.0', prereleases=False)>
+        >>> Specifier('>=1.0.0', prereleases=True)
+        <Specifier('>=1.0.0', prereleases=True)>
+        """
         pre = (
             f", prereleases={self.prereleases!r}"
             if self._prereleases is not None
@@ -209,6 +299,13 @@ class Specifier(BaseSpecifier):
         return f"<{self.__class__.__name__}({str(self)!r}{pre})>"
 
     def __str__(self) -> str:
+        """A string representation of the Specifier that can be round-tripped.
+
+        >>> str(Specifier('>=1.0.0'))
+        '>=1.0.0'
+        >>> str(Specifier('>=1.0.0', prereleases=False))
+        '>=1.0.0'
+        """
         return "{}{}".format(*self._spec)
 
     @property
@@ -223,6 +320,24 @@ class Specifier(BaseSpecifier):
         return hash(self._canonical_spec)
 
     def __eq__(self, other: object) -> bool:
+        """Whether or not the two Specifier-like objects are equal.
+
+        :param other: The other object to check against.
+
+        The value of :attr:`prereleases` is ignored.
+
+        >>> Specifier("==1.2.3") == Specifier("== 1.2.3.0")
+        True
+        >>> (Specifier("==1.2.3", prereleases=False) ==
+        ...  Specifier("==1.2.3", prereleases=True))
+        True
+        >>> Specifier("==1.2.3") == "==1.2.3"
+        True
+        >>> Specifier("==1.2.3") == Specifier("==1.2.4")
+        False
+        >>> Specifier("==1.2.3") == Specifier("~=1.2.3")
+        False
+        """
         if isinstance(other, str):
             try:
                 other = self.__class__(str(other))
@@ -375,20 +490,53 @@ class Specifier(BaseSpecifier):
     def _compare_arbitrary(self, prospective: Version, spec: str) -> bool:
         return str(prospective).lower() == str(spec).lower()
 
-    @property
-    def operator(self) -> str:
-        return self._spec[0]
+    def __contains__(self, item: Union[str, Version]) -> bool:
+        """Return whether or not the item is contained in this specifier.
 
-    @property
-    def version(self) -> str:
-        return self._spec[1]
+        :param item: The item to check for.
 
-    def __contains__(self, item: str) -> bool:
+        This is used for the ``in`` operator and behaves the same as
+        :meth:`contains` with no ``prereleases`` argument passed.
+
+        >>> "1.2.3" in Specifier(">=1.2.3")
+        True
+        >>> Version("1.2.3") in Specifier(">=1.2.3")
+        True
+        >>> "1.0.0" in Specifier(">=1.2.3")
+        False
+        >>> "1.3.0a1" in Specifier(">=1.2.3")
+        False
+        >>> "1.3.0a1" in Specifier(">=1.2.3", prereleases=True)
+        True
+        """
         return self.contains(item)
 
     def contains(
         self, item: UnparsedVersion, prereleases: Optional[bool] = None
     ) -> bool:
+        """Return whether or not the item is contained in this specifier.
+
+        :param item:
+            The item to check for, which can be a version string or a
+            :class:`Version` instance.
+        :param prereleases:
+            Whether or not to match prereleases with this Specifier. If set to
+            ``None`` (the default), it uses :attr:`prereleases` to determine
+            whether or not prereleases are allowed.
+
+        >>> Specifier(">=1.2.3").contains("1.2.3")
+        True
+        >>> Specifier(">=1.2.3").contains(Version("1.2.3"))
+        True
+        >>> Specifier(">=1.2.3").contains("1.0.0")
+        False
+        >>> Specifier(">=1.2.3").contains("1.3.0a1")
+        False
+        >>> Specifier(">=1.2.3", prereleases=True).contains("1.3.0a1")
+        True
+        >>> Specifier(">=1.2.3").contains("1.3.0a1", prereleases=True)
+        True
+        """
 
         # Determine if prereleases are to be allowed or not.
         if prereleases is None:
@@ -412,6 +560,32 @@ class Specifier(BaseSpecifier):
     def filter(
         self, iterable: Iterable[UnparsedVersion], prereleases: Optional[bool] = None
     ) -> Iterable[UnparsedVersion]:
+        """Filter items in the given iterable, that match the specifier.
+
+        :param iterable:
+            An iterable that can contain version strings and :class:`Version` instances.
+            The items in the iterable will be filtered according to the specifier.
+        :param prereleases:
+            Whether or not to allow prereleases in the returned iterable. If set to
+            ``None`` (the default), it will be intelligently decide whether to allow
+            prereleases or not (based on the :attr:`prereleases` attribute, and
+            whether the only versions matching are prereleases).
+
+        This method is smarter than just ``filter(Specifier().contains, [...])``
+        because it implements the rule from :pep:`440` that a prerelease item
+        SHOULD be accepted if no other versions match the given specifier.
+
+        >>> list(Specifier(">=1.2.3").filter(["1.2", "1.3", "1.5a1"]))
+        ['1.3']
+        >>> list(Specifier(">=1.2.3").filter(["1.2", "1.2.3", "1.3", Version("1.4")]))
+        ['1.2.3', '1.3', <Version('1.4')>]
+        >>> list(Specifier(">=1.2.3").filter(["1.2", "1.5a1"]))
+        ['1.5a1']
+        >>> list(Specifier(">=1.2.3").filter(["1.3", "1.5a1"], prereleases=True))
+        ['1.3', '1.5a1']
+        >>> list(Specifier(">=1.2.3", prereleases=True).filter(["1.3", "1.5a1"]))
+        ['1.3', '1.5a1']
+        """
 
         yielded = False
         found_prereleases = []
@@ -443,35 +617,6 @@ class Specifier(BaseSpecifier):
         if not yielded and found_prereleases:
             for version in found_prereleases:
                 yield version
-
-    @property
-    def prereleases(self) -> bool:
-
-        # If there is an explicit prereleases set for this, then we'll just
-        # blindly use that.
-        if self._prereleases is not None:
-            return self._prereleases
-
-        # Look at all of our specifiers and determine if they are inclusive
-        # operators, and if they are if they are including an explicit
-        # prerelease.
-        operator, version = self._spec
-        if operator in ["==", ">=", "<=", "~=", "==="]:
-            # The == specifier can include a trailing .*, if it does we
-            # want to remove before parsing.
-            if operator == "==" and version.endswith(".*"):
-                version = version[:-2]
-
-            # Parse the version, and if it is a pre-release than this
-            # specifier allows pre-releases.
-            if Version(version).is_prerelease:
-                return True
-
-        return False
-
-    @prereleases.setter
-    def prereleases(self, value: bool) -> None:
-        self._prereleases = value
 
 
 _prefix_regex = re.compile(r"^([0-9]+)((?:a|b|c|rc)[0-9]+)$")
@@ -513,11 +658,31 @@ def _pad_version(left: List[str], right: List[str]) -> Tuple[List[str], List[str
 
 
 class SpecifierSet(BaseSpecifier):
+    """This class abstracts handling of a set of version specifiers.
+
+    It can be passed a single specifier (``>=3.0``), a comma-separated list of
+    specifiers (``>=3.0,!=3.1``), or no specifier at all.
+    """
+
     def __init__(
         self, specifiers: str = "", prereleases: Optional[bool] = None
     ) -> None:
+        """Initialize a SpecifierSet instance.
 
-        # Split on , to break each individual specifier into it's own item, and
+        :param specifiers:
+            The string representation of a specifier or a comma-separated list of
+            specifiers which will be parsed and normalized before use.
+        :param prereleases:
+            This tells the SpecifierSet if it should accept prerelease versions if
+            applicable or not. The default of ``None`` will autodetect it from the
+            given specifiers.
+
+        :raises InvalidSpecifier:
+            If the given ``specifiers`` are not parseable than this exception will be
+            raised.
+        """
+
+        # Split on `,` to break each individual specifier into it's own item, and
         # strip each item to remove leading/trailing whitespace.
         split_specifiers = [s.strip() for s in specifiers.split(",") if s.strip()]
 
@@ -534,7 +699,40 @@ class SpecifierSet(BaseSpecifier):
         # we accept prereleases or not.
         self._prereleases = prereleases
 
+    @property
+    def prereleases(self) -> Optional[bool]:
+        # If we have been given an explicit prerelease modifier, then we'll
+        # pass that through here.
+        if self._prereleases is not None:
+            return self._prereleases
+
+        # If we don't have any specifiers, and we don't have a forced value,
+        # then we'll just return None since we don't know if this should have
+        # pre-releases or not.
+        if not self._specs:
+            return None
+
+        # Otherwise we'll see if any of the given specifiers accept
+        # prereleases, if any of them do we'll return True, otherwise False.
+        return any(s.prereleases for s in self._specs)
+
+    @prereleases.setter
+    def prereleases(self, value: bool) -> None:
+        self._prereleases = value
+
     def __repr__(self) -> str:
+        """A representation of the specifier set that shows all internal state.
+
+        Note that the ordering of the individual specifiers within the set may not
+        match the input string.
+
+        >>> SpecifierSet('>=1.0.0,!=2.0.0')
+        <SpecifierSet('!=2.0.0,>=1.0.0')>
+        >>> SpecifierSet('>=1.0.0,!=2.0.0', prereleases=False)
+        <SpecifierSet('!=2.0.0,>=1.0.0', prereleases=False)>
+        >>> SpecifierSet('>=1.0.0,!=2.0.0', prereleases=True)
+        <SpecifierSet('!=2.0.0,>=1.0.0', prereleases=True)>
+        """
         pre = (
             f", prereleases={self.prereleases!r}"
             if self._prereleases is not None
@@ -544,12 +742,31 @@ class SpecifierSet(BaseSpecifier):
         return f"<SpecifierSet({str(self)!r}{pre})>"
 
     def __str__(self) -> str:
+        """A string representation of the specifier set that can be round-tripped.
+
+        Note that the ordering of the individual specifiers within the set may not
+        match the input string.
+
+        >>> str(SpecifierSet(">=1.0.0,!=1.0.1"))
+        '!=1.0.1,>=1.0.0'
+        >>> str(SpecifierSet(">=1.0.0,!=1.0.1", prereleases=False))
+        '!=1.0.1,>=1.0.0'
+        """
         return ",".join(sorted(str(s) for s in self._specs))
 
     def __hash__(self) -> int:
         return hash(self._specs)
 
     def __and__(self, other: Union["SpecifierSet", str]) -> "SpecifierSet":
+        """Return a SpecifierSet which is a combination of the two sets.
+
+        :param other: The other object to combine with.
+
+        >>> SpecifierSet(">=1.0.0,!=1.0.1") & '<=2.0.0,!=2.0.1'
+        <SpecifierSet('!=1.0.1,!=2.0.1,<=2.0.0,>=1.0.0')>
+        >>> SpecifierSet(">=1.0.0,!=1.0.1") & SpecifierSet('<=2.0.0,!=2.0.1')
+        <SpecifierSet('!=1.0.1,!=2.0.1,<=2.0.0,>=1.0.0')>
+        """
         if isinstance(other, str):
             other = SpecifierSet(other)
         elif not isinstance(other, SpecifierSet):
@@ -573,6 +790,24 @@ class SpecifierSet(BaseSpecifier):
         return specifier
 
     def __eq__(self, other: object) -> bool:
+        """Whether or not the two SpecifierSet-like objects are equal.
+
+        :param other: The other object to check against.
+
+        The value of :attr:`prereleases` is ignored.
+
+        >>> SpecifierSet(">=1.0.0,!=1.0.1") == SpecifierSet(">=1.0.0,!=1.0.1")
+        True
+        >>> (SpecifierSet(">=1.0.0,!=1.0.1", prereleases=False) ==
+        ...  SpecifierSet(">=1.0.0,!=1.0.1", prereleases=True))
+        True
+        >>> SpecifierSet(">=1.0.0,!=1.0.1") == ">=1.0.0,!=1.0.1"
+        True
+        >>> SpecifierSet(">=1.0.0,!=1.0.1") == SpecifierSet(">=1.0.0")
+        False
+        >>> SpecifierSet(">=1.0.0,!=1.0.1") == SpecifierSet(">=1.0.0,!=1.0.2")
+        False
+        """
         if isinstance(other, (str, Specifier)):
             other = SpecifierSet(str(other))
         elif not isinstance(other, SpecifierSet):
@@ -581,34 +816,35 @@ class SpecifierSet(BaseSpecifier):
         return self._specs == other._specs
 
     def __len__(self) -> int:
+        """Returns the number of specifiers in this specifier set."""
         return len(self._specs)
 
     def __iter__(self) -> Iterator[Specifier]:
+        """
+        Returns an iterator over all the underlying :class:`Specifier` instances
+        in this specifier set.
+        """
         return iter(self._specs)
 
-    @property
-    def prereleases(self) -> Optional[bool]:
-
-        # If we have been given an explicit prerelease modifier, then we'll
-        # pass that through here.
-        if self._prereleases is not None:
-            return self._prereleases
-
-        # If we don't have any specifiers, and we don't have a forced value,
-        # then we'll just return None since we don't know if this should have
-        # pre-releases or not.
-        if not self._specs:
-            return None
-
-        # Otherwise we'll see if any of the given specifiers accept
-        # prereleases, if any of them do we'll return True, otherwise False.
-        return any(s.prereleases for s in self._specs)
-
-    @prereleases.setter
-    def prereleases(self, value: bool) -> None:
-        self._prereleases = value
-
     def __contains__(self, item: UnparsedVersion) -> bool:
+        """Return whether or not the item is contained in this specifier.
+
+        :param item: The item to check for.
+
+        This is used for the ``in`` operator and behaves the same as
+        :meth:`contains` with no ``prereleases`` argument passed.
+
+        >>> "1.2.3" in SpecifierSet(">=1.0.0,!=1.0.1")
+        True
+        >>> Version("1.2.3") in SpecifierSet(">=1.0.0,!=1.0.1")
+        True
+        >>> "1.0.1" in SpecifierSet(">=1.0.0,!=1.0.1")
+        False
+        >>> "1.3.0a1" in SpecifierSet(">=1.0.0,!=1.0.1")
+        False
+        >>> "1.3.0a1" in SpecifierSet(">=1.0.0,!=1.0.1", prereleases=True)
+        True
+        """
         return self.contains(item)
 
     def contains(
@@ -617,7 +853,29 @@ class SpecifierSet(BaseSpecifier):
         prereleases: Optional[bool] = None,
         installed: Optional[bool] = None,
     ) -> bool:
+        """Return whether or not the item is contained in this SpecifierSet.
 
+        :param item:
+            The item to check for, which can be a version string or a
+            :class:`Version` instance.
+        :param prereleases:
+            Whether or not to match prereleases with this SpecifierSet. If set to
+            ``None`` (the default), it uses :attr:`prereleases` to determine
+            whether or not prereleases are allowed.
+
+        >>> SpecifierSet(">=1.0.0,!=1.0.1").contains("1.2.3")
+        True
+        >>> SpecifierSet(">=1.0.0,!=1.0.1").contains(Version("1.2.3"))
+        True
+        >>> SpecifierSet(">=1.0.0,!=1.0.1").contains("1.0.1")
+        False
+        >>> SpecifierSet(">=1.0.0,!=1.0.1").contains("1.3.0a1")
+        False
+        >>> SpecifierSet(">=1.0.0,!=1.0.1", prereleases=True).contains("1.3.0a1")
+        True
+        >>> SpecifierSet(">=1.0.0,!=1.0.1").contains("1.3.0a1", prereleases=True)
+        True
+        """
         # Ensure that our item is a Version instance.
         if not isinstance(item, Version):
             item = Version(item)
@@ -649,7 +907,44 @@ class SpecifierSet(BaseSpecifier):
     def filter(
         self, iterable: Iterable[UnparsedVersion], prereleases: Optional[bool] = None
     ) -> Iterable[UnparsedVersion]:
+        """Filter items in the given iterable, that match the specifiers in this set.
 
+        :param iterable:
+            An iterable that can contain version strings and :class:`Version` instances.
+            The items in the iterable will be filtered according to the specifier.
+        :param prereleases:
+            Whether or not to allow prereleases in the returned iterable. If set to
+            ``None`` (the default), it will be intelligently decide whether to allow
+            prereleases or not (based on the :attr:`prereleases` attribute, and
+            whether the only versions matching are prereleases).
+
+        This method is smarter than just ``filter(SpecifierSet(...).contains, [...])``
+        because it implements the rule from :pep:`440` that a prerelease item
+        SHOULD be accepted if no other versions match the given specifier.
+
+        >>> list(SpecifierSet(">=1.2.3").filter(["1.2", "1.3", "1.5a1"]))
+        ['1.3']
+        >>> list(SpecifierSet(">=1.2.3").filter(["1.2", "1.3", Version("1.4")]))
+        ['1.3', <Version('1.4')>]
+        >>> list(SpecifierSet(">=1.2.3").filter(["1.2", "1.5a1"]))
+        []
+        >>> list(SpecifierSet(">=1.2.3").filter(["1.3", "1.5a1"], prereleases=True))
+        ['1.3', '1.5a1']
+        >>> list(SpecifierSet(">=1.2.3", prereleases=True).filter(["1.3", "1.5a1"]))
+        ['1.3', '1.5a1']
+
+        An "empty" SpecifierSet will filter items based on the presence of prerelease
+        versions in the set.
+
+        >>> list(SpecifierSet("").filter(["1.3", "1.5a1"]))
+        ['1.3']
+        >>> list(SpecifierSet("").filter(["1.5a1"]))
+        ['1.5a1']
+        >>> list(SpecifierSet("", prereleases=True).filter(["1.3", "1.5a1"]))
+        ['1.3', '1.5a1']
+        >>> list(SpecifierSet("").filter(["1.3", "1.5a1"], prereleases=True))
+        ['1.3', '1.5a1']
+        """
         # Determine if we're forcing a prerelease or not, if we're not forcing
         # one for this particular filter call, then we'll use whatever the
         # SpecifierSet thinks for whether or not we should support prereleases.


### PR DESCRIPTION
Toward #567.

At the time of opening this PR, only three modules have been converted over -- `metadata`, `version` and `specifiers`. I'd like to get a round of feedback on this, before moving forward on the other modules (I'm adding example usage to make the various concepts clearer and that is taking a decent amount of time!).

I think it's reasonable to do this incrementally, so we can handle the other modules once we have agreement that this is a positive direction to take things. :)

PS: Some code moved up-and-down in the class bodies, since I've configured autodoc ordering to be `"bysource"`. It might make sense to do `"groupwise"` instead, but I prefer this since it gives us more control on ordering.
