### PR TITLE
parse_marker should consume the entire source string

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog
 *unreleased*
 ~~~~~~~~~~~~
 
-No unreleased changes.
+* Enforce that the entire marker string is parsed (:issue:`687`)
 
 23.1 - 2023-04-12
 ~~~~~~~~~~~~~~~~~

--- a/src/packaging/_parser.py
+++ b/src/packaging/_parser.py
@@ -252,7 +252,13 @@ def _parse_version_many(tokenizer: Tokenizer) -> str:
 # Recursive descent parser for marker expression
 # --------------------------------------------------------------------------------------
 def parse_marker(source: str) -> MarkerList:
-    return _parse_marker(Tokenizer(source, rules=DEFAULT_RULES))
+    return _parse_full_marker(Tokenizer(source, rules=DEFAULT_RULES))
+
+
+def _parse_full_marker(tokenizer: Tokenizer) -> MarkerList:
+    retval = _parse_marker(tokenizer)
+    tokenizer.expect("END", expected="end of marker expression")
+    return retval
 
 
 def _parse_marker(tokenizer: Tokenizer) -> MarkerList:

--- a/tests/test_markers.py
+++ b/tests/test_markers.py
@@ -167,6 +167,7 @@ class TestMarker:
             "(python_version)",
             "python_version >= 1.0 and (python_version)",
             '(python_version == "2.7" and os_name == "linux"',
+            '(python_version == "2.7") with random text',
         ],
     )
     def test_parses_invalid(self, marker_string):


### PR DESCRIPTION
Typos in the marker string are silently ignored if we don't require parsing the entire string.
```py
Marker('python_version > "3.6" or (python_version == "3.6" and os_name == "unix") for extra == "5"')
```
Without fix: `<Marker('python_version > "3.6" or (python_version == "3.6" and os_name == "unix")')>`
With fix:
```
packaging.markers.InvalidMarker: Expected end of marker
    python_version > "3.6" or (python_version == "3.6" and os_name == "unix") for extra == "5"
                                                                              ^
```