### PR TITLE
Refactor nox requirements to use requirements files (#601)

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -28,7 +28,7 @@ def tests(session):
     def coverage(*args):
         session.run("python", "-m", "coverage", *args)
 
-    session.install("coverage[toml]>=5.0.0", "pretend", "pytest>=6.2.0", "pip>=9.0.2")
+    session.install("-r", "tests/requirements.txt")
     session.install(".")
 
     if "pypy" not in session.python:
@@ -69,7 +69,7 @@ def lint(session):
 @nox.session(python="3.9")
 def docs(session):
     shutil.rmtree("docs/_build", ignore_errors=True)
-    session.install("furo")
+    session.install("-r", "docs/requirements.txt")
     session.install("-e", ".")
 
     variants = [

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,0 +1,4 @@
+coverage[toml]>=5.0.0
+pip>=9.0.2
+pretend
+pytest>=6.2.0


### PR DESCRIPTION
There is an active discussion about alternatives in [discuss.python.org](https://discuss.python.org/t/adding-a-non-metadata-installer-only-dev-dependencies-table-to-pyproject-toml/20106/17), but hopefully this will help with the immediate need. 🙂 

First patch, so please say if it's too early in the discussion to make a PR, or if another approach would be better!