### PR TITLE
Improve error for local version label with unsupported operators

### DIFF
--- a/src/packaging/_parser.py
+++ b/src/packaging/_parser.py
@@ -233,6 +233,12 @@ def _parse_version_many(tokenizer: Tokenizer) -> str:
                 span_start=span_start,
                 span_end=tokenizer.position + 1,
             )
+        if tokenizer.check("VERSION_LOCAL_LABEL_TRAIL", peek=True):
+            tokenizer.raise_syntax_error(
+                "Local version label can only be used with `==` or `!=` operators",
+                span_start=span_start,
+                span_end=tokenizer.position,
+            )
         tokenizer.consume("WS")
         if not tokenizer.check("COMMA"):
             break

--- a/src/packaging/_tokenizer.py
+++ b/src/packaging/_tokenizer.py
@@ -79,6 +79,7 @@ DEFAULT_RULES: "Dict[str, Union[str, re.Pattern[str]]]" = {
     "URL": r"[^ \t]+",
     "IDENTIFIER": r"\b[a-zA-Z0-9][a-zA-Z0-9._-]*\b",
     "VERSION_PREFIX_TRAIL": r"\.\*",
+    "VERSION_LOCAL_LABEL_TRAIL": r"\+[a-z0-9]+(?:[-_\.][a-z0-9]+)*",
     "WS": r"[ \t]+",
     "END": r"$",
 }

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -301,6 +301,26 @@ class TestRequirementParsing:
             "           ~~~~~^"
         )
 
+    @pytest.mark.parametrize("operator", [">=", "<=", ">", "<", "~="])
+    def test_error_when_local_version_label_is_used_incorrectly(
+        self, operator: str
+    ) -> None:
+        # GIVEN
+        to_parse = f"name {operator} 1.0+local.version.label"
+        op_tilde = len(operator) * "~"
+
+        # WHEN
+        with pytest.raises(InvalidRequirement) as ctx:
+            Requirement(to_parse)
+
+        # THEN
+        assert ctx.exconly() == (
+            "packaging.requirements.InvalidRequirement: "
+            "Local version label can only be used with `==` or `!=` operators\n"
+            f"    name {operator} 1.0+local.version.label\n"
+            f"         {op_tilde}~~~~^"
+        )
+
     def test_error_when_bracket_not_closed_correctly(self) -> None:
         # GIVEN
         to_parse = "name[bar, baz >= 1.0"


### PR DESCRIPTION
This makes it clearer why the failure happens the way it happened.

Before:

```
packaging.requirements.InvalidRequirement: Expected end or semicolon (after version specifier)
    foo >= 1.0+local
        ~~~~~~^
```

After:

```
packaging.requirements.InvalidRequirement: Local version label can only be used with `==` or `!=` operators
    foo >= 1.0+local
        ~~~~~~^
```
