### PR TITLE
test: Expand testing for wheel multi-version multi-platform

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -150,6 +150,18 @@ def test_canonicalize_version_no_strip_trailing_zero(version: str) -> None:
             },
         ),
         (
+            "foo-2-py2.py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+            "foo",
+            Version("2"),
+            (),
+            {
+                Tag("py2", "none", "manylinux_2_17_x86_64"),
+                Tag("py2", "none", "manylinux2014_x86_64"),
+                Tag("py3", "none", "manylinux_2_17_x86_64"),
+                Tag("py3", "none", "manylinux2014_x86_64"),
+            },
+        ),
+        (
             "foo_bár-1.0-py3-none-any.whl",
             "foo-bár",
             Version("1.0"),


### PR DESCRIPTION
Following this [past week's issue](https://pypi.org/project/wheel/#history) with `wheel==0.38`, this adds slightly more testing to help guard against a similar issue in this package. While its somewhat duplicative of what might already be tested in `test_tags.py`, since this is the most natural place to put an "end-user" consumption test (viz the internals), I thought the juice was worth the squeeze as a defensive test.

I submitted a PR with similar testing to the `wheel` package via https://github.com/pypa/wheel/pull/486, but since the intention is to have `wheel` depend on `packaging` eventually, I also wanted to make a similar contribution here.

* Add slightly more testing to the wheel and sdist tests
* Add venv to the .gitignore