### PR TITLE
refactor _generic_api to use EXT_SUFFIX

### DIFF
--- a/src/packaging/tags.py
+++ b/src/packaging/tags.py
@@ -233,12 +233,13 @@ def _generic_abi() -> List[str]:
     # - linux:   '.cpython-310-x86_64-linux-gnu.so' => cp310
     # - mac:     '.cpython-310-darwin.so'           => cp310
     # - win:     '.cp310-win_amd64.pyd'             => cp310
-    # - pypy:    '.pypy38-pp73-x86_64-linux-gnu.so' => pypy38-pp73
+    # - pypy:    '.pypy38-pp73-x86_64-linux-gnu.so' => pypy38_pp73
     # - graalpy: '.graalpy-38-native-x86_64-darwin.dylib'
-    #                                               => graalpy-38-native
+    #                                               => graalpy_38_native
 
     ext_suffix = _get_config_var("EXT_SUFFIX", warn=True)
-    assert ext_suffix[0] == "."
+    if not isinstance(ext_suffix, str) or ext_suffix[0] != ".":
+        raise SystemError("invalid sysconfig.get_config_var('EXT_SUFFIX')")
     _, soabi, ext = ext_suffix.split(".")
     if soabi.startswith("cpython"):
         abi = "cp" + soabi.split("-")[1]

--- a/src/packaging/tags.py
+++ b/src/packaging/tags.py
@@ -233,6 +233,7 @@ def _generic_abi() -> List[str]:
     # - linux:   '.cpython-310-x86_64-linux-gnu.so' => cp310
     # - mac:     '.cpython-310-darwin.so'           => cp310
     # - win:     '.cp310-win_amd64.pyd'             => cp310
+    # - win:     '.pyd'                             => cp37 (uses _cpython_abis())
     # - pypy:    '.pypy38-pp73-x86_64-linux-gnu.so' => pypy38_pp73
     # - graalpy: '.graalpy-38-native-x86_64-darwin.dylib'
     #                                               => graalpy_38_native
@@ -246,12 +247,17 @@ def _generic_abi() -> List[str]:
         return _cpython_abis(sys.version_info[:2])
     soabi = parts[1]
     if soabi.startswith("cpython"):
+        # non-windows
         abi = "cp" + soabi.split("-")[1]
+    elif soabi.startswith("cp"):
+        # windows
+        abi = soabi.split("-")[0]
     elif soabi.startswith("pypy"):
         abi = "-".join(soabi.split("-")[:2])
     elif soabi.startswith("graalpy"):
         abi = "-".join(soabi.split("-")[:3])
     elif soabi:
+        # pyston, ironpython, others?
         abi = soabi
     else:
         return []

--- a/src/packaging/tags.py
+++ b/src/packaging/tags.py
@@ -240,7 +240,11 @@ def _generic_abi() -> List[str]:
     ext_suffix = _get_config_var("EXT_SUFFIX", warn=True)
     if not isinstance(ext_suffix, str) or ext_suffix[0] != ".":
         raise SystemError("invalid sysconfig.get_config_var('EXT_SUFFIX')")
-    _, soabi, ext = ext_suffix.split(".")
+    parts = ext_suffix.split(".")
+    if len(parts) < 3:
+        # CPython3.7 and earlier uses ".pyd" on windows
+        return _cpython_abis(sys.version_info[:2])
+    soabi = parts[1]
     if soabi.startswith("cpython"):
         abi = "cp" + soabi.split("-")[1]
     elif soabi.startswith("pypy"):

--- a/src/packaging/tags.py
+++ b/src/packaging/tags.py
@@ -226,10 +226,12 @@ def cpython_tags(
 
 
 def _generic_abi() -> List[str]:
-    """Return the ABI tag based on EXT_SUFFIX"""
-    # ext_suffix is something like this. We want to keep the parts which are
-    # related to the ABI and remove the parts which are related to the
-    # platform:
+    """
+    Return the ABI tag based on EXT_SUFFIX.
+    """
+    # The following are examples of `EXT_SUFFIX`.
+    # We want to keep the parts which are related to the ABI and remove the
+    # parts which are related to the platform:
     # - linux:   '.cpython-310-x86_64-linux-gnu.so' => cp310
     # - mac:     '.cpython-310-darwin.so'           => cp310
     # - win:     '.cp310-win_amd64.pyd'             => cp310
@@ -243,7 +245,7 @@ def _generic_abi() -> List[str]:
         raise SystemError("invalid sysconfig.get_config_var('EXT_SUFFIX')")
     parts = ext_suffix.split(".")
     if len(parts) < 3:
-        # CPython3.7 and earlier uses ".pyd" on windows
+        # CPython3.7 and earlier uses ".pyd" on Windows.
         return _cpython_abis(sys.version_info[:2])
     soabi = parts[1]
     if soabi.startswith("cpython"):
@@ -496,7 +498,10 @@ def platform_tags() -> Iterator[str]:
 
 def interpreter_name() -> str:
     """
-    Returns the name of the running interpreter, usually as two characters.
+    Returns the name of the running interpreter.
+
+    Some implementations have a reserved, two-letter abbreviation which will
+    be returned when appropriate.
     """
     name = sys.implementation.name
     return INTERPRETER_SHORT_NAMES.get(name) or name

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -875,6 +875,15 @@ class TestGenericTags:
         monkeypatch.setattr(tags, "interpreter_name", lambda: "pp")
         assert tags._generic_abi() == ["pypy39_pp73"]
 
+    def test__generic_abi_old_windows(self, monkeypatch):
+        config = {
+            "EXT_SUFFIX": ".pyd",
+            "Py_DEBUG": 0,
+            "WITH_PYMALLOC": 0,
+        }
+        monkeypatch.setattr(sysconfig, "get_config_var", config.__getitem__)
+        assert tags._generic_abi() == tags._cpython_abis(sys.version_info[:2])
+
     def test_generic_platforms(self):
         platform = sysconfig.get_platform().replace("-", "_")
         platform = platform.replace(".", "_")

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -884,6 +884,12 @@ class TestGenericTags:
         monkeypatch.setattr(sysconfig, "get_config_var", config.__getitem__)
         assert tags._generic_abi() == tags._cpython_abis(sys.version_info[:2])
 
+    @pytest.mark.skipif(sys.implementation.name != "cpython", reason="CPython-only")
+    def test__generic_abi_windows(self):
+        """Test that the two methods of finding the abi tag agree
+        """
+        assert tags._generic_abi() == tags._cpython_abis(sys.version_info[:2])
+
     def test_generic_platforms(self):
         platform = sysconfig.get_platform().replace("-", "_")
         platform = platform.replace(".", "_")

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -845,8 +845,25 @@ class TestGenericTags:
     def test__generic_abi_jp(self, monkeypatch):
         config = {"EXT_SUFFIX": ".return exactly this.so"}
         monkeypatch.setattr(sysconfig, "get_config_var", config.__getitem__)
-        monkeypatch.setattr(tags, "interpreter_name", lambda: "other")
         assert tags._generic_abi() == ["return exactly this"]
+
+    def test__generic_abi_graal(self, monkeypatch):
+        config = {"EXT_SUFFIX": ".graalpy-38-native-x86_64-darwin.so"}
+        monkeypatch.setattr(sysconfig, "get_config_var", config.__getitem__)
+        assert tags._generic_abi() == ["graalpy_38_native"]
+
+    def test__generic_abi_none(self, monkeypatch):
+        config = {"EXT_SUFFIX": "..so"}
+        monkeypatch.setattr(sysconfig, "get_config_var", config.__getitem__)
+        assert tags._generic_abi() == []
+
+    @pytest.mark.parametrize("ext_suffix", ["invalid", None])
+    def test__generic_abi_error(self, ext_suffix, monkeypatch):
+        config = {"EXT_SUFFIX": ext_suffix}
+        monkeypatch.setattr(sysconfig, "get_config_var", config.__getitem__)
+        with pytest.raises(SystemError) as e:
+            tags._generic_abi()
+        assert "EXT_SUFFIX" in str(e.value)
 
     def test__generic_abi_linux_pypy(self, monkeypatch):
         # issue gh-606

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -884,10 +884,16 @@ class TestGenericTags:
         monkeypatch.setattr(sysconfig, "get_config_var", config.__getitem__)
         assert tags._generic_abi() == tags._cpython_abis(sys.version_info[:2])
 
+    def test__generic_abi_windows(self, monkeypatch):
+        config = {
+            "EXT_SUFFIX": ".cp310-win_amd64.pyd",
+        }
+        monkeypatch.setattr(sysconfig, "get_config_var", config.__getitem__)
+        assert tags._generic_abi() == ["cp310"]
+
     @pytest.mark.skipif(sys.implementation.name != "cpython", reason="CPython-only")
-    def test__generic_abi_windows(self):
-        """Test that the two methods of finding the abi tag agree
-        """
+    def test__generic_abi_agree(self):
+        """Test that the two methods of finding the abi tag agree"""
         assert tags._generic_abi() == tags._cpython_abis(sys.version_info[:2])
 
     def test_generic_platforms(self):


### PR DESCRIPTION
Fixes #606 where PyPy would like to change its non-compliant SOABI tag (`pypy36-pp73`) to a compliant one (`pypy39-pp73-x86_64-linux-gnu`).

The basic code is ~taken from [wheel.bdist_wheel](https://github.com/pypa/wheel/blob/7b9e8e1022b9c850756ef34bc1a4a88042988a86/src/wheel/bdist_wheel.py#L71)'s version.~
changed to use `EXT_SUFFIX` instead of `SOABI`.

A few other changes:
- return a list instead of a iterator, since all uses of the function converted to a list anyway
~- add a fallback for older cpython to call `_cpython_abis`, which means passing in PythonVersion~
- clarify the typical value of `interpreter_name`, since it actually is the 'cp' or 'pp' short name.

If I was starting over, PyPy's ABI tag would be `pp39_73` rather than `pypy39_73` to save two letters. Maybe someday ...

Edit (11-Nov-2022): refactored to use `EXT_SUFFIX`