### PR TITLE
Fix typos

### DIFF
--- a/src/packaging/_elffile.py
+++ b/src/packaging/_elffile.py
@@ -53,7 +53,7 @@ class ELFFile:
             raise ELFInvalid(f"invalid magic: {magic!r}")
 
         self.capacity = ident[4]  # Format for program header (bitness).
-        self.encoding = ident[5]  # Data structure encoding (endianess).
+        self.encoding = ident[5]  # Data structure encoding (endianness).
 
         try:
             # e_fmt: Format for program header.

--- a/src/packaging/_parser.py
+++ b/src/packaging/_parser.py
@@ -43,7 +43,7 @@ MarkerVar = Union[Variable, Value]
 MarkerItem = Tuple[MarkerVar, Op, MarkerVar]
 # MarkerAtom = Union[MarkerItem, List["MarkerAtom"]]
 # MarkerList = List[Union["MarkerList", MarkerAtom, str]]
-# mypy does not suport recursive type definition
+# mypy does not support recursive type definition
 # https://github.com/python/mypy/issues/731
 MarkerAtom = Any
 MarkerList = List[Any]

--- a/src/packaging/specifiers.py
+++ b/src/packaging/specifiers.py
@@ -617,7 +617,7 @@ class Specifier(BaseSpecifier):
 
             if self.contains(parsed_version, **kw):
                 # If our version is a prerelease, and we were not set to allow
-                # prereleases, then we'll store it for later incase nothing
+                # prereleases, then we'll store it for later in case nothing
                 # else matches this specifier.
                 if parsed_version.is_prerelease and not (
                     prereleases or self.prereleases


### PR DESCRIPTION
Found via `codespell -S .nox,.mypy_cache`

Let me know if you want to add `codespell` to `pre-commit` hooks.