### PR TITLE
Update coverage to `>=5.0.0`

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,9 +1,0 @@
-[run]
-branch = True
-omit = packaging/_compat.py
-
-[report]
-exclude_lines =
-    pragma: no cover
-    @abc.abstractmethod
-    @abc.abstractproperty

--- a/noxfile.py
+++ b/noxfile.py
@@ -26,8 +26,7 @@ def tests(session):
     def coverage(*args):
         session.run("python", "-m", "coverage", *args)
 
-    # Once coverage 5 is used then `.coverage` can move into `pyproject.toml`.
-    session.install("coverage<5.0.0", "pretend", "pytest>=6.2.0", "pip>=9.0.2")
+    session.install("coverage[toml]>=5.0.0", "pretend", "pytest>=6.2.0", "pip>=9.0.2")
     session.install(".")
 
     if "pypy" not in session.python:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,14 @@ requires = ['setuptools >= 40.8.0', 'wheel']
 build-backend = 'setuptools.build_meta'
 
 
+[tool.coverage.run]
+branch = true
+omit = ["packaging/_compat.py"]
+
+[tool.coverage.report]
+exclude_lines = ["pragma: no cover", "@abc.abstractmethod", "@abc.abstractproperty"]
+
+
 [tool.mypy]
 strict = true
 show_error_codes = true


### PR DESCRIPTION
`coverage<5.0.0` does not report correct coverage with python 3.11
The restriction added in #247 is not needed anymore (in fact, `==5.0.0` is now working properly somehow...)
