### PR TITLE
Correctly handle trailing whitespace on URL requirements

### DIFF
--- a/src/packaging/_parser.py
+++ b/src/packaging/_parser.py
@@ -148,8 +148,7 @@ def _parse_requirement_marker(
             f"Expected end or semicolon (after {after})",
             span_start=span_start,
         )
-    else:
-        tokenizer.read()
+    tokenizer.read()
 
     marker = _parse_marker(tokenizer)
     tokenizer.consume("WS")

--- a/src/packaging/_parser.py
+++ b/src/packaging/_parser.py
@@ -89,7 +89,7 @@ def _parse_requirement_details(
     tokenizer: Tokenizer,
 ) -> Tuple[str, str, Optional[MarkerList]]:
     """
-    requirement_details = AT URL (WS requirement_marker)?
+    requirement_details = AT URL (WS requirement_marker?)?
                         | specifier WS? (requirement_marker)?
     """
 
@@ -107,6 +107,10 @@ def _parse_requirement_details(
             return (url, specifier, marker)
 
         tokenizer.expect("WS", expected="whitespace after URL")
+
+        # The input might end after whitespace.
+        if tokenizer.check("END", peek=True):
+            return (url, specifier, marker)
 
         marker = _parse_requirement_marker(
             tokenizer, span_start=url_start, after="URL and whitespace"

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -581,14 +581,14 @@ class TestRequirementBehaviour:
         self, extras: str, url_or_specifier: str, marker: str
     ) -> None:
         # GIVEN
-        to_parse = f"name{extras}{url_or_specifier}{marker}".strip()
+        to_parse = f"name{extras}{url_or_specifier}{marker}"
 
         # WHEN
         req = Requirement(to_parse)
 
         # THEN
-        assert str(req) == to_parse
-        assert repr(req) == f"<Requirement({to_parse!r})>"
+        assert str(req) == to_parse.strip()
+        assert repr(req) == f"<Requirement({to_parse.strip()!r})>"
 
     @pytest.mark.parametrize("dep1, dep2", EQUAL_DEPENDENCIES)
     def test_equal_reqs_equal_hashes(self, dep1: str, dep2: str) -> None:


### PR DESCRIPTION
> ```
> Traceback (most recent call last):
>   File "generate.py", line 38, in <module>
>     req = Requirement(raw_req)
>   File "/home/ichard26/programming/oss/black-deps-ci/venv/lib/python3.8/site-packages/packaging/requirements.py", line 37, in __init__
>     raise InvalidRequirement(str(e)) from e
> packaging.requirements.InvalidRequirement: Expected end or semicolon (after URL and whitespace)
>     aiohttp @ https://github.com/aio-libs/aiohttp/archive/master.zip 
>               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
> ```
> 
> heh I did not expect packaging to become stricter on terminating whitespace

Reported by @ichard26 over Discord (if you're on the PyPA discord: https://discord.com/channels/803025117553754132/803025117995073578/1052081745446567986)

