### PR TITLE
Use stable Python 3.11 in tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         os: [Ubuntu, Windows, macOS]
         python_version:
-          ["3.7", "3.8", "3.9", "3.10", "3.11-dev", "pypy3.7", "pypy3.8", "pypy3.9"]
+          ["3.7", "3.8", "3.9", "3.10", "3.11", "pypy3.7", "pypy3.8", "pypy3.9"]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Since 3.11 has been out for a while now, the tests should probably use the latest stable instead of dev version.

Should the changes to [remove the `-dev` suffix for nox](https://github.com/pypa/packaging/pull/587/files) also be removed?
Or keep that, but also add Python 3.12-dev to the tests? Configured in such a way that those tests are allowed to fail.