### PR TITLE
Improve error shown when there's no space between semicolon and url

### DIFF
--- a/packaging/_parser.py
+++ b/packaging/_parser.py
@@ -90,9 +90,14 @@ def parse_named_requirement(requirement: str) -> Requirement:
             )
             # update position to point at the place where the space was expected
             tokens.position -= 1
+            suffix = (
+                f"Maybe you mean this instead?\n    "
+                f"{tokens.source[:tokens.position]} {tokens.source[tokens.position:]}"
+            )
         else:
             error_msg = "Expected semicolon (followed by markers) or end of string"
-        tokens.raise_syntax_error(message=error_msg)
+            suffix = ""
+        tokens.raise_syntax_error(message=error_msg, suffix=suffix)
     return Requirement(name, url, extras, specifier, marker)
 
 

--- a/packaging/_tokenizer.py
+++ b/packaging/_tokenizer.py
@@ -129,16 +129,16 @@ class Tokenizer:
             return self.read()
         return None
 
-    def raise_syntax_error(self, *, message: str) -> NoReturn:
+    def raise_syntax_error(self, *, message: str, suffix: str = "") -> NoReturn:
         """
         Raise SyntaxError at the given position in the marker.
         """
         at = f"at position {self.position}:"
         marker = " " * self.position + "^"
-        raise ParseExceptionError(
-            f"{message}\n{at}\n    {self.source}\n    {marker}",
-            self.position,
-        )
+        message = f"{message}\n{at}\n    {self.source}\n    {marker}"
+        if suffix:
+            message = f"{message}\n{suffix}"
+        raise ParseExceptionError(message, self.position)
 
     def _make_token(self, name: str, text: str) -> Token:
         """

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -196,6 +196,14 @@ class TestRequirements:
             Requirement('name[bar]>=3 python_version == "2.7"')
         assert "Expected semicolon (followed by markers) or end of string" in str(e)
 
+    def test_url_and_marker_with_missing_space_after_semicolon(self):
+        with pytest.raises(InvalidRequirement) as e:
+            Requirement('foobar @ https://foo.com; python_version < "3.11"')
+        assert (
+            "Expected space before semicolon (followed by markers) or end of string"
+            in str(e)
+        )
+
     def test_types(self):
         req = Requirement("foobar[quux]<2,>=3; os_name=='a'")
         assert isinstance(req.name, str)


### PR DESCRIPTION
Fixes #529 

I kind of wanted to also show:
> Expected space and semicolon (followed by markers) or end of string

when `url` doesn't end with `;` but this sentence seemed a bit unnatural to me and I couldn't think of a better way of phrasing it + if the user ends up not putting a space, they'll get the better message when they try for the second time anyway.

I also originally wanted to say something more similar to Python's error messages, i.e. "Maybe you meant to put a space before the semicolon?" but that doesn't quite fit with the error message format ending with "at position ..":
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/ubuntu/work/packaging/packaging/requirements.py", line 42, in __init__
    raise InvalidRequirement(str(e))
packaging.requirements.InvalidRequirement: Expected semicolon (followed by markers) or end of string. Maybe you meant to put a space before the semicolon?
at position 59:
    tomli @ https://github.com/hukkin/tomli/archive/master.zip; python_version < '3.11'
                                                              ^
```

Either way, I'm open to suggestions.