### PR TITLE
Remove unused LPAREN token from tokenizer

### DIFF
--- a/packaging/_tokenizer.py
+++ b/packaging/_tokenizer.py
@@ -35,7 +35,6 @@ class ParserSyntaxError(Exception):
 
 
 DEFAULT_RULES: "Dict[str, Union[str, re.Pattern[str]]]" = {
-    "LPAREN": r"\s*\(",
     "LEFT_PARENTHESIS": r"\(",
     "RIGHT_PARENTHESIS": r"\)",
     "LEFT_BRACKET": r"\[",


### PR DESCRIPTION
This token was a part of original handwritten parser, but it was later replaced with LEFT_PARENTHESIS token.