### PR TITLE
Support enriched metadata

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,9 @@ Changelog
 * Enforce that the entire marker string is parsed (:issue:`687`)
 * Requirement parsing no longer automatically validates the URL (:issue:`120`)
 * Canonicalize names for requirements comparison (:issue:`644`)
+* Introduce `metadata.Metadata` (along with `metadata.ExceptionGroup` and `metadata.InvalidMetadata`; :issue:`570`)
+* Introduce the `validate` keyword parameter to `utils.validate_name()` (:issue:`570`)
+* Introduce `utils.is_normalized_name()` (:issue:`570`)
 
 23.1 - 2023-04-12
 ~~~~~~~~~~~~~~~~~

--- a/docs/metadata.rst
+++ b/docs/metadata.rst
@@ -25,15 +25,39 @@ Usage
     'packaging'
     >>> raw["version"]
     '24.0'
+    >>> from packaging.metadata import Metadata
+    >>> parsed = Metadata.from_raw(raw)
+    >>> parsed.name
+    'packaging'
+    >>> parsed.version
+    <Version('24.0')>
 
 
 Reference
 ---------
 
+High Level Interface
+''''''''''''''''''''
+
+.. autoclass:: packaging.metadata.Metadata
+    :members:
+
 Low Level Interface
 '''''''''''''''''''
 
-.. automodule:: packaging.metadata
+.. autoclass:: packaging.metadata.RawMetadata
+    :members:
+
+.. autofunction:: packaging.metadata.parse_email
+
+
+Exceptions
+''''''''''
+
+.. autoclass:: packaging.metadata.InvalidMetadata
+    :members:
+
+.. autoclass:: packaging.metadata.ExceptionGroup
     :members:
 
 

--- a/docs/utils.rst
+++ b/docs/utils.rst
@@ -14,7 +14,7 @@ Reference
 
     A :class:`typing.NewType` of :class:`str`, representing a normalized name.
 
-.. function:: canonicalize_name(name)
+.. function:: canonicalize_name(name, validate=False)
 
     This function takes a valid Python package or extra name, and returns the
     normalized form of it.
@@ -23,7 +23,13 @@ Reference
     checkers to help require that a string has passed through this function
     before use.
 
+    If **validate** is true, then the function will check if **name** is a valid
+    distribution name before normalizing.
+
     :param str name: The name to normalize.
+    :param bool validate: Check whether the name is a valid distribution name.
+    :raises InvalidName: If **validate** is true and the name is not an
+        acceptable distribution name.
 
     .. doctest::
 
@@ -103,6 +109,9 @@ Reference
         >>> ver == Version('1.0')
         True
 
+.. exception:: InvalidName
+
+    Raised when a distribution name is invalid.
 
 .. exception:: InvalidWheelFilename
 

--- a/docs/utils.rst
+++ b/docs/utils.rst
@@ -41,6 +41,21 @@ Reference
         >>> canonicalize_name("requests")
         'requests'
 
+.. function:: is_normalized_name(name)
+
+    Check if a name is already normalized (i.e. :func:`canonicalize_name` would
+    roundtrip to the same value).
+
+    :param str name: The name to check.
+
+    .. doctest::
+
+        >>> from packaging.utils import is_normalized_name
+        >>> is_normalized_name("requests")
+        True
+        >>> is_normalized_name("Django")
+        False
+
 .. function:: canonicalize_version(version)
 
     This function takes a string representing a package version (or a

--- a/src/packaging/metadata.py
+++ b/src/packaging/metadata.py
@@ -546,7 +546,9 @@ class Metadata:
     classifiers = _Validator()
     # requires_dist = _Validator()  # XXX
     requires_python = _Validator(converters=[specifiers.SpecifierSet])
-    # requires_external = _Validator()  # XXX
+    # Because `Requires-External` allows for non-PEP 440 version specifiers, we
+    # don't do any processing on the values.
+    requires_external = _Validator()
     project_urls = _Validator()
     # provides_extra = _Validator()  # XXX
     provides_dist = _Validator()

--- a/src/packaging/metadata.py
+++ b/src/packaging/metadata.py
@@ -431,8 +431,10 @@ def parse_email(data: Union[bytes, str]) -> Tuple[RawMetadata, Dict[str, List[st
 
 _NOT_FOUND = object()
 
-# "2.0" is technically invalid, but people used it while waiting for "2.1".
-_MetadataVersion = Literal["1.0", "1.1", "1.2", "2.0", "2.1", "2.2", "2.3"]
+
+# Keep the two values in sync.
+_VALID_METADATA_VERSIONS = frozenset({"1.0", "1.1", "1.2", "2.1", "2.2", "2.3"})
+_MetadataVersion = Literal["1.0", "1.1", "1.2", "2.1", "2.2", "2.3"]
 
 
 class _Validator(Generic[T]):
@@ -504,7 +506,7 @@ class _Validator(Generic[T]):
         return value
 
     def _process_metadata_version(self, value: str) -> _MetadataVersion:
-        if value not in {"1.0", "1.1", "1.2", "2.0", "2.1", "2.2", "2.3"}:
+        if value not in _VALID_METADATA_VERSIONS:
             raise self._invalid_metadata(f"{value!r} is not a valid metadata version")
         return cast(_MetadataVersion, value)
 

--- a/src/packaging/metadata.py
+++ b/src/packaging/metadata.py
@@ -41,7 +41,7 @@ else:  # pragma: no cover
 
 
 try:
-    ExceptionGroup = __builtins__.ExceptionGroup
+    ExceptionGroup = __builtins__.ExceptionGroup  # type: ignore[attr-defined]
 except AttributeError:
 
     class ExceptionGroup(Exception):  # type: ignore[no-redef]  # noqa: N818
@@ -310,7 +310,7 @@ def parse_email(data: Union[bytes, str]) -> Tuple[RawMetadata, Dict[str, List[st
         # We use get_all() here, even for fields that aren't multiple use,
         # because otherwise someone could have e.g. two Name fields, and we
         # would just silently ignore it rather than doing something about it.
-        headers = parsed.get_all(name)
+        headers = parsed.get_all(name) or []
 
         # The way the email module works when parsing bytes is that it
         # unconditionally decodes the bytes as ascii using the surrogateescape

--- a/src/packaging/metadata.py
+++ b/src/packaging/metadata.py
@@ -585,8 +585,8 @@ class Metadata:
             try:
                 metadata_version = ins.metadata_version
                 metadata_age = _VALID_METADATA_VERSIONS.index(metadata_version)
-            except Exception as exc:
-                exceptions.append(exc)
+            except Exception as metadata_version_exc:
+                exceptions.append(metadata_version_exc)
                 metadata_version = None
 
             for key in frozenset(ins._raw) | _REQUIRED_ATTRS:

--- a/src/packaging/metadata.py
+++ b/src/packaging/metadata.py
@@ -468,6 +468,14 @@ def _valid_content_type(field: str, value: str) -> None:
         )
 
 
+def _valid_dynamic(field: str, value: str) -> None:
+    for dynamic_field in map(str.lower, value):
+        if dynamic_field in {"name", "version", "metadata-version"}:
+            raise InvalidMetadata(field, f"{value!r} is not allowed as a dynamic field")
+        elif dynamic_field not in _EMAIL_TO_RAW_MAPPING:
+            raise InvalidMetadata(field, f"{value!r} is not a valid dynamic field")
+
+
 _NOT_FOUND = object()
 
 
@@ -530,7 +538,10 @@ class Metadata:
         converters=[functools.partial(utils.canonicalize_name, validate=True)],
     )
     version = _Validator(validators=[_required], converters=[version_module.parse])
-    # dynamic = _Validator()  # XXX
+    dynamic = _Validator(
+        validators=[_valid_dynamic],
+        converters=[lambda fields: list(map(str.lower, fields))],
+    )
     platforms = _Validator()
     supported_platforms = _Validator()
     summary = _Validator(validators=[_single_line])

--- a/src/packaging/metadata.py
+++ b/src/packaging/metadata.py
@@ -58,6 +58,9 @@ except AttributeError:
             self.message = message
             self.exceptions = exceptions
 
+        def __repr__(self) -> str:
+            return f"{self.__class__.__name__}({self.message!r}, {self.exceptions!r})"
+
 
 class InvalidMetadata(ValueError):
     """A metadata field contains invalid data."""
@@ -634,7 +637,13 @@ class Metadata:
                 exceptions.append(metadata_version_exc)
                 metadata_version = None
 
-            for key in frozenset(ins._raw) | _REQUIRED_ATTRS:
+            # Make sure to check for the fields that are present, the required
+            # fields (so their absence can be reported).
+            fields_to_check = frozenset(ins._raw) | _REQUIRED_ATTRS
+            # Remove fields that have already been checked.
+            fields_to_check -= {"metadata_version"}
+
+            for key in fields_to_check:
                 try:
                     if metadata_version:
                         # Can't use getattr() as that triggers descriptor protocol which
@@ -757,3 +766,9 @@ class Metadata:
     """:external:ref:`core-metadata-provides-dist`"""
     obsoletes_dist: _Validator[List[str]] = _Validator(added="1.2")
     """:external:ref:`core-metadata-obsoletes-dist`"""
+    requires: _Validator[List[str]] = _Validator(added="1.1")
+    """``Requires`` (deprecated)"""
+    provides: _Validator[List[str]] = _Validator(added="1.1")
+    """``Provides`` (deprecated)"""
+    obsoletes: _Validator[List[str]] = _Validator(added="1.1")
+    """``Obsoletes`` (deprecated)"""

--- a/src/packaging/metadata.py
+++ b/src/packaging/metadata.py
@@ -597,7 +597,6 @@ class Metadata:
     supported_platforms: _Validator[List[str]] = _Validator(added="1.1")
     summary: _Validator[str] = _Validator()
     description: _Validator[str] = _Validator()  # TODO 2.1: can be in body
-    # TODO are the various parts of description_content_type case-insensitive?
     description_content_type: _Validator[str] = _Validator(added="2.1")
     keywords: _Validator[List[str]] = _Validator()
     home_page: _Validator[str] = _Validator()

--- a/src/packaging/metadata.py
+++ b/src/packaging/metadata.py
@@ -578,7 +578,7 @@ class Metadata:
     @classmethod
     def from_raw(cls, data: RawMetadata, *, validate: bool = True) -> "Metadata":
         ins = cls()
-        ins._raw = data.copy()  # Mutated as part of caching enriched values.
+        ins._raw = data.copy()  # Mutations occur due to caching enriched values.
 
         if validate:
             exceptions = []

--- a/src/packaging/metadata.py
+++ b/src/packaging/metadata.py
@@ -523,15 +523,18 @@ class _Validator(Generic[T]):
 class Metadata:
     _raw: RawMetadata
 
-    # XXX from_raw(cls, data: RawMetadata, *, validate=False) -> "Metadata":
+    @classmethod
+    def from_raw(cls, data: RawMetadata) -> "Metadata":
+        ins = cls()
+        ins._raw = data
+        return ins
 
     @classmethod
     def from_email(cls, data: Union[bytes, str]) -> "Metadata":
         """Parse metadata from an email message."""
         raw, unparsed = parse_email(data)
-        ins = cls()
-        ins._raw = raw
-        return ins
+        return cls.from_raw(raw)
+        # XXX Check `unparsed` for valid keys
 
     # XXX Check fields that are specified in an invalid version?
     metadata_version = _Validator(

--- a/src/packaging/metadata.py
+++ b/src/packaging/metadata.py
@@ -489,10 +489,12 @@ class _Validator(Generic[T]):
             self.raw_name, msg.format_map({"field": repr(self.raw_name)})
         )
 
-    def _process_name(self, value: str) -> utils.NormalizedName:
+    def _process_name(self, value: str) -> str:
         if not value:
             raise self._invalid_metadata("{field} is a required field")
-        return utils.canonicalize_name(value, validate=True)
+        # Validate the name as a side-effect.
+        utils.canonicalize_name(value, validate=True)
+        return value
 
     def _process_version(self, value: str) -> version_module.Version:
         if not value:
@@ -586,7 +588,7 @@ class Metadata:
     #      over-arching validate() method?
 
     metadata_version: _Validator[_MetadataVersion] = _Validator()
-    name: _Validator[utils.NormalizedName] = _Validator()
+    name: _Validator[str] = _Validator()
     version: _Validator[version_module.Version] = _Validator()
     dynamic: _Validator[List[str]] = _Validator(
         added="2.2",

--- a/src/packaging/metadata.py
+++ b/src/packaging/metadata.py
@@ -47,7 +47,7 @@ except AttributeError:
     class ExceptionGroup(Exception):  # type: ignore[no-redef]  # noqa: N818
         """Minimal implementation of ExceptionGroup from Python 3.11."""
 
-        def __init__(self, message: str, exceptions: List[Exception], /) -> None:
+        def __init__(self, message: str, exceptions: List[Exception]) -> None:
             self.message = message
             self.exceptions = exceptions
 

--- a/src/packaging/metadata.py
+++ b/src/packaging/metadata.py
@@ -3,7 +3,6 @@ import email.header
 import email.message
 import email.parser
 import email.policy
-import functools
 import sys
 import typing
 from typing import Any, Callable, Dict, Generic, List, Optional, Tuple, Union, cast

--- a/src/packaging/metadata.py
+++ b/src/packaging/metadata.py
@@ -462,7 +462,7 @@ class _Validator(Generic[T]):
         cache = instance.__dict__
         value = cache.get(self.name, _NOT_FOUND)
         if value is _NOT_FOUND:
-            raw_value = instance._raw.get(self.raw_name)
+            raw_value = instance._raw.get(self.name)
             for validator in self.validators:
                 validator(self.raw_name, raw_value)
             value = raw_value
@@ -470,7 +470,7 @@ class _Validator(Generic[T]):
                 value = converter(value)
             cache[self.name] = value
             try:
-                del instance._raw[self.raw_name]
+                del instance._raw[self.name]
             except KeyError:
                 pass
         return value
@@ -499,7 +499,7 @@ class Metadata:
     )
     version = _Validator(validators=[_required], converters=[version_module.parse])
     # dynamic = _Validator()  # XXX
-    # platforms = _Validator()
+    platforms = _Validator()
     # supported_platforms = _Validator()
     summary = _Validator(validators=[_single_line])
     # description = _Validator()

--- a/src/packaging/metadata.py
+++ b/src/packaging/metadata.py
@@ -508,7 +508,6 @@ class _Validator(Generic[T]):
 
 
 class Metadata:
-
     _raw: RawMetadata
 
     @classmethod
@@ -548,7 +547,7 @@ class Metadata:
     # requires_dist = _Validator()  # XXX
     # requires_python = _Validator()  # XXX
     # requires_external = _Validator()  # XXX
-    # project_urls = _Validator()
+    project_urls = _Validator()
     # provides_extra = _Validator()  # XXX
     provides_dist = _Validator()
     obsoletes_dist = _Validator()

--- a/src/packaging/metadata.py
+++ b/src/packaging/metadata.py
@@ -545,10 +545,10 @@ class Metadata:
     maintainer_email = _Validator()
     license = _Validator()
     classifiers = _Validator()
-    # requires_dists = _Validator()  # XXX
+    # requires_dist = _Validator()  # XXX
     # requires_python = _Validator()  # XXX
-    # requires_externals = _Validator()  # XXX
+    # requires_external = _Validator()  # XXX
     # project_urls = _Validator()
-    # provides_extras = _Validator()  # XXX
+    # provides_extra = _Validator()  # XXX
     provides_dist = _Validator()
     obsoletes_dist = _Validator()

--- a/src/packaging/metadata.py
+++ b/src/packaging/metadata.py
@@ -550,6 +550,14 @@ class Metadata:
     # don't do any processing on the values.
     requires_external = _Validator()
     project_urls = _Validator()
-    # provides_extra = _Validator()  # XXX
+    # PEP 685 lets us raise an error if an extra doesn't pass `Name` validation
+    # regardless of metadata version.
+    provides_extra = _Validator(
+        validators=[
+            lambda field, names: [
+                utils.canonicalize_name(name, validate=True) for name in names
+            ]
+        ]
+    )
     provides_dist = _Validator()
     obsoletes_dist = _Validator()

--- a/src/packaging/metadata.py
+++ b/src/packaging/metadata.py
@@ -8,7 +8,7 @@ import sys
 import typing
 from typing import Any, Callable, Dict, Generic, List, Optional, Tuple, Union, cast
 
-from . import specifiers, utils, version as version_module
+from . import requirements, specifiers, utils, version as version_module
 
 T = typing.TypeVar("T")
 
@@ -510,6 +510,8 @@ class _Validator(Generic[T]):
 class Metadata:
     _raw: RawMetadata
 
+    # XXX from_raw(cls, data: RawMetadata, *, validate=False) -> "Metadata":
+
     @classmethod
     def from_email(cls, data: Union[bytes, str], *, validate=False) -> "Metadata":
         """Parse metadata from an email message."""
@@ -544,7 +546,9 @@ class Metadata:
     maintainer_email = _Validator()
     license = _Validator()
     classifiers = _Validator()
-    # requires_dist = _Validator()  # XXX
+    requires_dist = _Validator(
+        converters=[lambda reqs: list(map(requirements.Requirement, reqs))]
+    )
     requires_python = _Validator(converters=[specifiers.SpecifierSet])
     # Because `Requires-External` allows for non-PEP 440 version specifiers, we
     # don't do any processing on the values.

--- a/src/packaging/metadata.py
+++ b/src/packaging/metadata.py
@@ -5,7 +5,18 @@ import email.parser
 import email.policy
 import sys
 import typing
-from typing import Any, Callable, Dict, Generic, List, Optional, Tuple, Union, cast
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Generic,
+    List,
+    Optional,
+    Tuple,
+    Type,
+    Union,
+    cast,
+)
 
 from . import requirements, specifiers, utils, version as version_module
 
@@ -27,6 +38,18 @@ else:  # pragma: no cover
             class TypedDict:
                 def __init_subclass__(*_args, **_kwargs):
                     pass
+
+
+try:
+    ExceptionGroup = __builtins__.ExceptionGroup
+except AttributeError:
+
+    class ExceptionGroup(Exception):  # type: ignore[no-redef]  # noqa: N818
+        """Minimal implementation of ExceptionGroup from Python 3.11."""
+
+        def __init__(self, message: str, exceptions: List[Exception], /) -> None:
+            self.message = message
+            self.exceptions = exceptions
 
 
 class InvalidMetadata(ValueError):
@@ -454,7 +477,7 @@ class _Validator(Generic[T]):
         self.name = name
         self.raw_name = _RAW_TO_EMAIL_MAPPING[name]
 
-    def __get__(self, instance: "Metadata", _owner: type["Metadata"]) -> T:
+    def __get__(self, instance: "Metadata", _owner: Type["Metadata"]) -> T:
         # TODO: validate the field is valid for the version of the metadata.
         # With Python 3.8, the caching can be replaced with functools.cached_property().
         cache = instance.__dict__

--- a/src/packaging/metadata.py
+++ b/src/packaging/metadata.py
@@ -712,7 +712,7 @@ class Metadata:
     platforms: _Validator[List[str]] = _Validator()
     """:external:ref:`core-metadata-platform`"""
     supported_platforms: _Validator[List[str]] = _Validator(added="1.1")
-    """:external:ref:`core-metadata-supported-platform"""
+    """:external:ref:`core-metadata-supported-platform`"""
     summary: _Validator[str] = _Validator()
     """:external:ref:`core-metadata-summary` (validated to contain no newlines)"""
     description: _Validator[str] = _Validator()  # TODO 2.1: can be in body

--- a/src/packaging/metadata.py
+++ b/src/packaging/metadata.py
@@ -491,17 +491,20 @@ _MetadataVersion = Literal["1.0", "1.1", "1.2", "2.0", "2.1", "2.2", "2.3"]
 class _Validator(Generic[T]):
     name: str
     raw_name: str
+    validators: List[Callable[[str, Any], None]]
+    converters: List[Callable[[Any], T]]
+    added: _MetadataVersion
 
     def __init__(
         self,
         *,
         validators: List[Callable[[str, Any], None]] = [],
-        converters: List[Callable[[Any], Any]] = [],
+        converters: List[Callable[[Any], T]] = [],
         added: _MetadataVersion = "1.0",
     ) -> None:
         self.validators = validators
         self.converters = converters
-        self.added = _MetadataVersion
+        self.added = added
 
     def __set_name__(self, _owner: "Metadata", name: str) -> None:
         self.name = name
@@ -592,7 +595,7 @@ class Metadata:
     # regardless of metadata version.
     provides_extra: _Validator[List[utils.NormalizedName]] = _Validator(
         validators=[
-            # XXX `type: ignore`
+            # XXX Remove the `type: ignore`
             lambda field, names: [  # type: ignore[list-item]
                 utils.canonicalize_name(name, validate=True) for name in names
             ]

--- a/src/packaging/metadata.py
+++ b/src/packaging/metadata.py
@@ -513,12 +513,12 @@ class _Validator(Generic[T]):
         message = email.message.EmailMessage()
         message["content-type"] = value
         content_type, parameters = (
-            message.get_content_type(),  # Defaults to `text/plain` if not parseable.
+            message.get_content_type().lower(),  # Defaults to `text/plain` if not parseable.
             message["content-type"].params,
         )
         # Check if content-type is valid or defaulted to `text/plain` and thus was
         # not parseable.
-        if content_type not in content_types or content_type not in value:
+        if content_type not in content_types or content_type not in value.lower():
             raise self._invalid_metadata(
                 f"{{field}} must be one of {list(content_types)}, not {value!r}"
             )

--- a/src/packaging/metadata.py
+++ b/src/packaging/metadata.py
@@ -500,7 +500,7 @@ class Metadata:
     version = _Validator(validators=[_required], converters=[version_module.parse])
     # dynamic = _Validator()  # XXX
     platforms = _Validator()
-    # supported_platforms = _Validator()
+    supported_platforms = _Validator()
     summary = _Validator(validators=[_single_line])
     # description = _Validator()
     # description_content_type = _Validator()  # XXX

--- a/src/packaging/metadata.py
+++ b/src/packaging/metadata.py
@@ -126,7 +126,7 @@ _STRING_FIELDS = {
     "version",
 }
 
-_LIST_STRING_FIELDS = {
+_LIST_FIELDS = {
     "classifiers",
     "dynamic",
     "obsoletes",
@@ -366,7 +366,7 @@ def parse_email(data: Union[bytes, str]) -> Tuple[RawMetadata, Dict[str, List[st
         # If this is one of our list of string fields, then we can just assign
         # the value, since email *only* has strings, and our get_all() call
         # above ensures that this is a list.
-        elif raw_name in _LIST_STRING_FIELDS:
+        elif raw_name in _LIST_FIELDS:
             raw[raw_name] = value
         # Special Case: Keywords
         # The keywords field is implemented in the metadata spec as a str,

--- a/src/packaging/metadata.py
+++ b/src/packaging/metadata.py
@@ -519,8 +519,10 @@ class _Validator(Generic[T]):
         content_types = {"text/plain", "text/x-rst", "text/markdown"}
         message = email.message.EmailMessage()
         message["content-type"] = value
+
         content_type, parameters = (
-            message.get_content_type().lower(),  # Defaults to `text/plain` if not parseable.
+            # Defaults to `text/plain` if parsing failed.
+            message.get_content_type().lower(),
             message["content-type"].params,
         )
         # Check if content-type is valid or defaulted to `text/plain` and thus was
@@ -574,7 +576,7 @@ class Metadata:
     _raw: RawMetadata
 
     @classmethod
-    def from_raw(cls, data: RawMetadata, *, validate=True) -> "Metadata":
+    def from_raw(cls, data: RawMetadata, *, validate: bool = True) -> "Metadata":
         ins = cls()
         ins._raw = data.copy()  # Mutated as part of caching enriched values.
 
@@ -592,9 +594,11 @@ class Metadata:
         return ins
 
     @classmethod
-    def from_email(cls, data: Union[bytes, str], *, validate=True) -> "Metadata":
+    def from_email(
+        cls, data: Union[bytes, str], *, validate: bool = True
+    ) -> "Metadata":
         """Parse metadata from an email message."""
-        exceptions = []
+        exceptions: list[Exception] = []
         raw, unparsed = parse_email(data)
 
         if validate:

--- a/src/packaging/metadata.py
+++ b/src/packaging/metadata.py
@@ -536,19 +536,19 @@ class Metadata:
     description = _Validator()
     # TODO are the various parts of description_content_type case-insensitive?
     description_content_type = _Validator(validators=[_valid_content_type])
-    # keywords = _Validator()
-    # home_page = _Validator()
-    # download_url = _Validator()
-    # author = _Validator()
-    # author_email = _Validator()
-    # maintainer = _Validator()
-    # maintainer_email = _Validator()
-    # license = _Validator()
-    # classifiers = _Validator()
+    keywords = _Validator()
+    home_page = _Validator()
+    download_url = _Validator()
+    author = _Validator()
+    author_email = _Validator()
+    maintainer = _Validator()
+    maintainer_email = _Validator()
+    license = _Validator()
+    classifiers = _Validator()
     # requires_dists = _Validator()  # XXX
     # requires_python = _Validator()  # XXX
     # requires_externals = _Validator()  # XXX
     # project_urls = _Validator()
     # provides_extras = _Validator()  # XXX
-    # provides_dists = _Validator()
-    # obsoletes_dists = _Validator()
+    provides_dist = _Validator()
+    obsoletes_dist = _Validator()

--- a/src/packaging/metadata.py
+++ b/src/packaging/metadata.py
@@ -8,7 +8,7 @@ import sys
 import typing
 from typing import Any, Callable, Dict, Generic, List, Optional, Tuple, Union, cast
 
-from . import utils, version as version_module
+from . import specifiers, utils, version as version_module
 
 T = typing.TypeVar("T")
 
@@ -545,7 +545,7 @@ class Metadata:
     license = _Validator()
     classifiers = _Validator()
     # requires_dist = _Validator()  # XXX
-    # requires_python = _Validator()  # XXX
+    requires_python = _Validator(converters=[specifiers.SpecifierSet])
     # requires_external = _Validator()  # XXX
     project_urls = _Validator()
     # provides_extra = _Validator()  # XXX

--- a/src/packaging/metadata.py
+++ b/src/packaging/metadata.py
@@ -696,7 +696,7 @@ class Metadata:
             raise ExceptionGroup("invalid or unparsed metadata", exceptions) from None
 
     metadata_version: _Validator[_MetadataVersion] = _Validator()
-    """``Core-Metadata``
+    """:external:ref:`core-metadata-metadata-version`
     (required; validated to be a valid metadata version)"""
     name: _Validator[str] = _Validator()
     """:external:ref:`core-metadata-name`
@@ -710,9 +710,9 @@ class Metadata:
     """:external:ref:`core-metadata-dynamic`
     (validated against core metadata field names and lowercased)"""
     platforms: _Validator[List[str]] = _Validator()
-    """``Platform``"""
+    """:external:ref:`core-metadata-platform`"""
     supported_platforms: _Validator[List[str]] = _Validator(added="1.1")
-    """``Supported-Platform``"""
+    """:external:ref:`core-metadata-supported-platform"""
     summary: _Validator[str] = _Validator()
     """:external:ref:`core-metadata-summary` (validated to contain no newlines)"""
     description: _Validator[str] = _Validator()  # TODO 2.1: can be in body
@@ -722,9 +722,9 @@ class Metadata:
     keywords: _Validator[List[str]] = _Validator()
     """:external:ref:`core-metadata-keywords`"""
     home_page: _Validator[str] = _Validator()
-    """``Home-Page``"""
+    """:external:ref:`core-metadata-home-page`"""
     download_url: _Validator[str] = _Validator(added="1.1")
-    """``Download-URL``"""
+    """:external:ref:`core-metadata-download-url`"""
     author: _Validator[str] = _Validator()
     """:external:ref:`core-metadata-author`"""
     author_email: _Validator[str] = _Validator()
@@ -744,7 +744,7 @@ class Metadata:
     # Because `Requires-External` allows for non-PEP 440 version specifiers, we
     # don't do any processing on the values.
     requires_external: _Validator[List[str]] = _Validator(added="1.2")
-    """``Requires-External``"""
+    """:external:ref:`core-metadata-requires-external`"""
     project_urls: _Validator[Dict[str, str]] = _Validator(added="1.2")
     """:external:ref:`core-metadata-project-url`"""
     # PEP 685 lets us raise an error if an extra doesn't pass `Name` validation
@@ -754,6 +754,6 @@ class Metadata:
     )
     """:external:ref:`core-metadata-provides-extra`"""
     provides_dist: _Validator[List[str]] = _Validator(added="1.2")
-    """``Provides-Dist``"""
+    """:external:ref:`core-metadata-provides-dist`"""
     obsoletes_dist: _Validator[List[str]] = _Validator(added="1.2")
-    """``Obsoletes-Dist``"""
+    """:external:ref:`core-metadata-obsoletes-dist`"""

--- a/src/packaging/metadata.py
+++ b/src/packaging/metadata.py
@@ -550,7 +550,7 @@ class Metadata:
         """Parse metadata from an email message."""
         raw, unparsed = parse_email(data)
         return cls.from_raw(raw)
-        # XXX Check `unparsed` for valid keys
+        # TODO Check `unparsed` for valid keys?
 
     # TODO Check that fields are specified in a valid metadata version?
 

--- a/src/packaging/utils.py
+++ b/src/packaging/utils.py
@@ -12,6 +12,12 @@ BuildTag = Union[Tuple[()], Tuple[int, str]]
 NormalizedName = NewType("NormalizedName", str)
 
 
+class InvalidName(ValueError):
+    """
+    An invalid distribution name; users should refer to the packaging user guide.
+    """
+
+
 class InvalidWheelFilename(ValueError):
     """
     An invalid wheel filename was found, users should refer to PEP 427.
@@ -24,12 +30,18 @@ class InvalidSdistFilename(ValueError):
     """
 
 
+# Core metadata spec for `Name`
+_validate_regex = re.compile(
+    r"^([A-Z0-9]|[A-Z0-9][A-Z0-9._-]*[A-Z0-9])$", re.IGNORECASE
+)
 _canonicalize_regex = re.compile(r"[-_.]+")
 # PEP 427: The build number must start with a digit.
 _build_tag_regex = re.compile(r"(\d+)(.*)")
 
 
-def canonicalize_name(name: str) -> NormalizedName:
+def canonicalize_name(name: str, validate: bool = False) -> NormalizedName:
+    if validate and not _validate_regex.match(name):
+        raise InvalidName(f"distribution name is invalid: {name!r}")
     # This is taken from PEP 503.
     value = _canonicalize_regex.sub("-", name).lower()
     return cast(NormalizedName, value)

--- a/src/packaging/utils.py
+++ b/src/packaging/utils.py
@@ -40,7 +40,7 @@ _normalized_regex = re.compile(r"^([a-z0-9]|[a-z0-9]([a-z0-9-](?!--))*[a-z0-9])$
 _build_tag_regex = re.compile(r"(\d+)(.*)")
 
 
-def canonicalize_name(name: str, validate: bool = False) -> NormalizedName:
+def canonicalize_name(name: str, *, validate: bool = False) -> NormalizedName:
     if validate and not _validate_regex.match(name):
         raise InvalidName(f"name is invalid: {name!r}")
     # This is taken from PEP 503.

--- a/src/packaging/utils.py
+++ b/src/packaging/utils.py
@@ -100,7 +100,7 @@ def parse_wheel_filename(
 
     parts = filename.split("-", dashes - 2)
     name_part = parts[0]
-    # See PEP 427 for the rules on escaping the project name
+    # See PEP 427 for the rules on escaping the project name.
     if "__" in name_part or re.match(r"^[\w\d._]*$", name_part, re.UNICODE) is None:
         raise InvalidWheelFilename(f"Invalid project name: {filename}")
     name = canonicalize_name(name_part)

--- a/src/packaging/utils.py
+++ b/src/packaging/utils.py
@@ -42,7 +42,7 @@ _build_tag_regex = re.compile(r"(\d+)(.*)")
 
 def canonicalize_name(name: str, validate: bool = False) -> NormalizedName:
     if validate and not _validate_regex.match(name):
-        raise InvalidName(f"distribution name is invalid: {name!r}")
+        raise InvalidName(f"name is invalid: {name!r}")
     # This is taken from PEP 503.
     value = _canonicalize_regex.sub("-", name).lower()
     return cast(NormalizedName, value)

--- a/src/packaging/utils.py
+++ b/src/packaging/utils.py
@@ -35,6 +35,7 @@ _validate_regex = re.compile(
     r"^([A-Z0-9]|[A-Z0-9][A-Z0-9._-]*[A-Z0-9])$", re.IGNORECASE
 )
 _canonicalize_regex = re.compile(r"[-_.]+")
+_normalized_regex = re.compile(r"^([a-z0-9]|[a-z0-9]([a-z0-9-](?!--))*[a-z0-9])$")
 # PEP 427: The build number must start with a digit.
 _build_tag_regex = re.compile(r"(\d+)(.*)")
 
@@ -45,6 +46,10 @@ def canonicalize_name(name: str, validate: bool = False) -> NormalizedName:
     # This is taken from PEP 503.
     value = _canonicalize_regex.sub("-", name).lower()
     return cast(NormalizedName, value)
+
+
+def is_normalized_name(name: str) -> bool:
+    return _normalized_regex.match(name) is not None
 
 
 def canonicalize_version(

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -378,3 +378,8 @@ class TestMetadata:
         expected = specifiers.SpecifierSet(specifier)
         meta = metadata.Metadata.from_email(f"Requires-Python: {specifier}")
         assert meta.requires_python == expected
+
+    def test_invalid_requires_python(self):
+        meta = metadata.Metadata.from_email("Requires-Python: NotReal")
+        with pytest.raises(specifiers.InvalidSpecifier):
+            meta.requires_python

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -288,15 +288,16 @@ class TestMetadata:
         assert getattr(meta, attribute) == values
 
     @pytest.mark.parametrize(
-        "version", ["1.0", "1.1", "1.2", "2.0", "2.1", "2.2", "2.3"]
+        "version", ["1.0", "1.1", "1.2", "2.1", "2.2", "2.3"]
     )
     def test_valid_metadata_version(self, version):
         meta = metadata.Metadata.from_raw({"metadata_version": version})
 
         assert meta.metadata_version == version
 
-    def test_invalid_metadata_version(self):
-        meta = metadata.Metadata.from_raw({"metadata_version": "1.3"})
+    @pytest.mark.parametrize("version", ["1.3", "2.0"])
+    def test_invalid_metadata_version(self, version):
+        meta = metadata.Metadata.from_raw({"metadata_version": version})
 
         with pytest.raises(metadata.InvalidMetadata):
             meta.metadata_version

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -361,3 +361,14 @@ class TestMetadata:
         keywords = ["hello", "world"]
         meta = metadata.Metadata.from_email(f"Keywords: {','.join(keywords)}")
         assert meta.keywords == keywords
+
+    def test_project_urls(self):
+        urls = {
+            "Documentation": "https://example.com/BeagleVote",
+            "Bug Tracker": "http://bitbucket.org/tarek/distribute/issues/",
+        }
+        meta = metadata.Metadata.from_email(
+            "\n".join(f"Project-URL: {k}, {v}" for k, v in urls.items())
+        )
+
+        assert meta.project_urls == urls

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -3,11 +3,12 @@ import pathlib
 import pytest
 
 from packaging import metadata, requirements, specifiers, utils, version
+from packaging.metadata import ExceptionGroup
 
 
 class TestRawMetadata:
     @pytest.mark.parametrize("raw_field", metadata._STRING_FIELDS)
-    def test_non_repeating_fields_only_once(self, raw_field: set[str]):
+    def test_non_repeating_fields_only_once(self, raw_field):
         data = "VaLuE"
         header_field = metadata._RAW_TO_EMAIL_MAPPING[raw_field]
         single_header = f"{header_field}: {data}"
@@ -18,7 +19,7 @@ class TestRawMetadata:
         assert raw[raw_field] == data
 
     @pytest.mark.parametrize("raw_field", metadata._STRING_FIELDS)
-    def test_non_repeating_fields_repeated(self, raw_field: set[str]):
+    def test_non_repeating_fields_repeated(self, raw_field):
         header_field = metadata._RAW_TO_EMAIL_MAPPING[raw_field]
         data = "VaLuE"
         single_header = f"{header_field}: {data}"
@@ -30,7 +31,7 @@ class TestRawMetadata:
         assert unparsed[header_field] == [data] * 2
 
     @pytest.mark.parametrize("raw_field", metadata._LIST_FIELDS)
-    def test_repeating_fields_only_once(self, raw_field: set[str]):
+    def test_repeating_fields_only_once(self, raw_field):
         data = "VaLuE"
         header_field = metadata._RAW_TO_EMAIL_MAPPING[raw_field]
         single_header = f"{header_field}: {data}"
@@ -41,7 +42,7 @@ class TestRawMetadata:
         assert raw[raw_field] == [data]
 
     @pytest.mark.parametrize("raw_field", metadata._LIST_FIELDS)
-    def test_repeating_fields_repeated(self, raw_field: set[str]):
+    def test_repeating_fields_repeated(self, raw_field):
         header_field = metadata._RAW_TO_EMAIL_MAPPING[raw_field]
         data = "VaLuE"
         single_header = f"{header_field}: {data}"

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -390,6 +390,9 @@ class TestMetadata:
             "classifiers",
             "provides_dist",
             "obsoletes_dist",
+            "requires",
+            "provides",
+            "obsoletes",
         ],
     )
     def test_multi_value_unvalidated_attribute(self, attribute):

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -252,6 +252,13 @@ class TestMetadata:
 
         assert meta.metadata_version == metadata_version
 
+    def test_from_email_unparsed(self):
+        with pytest.raises(ExceptionGroup) as exc_info:
+            meta = metadata.Metadata.from_email("Hello: PyPA")
+
+            assert len(exc_info.exceptions) == 1
+            assert isinstance(exc_info.exceptions[0], metadata.InvalidMetadata)
+
     @pytest.mark.parametrize(
         "attribute",
         [
@@ -287,9 +294,7 @@ class TestMetadata:
 
         assert getattr(meta, attribute) == values
 
-    @pytest.mark.parametrize(
-        "version", ["1.0", "1.1", "1.2", "2.1", "2.2", "2.3"]
-    )
+    @pytest.mark.parametrize("version", ["1.0", "1.1", "1.2", "2.1", "2.2", "2.3"])
     def test_valid_metadata_version(self, version):
         meta = metadata.Metadata.from_raw({"metadata_version": version})
 

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -246,6 +246,12 @@ class TestRawMetadata:
 
 
 class TestMetadata:
+    def test_from_email(self):
+        metadata_version = "2.3"
+        meta = metadata.Metadata.from_email(f"Metadata-Version: {metadata_version}")
+
+        assert meta.metadata_version == metadata_version
+
     @pytest.mark.parametrize(
         "attribute",
         [
@@ -261,9 +267,8 @@ class TestMetadata:
     )
     def test_single_value_unvalidated_attribute(self, attribute):
         value = "Not important"
-        meta = metadata.Metadata.from_email(
-            f"{metadata._RAW_TO_EMAIL_MAPPING[attribute]}: {value}"
-        )
+        meta = metadata.Metadata.from_raw({attribute: value})
+
         assert getattr(meta, attribute) == value
 
     @pytest.mark.parametrize(
@@ -278,62 +283,62 @@ class TestMetadata:
     )
     def test_multi_value_unvalidated_attribute(self, attribute):
         values = ["Not important", "Still not important"]
-        parts = [
-            f"{metadata._RAW_TO_EMAIL_MAPPING[attribute]}: {value}" for value in values
-        ]
-        meta = metadata.Metadata.from_email("\n".join(parts))
+        meta = metadata.Metadata.from_raw({attribute: values})
+
         assert getattr(meta, attribute) == values
 
     @pytest.mark.parametrize(
         "version", ["1.0", "1.1", "1.2", "2.0", "2.1", "2.2", "2.3"]
     )
     def test_valid_metadata_version(self, version):
-        meta = metadata.Metadata.from_email(f"Metadata-Version: {version}")
+        meta = metadata.Metadata.from_raw({"metadata_version": version})
 
         assert meta.metadata_version == version
 
     def test_invalid_metadata_version(self):
-        meta = metadata.Metadata.from_email("Metadata-Version: 1.3")
+        meta = metadata.Metadata.from_raw({"metadata_version": "1.3"})
 
         with pytest.raises(metadata.InvalidMetadata):
             meta.metadata_version
 
     def test_valid_version(self):
         version_str = "1.2.3"
-        meta = metadata.Metadata.from_email(f"Version: {version_str}")
+        meta = metadata.Metadata.from_raw({"version": version_str})
         assert meta.version == version.parse(version_str)
 
     def test_missing_version(self):
-        meta = metadata.Metadata.from_email("")
+        meta = metadata.Metadata.from_raw({})
         with pytest.raises(metadata.InvalidMetadata) as exc_info:
             meta.version
         assert exc_info.value.field == "version"
 
     def test_invalid_version(self):
-        meta = metadata.Metadata.from_email("Version: a.b.c")
+        meta = metadata.Metadata.from_raw({"version": "a.b.c"})
+
         with pytest.raises(version.InvalidVersion):
             meta.version
 
     def test_valid_summary(self):
         summary = "Hello"
-        meta = metadata.Metadata.from_email(f"Summary: {summary}")
+        meta = metadata.Metadata.from_raw({"summary": summary})
+
         assert meta.summary == summary
 
     def test_invalid_summary(self):
-        summary = "Hello"
-        meta = metadata.Metadata.from_email(f"Summary: {summary}\n    Again")
+        meta = metadata.Metadata.from_raw({"summary": "Hello\n    Again"})
+
         with pytest.raises(metadata.InvalidMetadata) as exc_info:
             meta.summary
         assert exc_info.value.field == "summary"
 
     def test_valid_name(self):
         name = "Hello_World"
-        meta = metadata.Metadata.from_email(f"Name: {name}")
+        meta = metadata.Metadata.from_raw({"name": name})
         assert meta.name == utils.canonicalize_name(name)
 
     def test_invalid_name(self):
-        name = "-not-legal"
-        meta = metadata.Metadata.from_email(f"Name: {name}")
+        meta = metadata.Metadata.from_raw({"name": "-not-legal"})
+
         with pytest.raises(utils.InvalidName):
             meta.name
 
@@ -352,7 +357,8 @@ class TestMetadata:
         ],
     )
     def test_valid_description_content_type(self, content_type):
-        meta = metadata.Metadata.from_email(f"description-content-type: {content_type}")
+        meta = metadata.Metadata.from_raw({"description_content_type": content_type})
+
         assert meta.description_content_type == content_type
 
     @pytest.mark.parametrize(
@@ -367,13 +373,15 @@ class TestMetadata:
         ],
     )
     def test_invalid_description_content_type(self, content_type):
-        meta = metadata.Metadata.from_email(f"description-content-type: {content_type}")
+        meta = metadata.Metadata.from_raw({"description_content_type": content_type})
+
         with pytest.raises(metadata.InvalidMetadata):
             meta.description_content_type
 
     def test_keywords(self):
         keywords = ["hello", "world"]
-        meta = metadata.Metadata.from_email(f"Keywords: {','.join(keywords)}")
+        meta = metadata.Metadata.from_raw({"keywords": keywords})
+
         assert meta.keywords == keywords
 
     def test_project_urls(self):
@@ -381,21 +389,19 @@ class TestMetadata:
             "Documentation": "https://example.com/BeagleVote",
             "Bug Tracker": "http://bitbucket.org/tarek/distribute/issues/",
         }
-        meta = metadata.Metadata.from_email(
-            "\n".join(f"Project-URL: {k}, {v}" for k, v in urls.items())
-        )
+        meta = metadata.Metadata.from_raw({"project_urls": urls})
 
         assert meta.project_urls == urls
 
     @pytest.mark.parametrize("specifier", [">=3", ">2.6,!=3.0.*,!=3.1.*", "~=2.6"])
     def test_valid_requires_python(self, specifier):
         expected = specifiers.SpecifierSet(specifier)
-        meta = metadata.Metadata.from_email(f"Requires-Python: {specifier}")
+        meta = metadata.Metadata.from_raw({"requires_python": specifier})
 
         assert meta.requires_python == expected
 
     def test_invalid_requires_python(self):
-        meta = metadata.Metadata.from_email("Requires-Python: NotReal")
+        meta = metadata.Metadata.from_raw({"requires_python": "NotReal"})
         with pytest.raises(specifiers.InvalidSpecifier):
             meta.requires_python
 
@@ -406,25 +412,19 @@ class TestMetadata:
             'make; sys_platform != "win32"',
             "libjpeg (>6b)",
         ]
-        meta = metadata.Metadata.from_email(
-            "\n".join(f"Requires-External: {e}" for e in externals)
-        )
+        meta = metadata.Metadata.from_raw({"requires_external": externals})
 
         assert meta.requires_external == externals
 
     def test_valid_provides_extra(self):
         extras = ["dev", "test"]
-        meta = metadata.Metadata.from_email(
-            "\n".join(f"Provides-Extra: {e}" for e in extras)
-        )
+        meta = metadata.Metadata.from_raw({"provides_extra": extras})
 
         assert meta.provides_extra == extras
 
     def test_invalid_provides_extra(self):
         extras = ["pdf", "-Not-Valid", "ok"]
-        meta = metadata.Metadata.from_email(
-            "\n".join(f"Provides-Extra: {e}" for e in extras)
-        )
+        meta = metadata.Metadata.from_raw({"provides_extra": extras})
 
         with pytest.raises(utils.InvalidName):
             meta.provides_extra
@@ -437,37 +437,33 @@ class TestMetadata:
             "pywin32 >1.0; sys_platform == 'win32'",
         ]
         expected_requires = list(map(requirements.Requirement, requires))
-        meta = metadata.Metadata.from_email(
-            "\n".join(f"Requires-Dist: {r}" for r in requires)
-        )
+        meta = metadata.Metadata.from_raw({"requires_dist": requires})
 
         assert meta.requires_dist == expected_requires
 
     def test_invalid_requires_dist(self):
         requires = ["pkginfo", "-not-real", "zope.interface (>3.5.0)"]
-        meta = metadata.Metadata.from_email(
-            "\n".join(f"Requires-Dist: {r}" for r in requires)
-        )
+        meta = metadata.Metadata.from_raw({"requires_dist": requires})
 
         with pytest.raises(requirements.InvalidRequirement):
             meta.requires_dist
 
     def test_valid_dynamic(self):
         dynamic = ["Keywords", "Home-Page", "Author"]
-        meta = metadata.Metadata.from_email("\n".join(f"Dynamic: {d}" for d in dynamic))
+        meta = metadata.Metadata.from_raw({"dynamic": dynamic})
 
         assert meta.dynamic == [d.lower() for d in dynamic]
 
     def test_invalid_dynamic(self):
         dynamic = ["Keywords", "NotReal", "Author"]
-        meta = metadata.Metadata.from_email("\n".join(f"Dynamic: {d}" for d in dynamic))
+        meta = metadata.Metadata.from_raw({"dynamic": dynamic})
 
         with pytest.raises(metadata.InvalidMetadata):
             meta.dynamic
 
     @pytest.mark.parametrize("field_name", ["name", "version", "metadata-version"])
     def test_disallowed_dynamic(self, field_name):
-        meta = metadata.Metadata.from_email(f"Dynamic: {field_name}")
+        meta = metadata.Metadata.from_raw({"dynamic": field_name})
 
         with pytest.raises(metadata.InvalidMetadata):
             meta.dynamic

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -2,7 +2,7 @@ import pathlib
 
 import pytest
 
-from packaging import metadata, utils, version
+from packaging import metadata, specifiers, utils, version
 
 
 class TestRawMetadata:
@@ -372,3 +372,9 @@ class TestMetadata:
         )
 
         assert meta.project_urls == urls
+
+    @pytest.mark.parametrize("specifier", [">=3", ">2.6,!=3.0.*,!=3.1.*", "~=2.6"])
+    def test_valid_requires_python(self, specifier):
+        expected = specifiers.SpecifierSet(specifier)
+        meta = metadata.Metadata.from_email(f"Requires-Python: {specifier}")
+        assert meta.requires_python == expected

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -246,6 +246,19 @@ class TestRawMetadata:
         assert raw["description"] == "This description intentionally left blank.\n"
 
 
+class TestExceptionGroup:
+    def test_attributes(self):
+        individual_exception = Exception("not important")
+        exc = metadata.ExceptionGroup("message", [individual_exception])
+        assert exc.message == "message"
+        assert exc.exceptions == [individual_exception]
+
+    def test_repr(self):
+        individual_exception = RuntimeError("not important")
+        exc = metadata.ExceptionGroup("message", [individual_exception])
+        assert individual_exception.__class__.__name__ in repr(exc)
+
+
 _RAW_EXAMPLE = {
     "metadata_version": "2.3",
     "name": "packaging",

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -437,3 +437,23 @@ class TestMetadata:
 
         with pytest.raises(requirements.InvalidRequirement):
             meta.requires_dist
+
+    def test_valid_dynamic(self):
+        dynamic = ["Keywords", "Home-Page", "Author"]
+        meta = metadata.Metadata.from_email("\n".join(f"Dynamic: {d}" for d in dynamic))
+
+        assert meta.dynamic == [d.lower() for d in dynamic]
+
+    def test_invalid_dynamic(self):
+        dynamic = ["Keywords", "NotReal", "Author"]
+        meta = metadata.Metadata.from_email("\n".join(f"Dynamic: {d}" for d in dynamic))
+
+        with pytest.raises(metadata.InvalidMetadata):
+            meta.dynamic
+
+    @pytest.mark.parametrize("field_name", ["name", "version", "metadata-version"])
+    def test_disallowed_dynamic(self, field_name):
+        meta = metadata.Metadata.from_email(f"Dynamic: {field_name}")
+
+        with pytest.raises(metadata.InvalidMetadata):
+            meta.dynamic

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -267,7 +267,7 @@ _RAW_EXAMPLE = {
 
 
 class TestMetadata:
-    def _invalid_with_cause(self, meta, /, attr, cause=None, *, field=None):
+    def _invalid_with_cause(self, meta, attr, cause=None, *, field=None):
         if field is None:
             field = attr
         with pytest.raises(metadata.InvalidMetadata) as exc_info:

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -300,3 +300,42 @@ class TestMetadata:
             f"Platform: {platform1}\nPlatform: {platform2}"
         )
         assert meta.platforms == [platform1, platform2]
+
+    def test_description(self):
+        description = "This description intentionally left blank."
+        meta = metadata.Metadata.from_email(f"Description: {description}")
+        assert meta.description == description
+
+    @pytest.mark.parametrize(
+        "content_type",
+        [
+            "text/plain",
+            "text/x-rst",
+            "text/markdown",
+            "text/plain; charset=UTF-8",
+            "text/x-rst; charset=UTF-8",
+            "text/markdown; charset=UTF-8; variant=GFM",
+            "text/markdown; charset=UTF-8; variant=CommonMark",
+            "text/markdown; variant=GFM",
+            "text/markdown; variant=CommonMark",
+        ],
+    )
+    def test_valid_description_content_type(self, content_type):
+        meta = metadata.Metadata.from_email(f"description-content-type: {content_type}")
+        assert meta.description_content_type == content_type
+
+    @pytest.mark.parametrize(
+        "content_type",
+        [
+            "application/json",
+            "TEXT/PLAIN",
+            "text/plain; charset=ascii",
+            "text/plain; charset=utf-8",
+            "text/markdown; variant=gfm",
+            "text/markdown; variant=commonmark",
+        ],
+    )
+    def test_invalid_description_content_type(self, content_type):
+        meta = metadata.Metadata.from_email(f"description-content-type: {content_type}")
+        with pytest.raises(metadata.InvalidMetadata):
+            meta.description_content_type

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -284,6 +284,20 @@ class TestMetadata:
         meta = metadata.Metadata.from_email("\n".join(parts))
         assert getattr(meta, attribute) == values
 
+    @pytest.mark.parametrize(
+        "version", ["1.0", "1.1", "1.2", "2.0", "2.1", "2.2", "2.3"]
+    )
+    def test_valid_metadata_version(self, version):
+        meta = metadata.Metadata.from_email(f"Metadata-Version: {version}")
+
+        assert meta.metadata_version == version
+
+    def test_invalid_metadata_version(self):
+        meta = metadata.Metadata.from_email("Metadata-Version: 1.3")
+
+        with pytest.raises(metadata.InvalidMetadata):
+            meta.metadata_version
+
     def test_valid_version(self):
         version_str = "1.2.3"
         meta = metadata.Metadata.from_email(f"Version: {version_str}")

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -284,3 +284,11 @@ class TestMetadata:
         meta = metadata.Metadata.from_email(f"Name: {name}")
         with pytest.raises(utils.InvalidName):
             meta.name
+
+    def test_platforms(self):
+        platform1 = "ObscureUnix"
+        platform2 = "RareDOS"
+        meta = metadata.Metadata.from_email(
+            f"Platform: {platform1}\nPlatform: {platform2}"
+        )
+        assert meta.platforms == [platform1, platform2]

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -285,6 +285,14 @@ class TestMetadata:
         with pytest.raises(utils.InvalidName):
             meta.name
 
+    def test_supported_platforms(self):
+        platform1 = "RedHat 7.2"
+        platform2 = "i386-win32-2791"
+        meta = metadata.Metadata.from_email(
+            f"Supported-Platform: {platform1}\nSupported-Platform: {platform2}"
+        )
+        assert meta.supported_platforms == [platform1, platform2]
+
     def test_platforms(self):
         platform1 = "ObscureUnix"
         platform2 = "RareDOS"

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -2,7 +2,7 @@ import pathlib
 
 import pytest
 
-from packaging import metadata, specifiers, utils, version
+from packaging import metadata, requirements, specifiers, utils, version
 
 
 class TestRawMetadata:
@@ -414,3 +414,26 @@ class TestMetadata:
 
         with pytest.raises(utils.InvalidName):
             meta.provides_extra
+
+    def test_valid_requires_dist(self):
+        requires = [
+            "pkginfo",
+            "PasteDeploy",
+            "zope.interface (>3.5.0)",
+            "pywin32 >1.0; sys_platform == 'win32'",
+        ]
+        expected_requires = list(map(requirements.Requirement, requires))
+        meta = metadata.Metadata.from_email(
+            "\n".join(f"Requires-Dist: {r}" for r in requires)
+        )
+
+        assert meta.requires_dist == expected_requires
+
+    def test_invalid_requires_dist(self):
+        requires = ["pkginfo", "-not-real", "zope.interface (>3.5.0)"]
+        meta = metadata.Metadata.from_email(
+            "\n".join(f"Requires-Dist: {r}" for r in requires)
+        )
+
+        with pytest.raises(requirements.InvalidRequirement):
+            meta.requires_dist

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -29,7 +29,7 @@ class TestRawMetadata:
         assert header_field in unparsed
         assert unparsed[header_field] == [data] * 2
 
-    @pytest.mark.parametrize("raw_field", metadata._LIST_STRING_FIELDS)
+    @pytest.mark.parametrize("raw_field", metadata._LIST_FIELDS)
     def test_repeating_fields_only_once(self, raw_field: set[str]):
         data = "VaLuE"
         header_field = metadata._RAW_TO_EMAIL_MAPPING[raw_field]
@@ -40,7 +40,7 @@ class TestRawMetadata:
         assert raw_field in raw
         assert raw[raw_field] == [data]
 
-    @pytest.mark.parametrize("raw_field", metadata._LIST_STRING_FIELDS)
+    @pytest.mark.parametrize("raw_field", metadata._LIST_FIELDS)
     def test_repeating_fields_repeated(self, raw_field: set[str]):
         header_field = metadata._RAW_TO_EMAIL_MAPPING[raw_field]
         data = "VaLuE"

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -397,3 +397,20 @@ class TestMetadata:
         )
 
         assert meta.requires_external == externals
+
+    def test_valid_provides_extra(self):
+        extras = ["dev", "test"]
+        meta = metadata.Metadata.from_email(
+            "\n".join(f"Provides-Extra: {e}" for e in extras)
+        )
+
+        assert meta.provides_extra == extras
+
+    def test_invalid_provides_extra(self):
+        extras = ["pdf", "-Not-Valid", "ok"]
+        meta = metadata.Metadata.from_email(
+            "\n".join(f"Provides-Extra: {e}" for e in extras)
+        )
+
+        with pytest.raises(utils.InvalidName):
+            meta.provides_extra

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -346,6 +346,7 @@ class TestMetadata:
         "content_type",
         [
             "text/plain",
+            "TEXT/PLAIN",
             "text/x-rst",
             "text/markdown",
             "text/plain; charset=UTF-8",
@@ -365,7 +366,6 @@ class TestMetadata:
         "content_type",
         [
             "application/json",
-            "TEXT/PLAIN",
             "text/plain; charset=ascii",
             "text/plain; charset=utf-8",
             "text/markdown; variant=gfm",

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -377,9 +377,23 @@ class TestMetadata:
     def test_valid_requires_python(self, specifier):
         expected = specifiers.SpecifierSet(specifier)
         meta = metadata.Metadata.from_email(f"Requires-Python: {specifier}")
+
         assert meta.requires_python == expected
 
     def test_invalid_requires_python(self):
         meta = metadata.Metadata.from_email("Requires-Python: NotReal")
         with pytest.raises(specifiers.InvalidSpecifier):
             meta.requires_python
+
+    def test_requires_external(self):
+        externals = [
+            "C",
+            "libpng (>=1.5)",
+            'make; sys_platform != "win32"',
+            "libjpeg (>6b)",
+        ]
+        meta = metadata.Metadata.from_email(
+            "\n".join(f"Requires-External: {e}" for e in externals)
+        )
+
+        assert meta.requires_external == externals

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -2,7 +2,7 @@ import pathlib
 
 import pytest
 
-from packaging import metadata, version
+from packaging import metadata, utils, version
 
 
 class TestRawMetadata:
@@ -273,3 +273,14 @@ class TestMetadata:
         with pytest.raises(metadata.InvalidMetadata) as exc_info:
             meta.summary
         assert exc_info.value.field == "summary"
+
+    def test_valid_name(self):
+        name = "Hello_World"
+        meta = metadata.Metadata.from_email(f"Name: {name}")
+        assert meta.name == utils.canonicalize_name(name)
+
+    def test_invalid_name(self):
+        name = "-not-legal"
+        meta = metadata.Metadata.from_email(f"Name: {name}")
+        with pytest.raises(utils.InvalidName):
+            meta.name

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -335,7 +335,7 @@ class TestMetadata:
     def test_valid_name(self):
         name = "Hello_World"
         meta = metadata.Metadata.from_raw({"name": name})
-        assert meta.name == utils.canonicalize_name(name)
+        assert meta.name == name
 
     def test_invalid_name(self):
         meta = metadata.Metadata.from_raw({"name": "-not-legal"})

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,6 +6,7 @@ import pytest
 
 from packaging.tags import Tag
 from packaging.utils import (
+    InvalidName,
     InvalidSdistFilename,
     InvalidWheelFilename,
     canonicalize_name,
@@ -33,6 +34,12 @@ from packaging.version import Version
 )
 def test_canonicalize_name(name, expected):
     assert canonicalize_name(name) == expected
+
+
+def test_canonicalize_name_invalid():
+    with pytest.raises(InvalidName):
+        canonicalize_name("_not_legal", validate=True)
+    assert canonicalize_name("_not_legal") == "-not-legal"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,6 +11,7 @@ from packaging.utils import (
     InvalidWheelFilename,
     canonicalize_name,
     canonicalize_version,
+    is_normalized_name,
     parse_sdist_filename,
     parse_wheel_filename,
 )
@@ -40,6 +41,27 @@ def test_canonicalize_name_invalid():
     with pytest.raises(InvalidName):
         canonicalize_name("_not_legal", validate=True)
     assert canonicalize_name("_not_legal") == "-not-legal"
+
+
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        ("foo", "foo"),
+        ("Foo", "foo"),
+        ("fOo", "foo"),
+        ("foo.bar", "foo-bar"),
+        ("Foo.Bar", "foo-bar"),
+        ("Foo.....Bar", "foo-bar"),
+        ("foo_bar", "foo-bar"),
+        ("foo___bar", "foo-bar"),
+        ("foo-bar", "foo-bar"),
+        ("foo----bar", "foo-bar"),
+    ],
+)
+def test_is_normalized_name(name, expected):
+    assert is_normalized_name(expected)
+    if name != expected:
+        assert not is_normalized_name(name)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Take raw metadata and wrap data as appropriate with more enriched representations (e.g., `requirements.Requirement` for `Requires-Dist`).

Part of #570