### PR TITLE
Fix _32_BIT_INTERPRETER for GraalPy

### DIFF
--- a/packaging/tags.py
+++ b/packaging/tags.py
@@ -4,6 +4,7 @@
 
 import logging
 import platform
+import struct
 import subprocess
 import sys
 import sysconfig

--- a/packaging/tags.py
+++ b/packaging/tags.py
@@ -37,7 +37,7 @@ INTERPRETER_SHORT_NAMES: Dict[str, str] = {
 }
 
 
-_32_BIT_INTERPRETER = sys.maxsize <= 2**32
+_32_BIT_INTERPRETER = (struct.calcsize("P") == 4)
 
 
 class Tag:


### PR DESCRIPTION
On GraalPy's 64-bit interpreter, `sys.maxsize` is `2**31-1` because Java arrays can be indexed only with 32-bit indices.

cc @timfel

TODO:
- [ ] keep backwards compat
- [ ] check macos