### PR TITLE
Ability to install `armv7l manylinux/musllinux` wheels on `armv8l`

### DIFF
--- a/src/packaging/_manylinux.py
+++ b/src/packaging/_manylinux.py
@@ -5,7 +5,7 @@ import os
 import re
 import sys
 import warnings
-from typing import Dict, Generator, Iterator, NamedTuple, Optional, Tuple
+from typing import Dict, Generator, Iterator, NamedTuple, Optional, Sequence, Tuple
 
 from ._elffile import EIClass, EIData, ELFFile, EMachine
 
@@ -50,12 +50,13 @@ def _is_linux_i686(executable: str) -> bool:
         )
 
 
-def _have_compatible_abi(executable: str, arch: str) -> bool:
-    if arch == "armv7l":
+def _have_compatible_abi(executable: str, archs: Sequence[str]) -> bool:
+    if "armv7l" in archs:
         return _is_linux_armhf(executable)
-    if arch == "i686":
+    if "i686" in archs:
         return _is_linux_i686(executable)
-    return arch in {"x86_64", "aarch64", "ppc64", "ppc64le", "s390x", "loongarch64"}
+    other_archs = {"x86_64", "aarch64", "ppc64", "ppc64le", "s390x", "loongarch64"}
+    return len(set(archs) & other_archs) > 0
 
 
 # If glibc ever changes its major version, we need to know what the last
@@ -203,17 +204,22 @@ _LEGACY_MANYLINUX_MAP = {
 }
 
 
-def platform_tags(linux: str, arch: str) -> Iterator[str]:
-    if arch == "armv8l":
-        # armv8l wheels are not accepted on PyPI
-        # As long as we pass the the ABI check below,
-        # the armv7l wheels can be installed.
-        arch = "armv7l"
-    if not _have_compatible_abi(sys.executable, arch):
+def platform_tags(archs: Sequence[str]) -> Iterator[str]:
+    """Generate manylinux tags compatible to the current platform.
+
+    :param archs: Sequence of compatible architectures.
+        The first one shall be the closest to the actual architecture and be the part of
+        platform tag after the ``linux_`` prefix, e.g. ``x86_64``.
+        The ``linux_`` prefix is assumed as a prerequisite for the current platform to
+        be manylinux-compatible.
+
+    :returns: An iterator of compatible manylinux tags.
+    """
+    if not _have_compatible_abi(sys.executable, archs):
         return
     # Oldest glibc to be supported regardless of architecture is (2, 17).
     too_old_glibc2 = _GLibCVersion(2, 16)
-    if arch in {"x86_64", "i686"}:
+    if set(archs) & {"x86_64", "i686"}:
         # On x86/i686 also oldest glibc to be supported is (2, 5).
         too_old_glibc2 = _GLibCVersion(2, 4)
     current_glibc = _GLibCVersion(*_get_glibc_version())
@@ -227,19 +233,20 @@ def platform_tags(linux: str, arch: str) -> Iterator[str]:
     for glibc_major in range(current_glibc.major - 1, 1, -1):
         glibc_minor = _LAST_GLIBC_MINOR[glibc_major]
         glibc_max_list.append(_GLibCVersion(glibc_major, glibc_minor))
-    for glibc_max in glibc_max_list:
-        if glibc_max.major == too_old_glibc2.major:
-            min_minor = too_old_glibc2.minor
-        else:
-            # For other glibc major versions oldest supported is (x, 0).
-            min_minor = -1
-        for glibc_minor in range(glibc_max.minor, min_minor, -1):
-            glibc_version = _GLibCVersion(glibc_max.major, glibc_minor)
-            tag = "manylinux_{}_{}".format(*glibc_version)
-            if _is_compatible(arch, glibc_version):
-                yield f"{tag}_{arch}"
-            # Handle the legacy manylinux1, manylinux2010, manylinux2014 tags.
-            if glibc_version in _LEGACY_MANYLINUX_MAP:
-                legacy_tag = _LEGACY_MANYLINUX_MAP[glibc_version]
+    for arch in archs:
+        for glibc_max in glibc_max_list:
+            if glibc_max.major == too_old_glibc2.major:
+                min_minor = too_old_glibc2.minor
+            else:
+                # For other glibc major versions oldest supported is (x, 0).
+                min_minor = -1
+            for glibc_minor in range(glibc_max.minor, min_minor, -1):
+                glibc_version = _GLibCVersion(glibc_max.major, glibc_minor)
+                tag = "manylinux_{}_{}".format(*glibc_version)
                 if _is_compatible(arch, glibc_version):
-                    yield f"{legacy_tag}_{arch}"
+                    yield f"{tag}_{arch}"
+                # Handle the legacy manylinux1, manylinux2010, manylinux2014 tags.
+                if glibc_version in _LEGACY_MANYLINUX_MAP:
+                    legacy_tag = _LEGACY_MANYLINUX_MAP[glibc_version]
+                    if _is_compatible(arch, glibc_version):
+                        yield f"{legacy_tag}_{arch}"

--- a/src/packaging/_manylinux.py
+++ b/src/packaging/_manylinux.py
@@ -55,8 +55,8 @@ def _have_compatible_abi(executable: str, archs: Sequence[str]) -> bool:
         return _is_linux_armhf(executable)
     if "i686" in archs:
         return _is_linux_i686(executable)
-    other_archs = {"x86_64", "aarch64", "ppc64", "ppc64le", "s390x", "loongarch64"}
-    return len(set(archs) & other_archs) > 0
+    allowed_archs = {"x86_64", "aarch64", "ppc64", "ppc64le", "s390x", "loongarch64"}
+    return any(arch in allowed_archs for arch in archs)
 
 
 # If glibc ever changes its major version, we need to know what the last

--- a/src/packaging/_manylinux.py
+++ b/src/packaging/_manylinux.py
@@ -204,6 +204,11 @@ _LEGACY_MANYLINUX_MAP = {
 
 
 def platform_tags(linux: str, arch: str) -> Iterator[str]:
+    if arch == "armv8l":
+        # armv8l wheels are not accepted on PyPI
+        # As long as we pass the the ABI check below,
+        # the armv7l wheels can be installed.
+        arch = "armv7l"
     if not _have_compatible_abi(sys.executable, arch):
         return
     # Oldest glibc to be supported regardless of architecture is (2, 17).
@@ -232,9 +237,9 @@ def platform_tags(linux: str, arch: str) -> Iterator[str]:
             glibc_version = _GLibCVersion(glibc_max.major, glibc_minor)
             tag = "manylinux_{}_{}".format(*glibc_version)
             if _is_compatible(arch, glibc_version):
-                yield linux.replace("linux", tag)
+                yield f"{tag}_{arch}"
             # Handle the legacy manylinux1, manylinux2010, manylinux2014 tags.
             if glibc_version in _LEGACY_MANYLINUX_MAP:
                 legacy_tag = _LEGACY_MANYLINUX_MAP[glibc_version]
                 if _is_compatible(arch, glibc_version):
-                    yield linux.replace("linux", legacy_tag)
+                    yield f"{legacy_tag}_{arch}"

--- a/src/packaging/_musllinux.py
+++ b/src/packaging/_musllinux.py
@@ -8,7 +8,7 @@ import functools
 import re
 import subprocess
 import sys
-from typing import Iterator, NamedTuple, Optional
+from typing import Iterator, NamedTuple, Optional, Sequence
 
 from ._elffile import ELFFile
 
@@ -51,24 +51,23 @@ def _get_musl_version(executable: str) -> Optional[_MuslVersion]:
     return _parse_musl_version(proc.stderr)
 
 
-def platform_tags(arch: str) -> Iterator[str]:
+def platform_tags(archs: Sequence[str]) -> Iterator[str]:
     """Generate musllinux tags compatible to the current platform.
 
-    :param arch: Should be the part of platform tag after the ``linux_``
-        prefix, e.g. ``x86_64``. The ``linux_`` prefix is assumed as a
-        prerequisite for the current platform to be musllinux-compatible.
+    :param archs: Sequence of compatible architectures.
+        The first one shall be the closest to the actual architecture and be the part of
+        platform tag after the ``linux_`` prefix, e.g. ``x86_64``.
+        The ``linux_`` prefix is assumed as a prerequisite for the current platform to
+        be musllinux-compatible.
 
     :returns: An iterator of compatible musllinux tags.
     """
     sys_musl = _get_musl_version(sys.executable)
     if sys_musl is None:  # Python not dynamically linked against musl.
         return
-    if arch == "armv8l":
-        # armv8l wheels are not accepted on PyPI
-        # The armv7l wheels can be installed.
-        arch = "armv7l"
-    for minor in range(sys_musl.minor, -1, -1):
-        yield f"musllinux_{sys_musl.major}_{minor}_{arch}"
+    for arch in archs:
+        for minor in range(sys_musl.minor, -1, -1):
+            yield f"musllinux_{sys_musl.major}_{minor}_{arch}"
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/src/packaging/_musllinux.py
+++ b/src/packaging/_musllinux.py
@@ -63,6 +63,10 @@ def platform_tags(arch: str) -> Iterator[str]:
     sys_musl = _get_musl_version(sys.executable)
     if sys_musl is None:  # Python not dynamically linked against musl.
         return
+    if arch == "armv8l":
+        # armv8l wheels are not accepted on PyPI
+        # The armv7l wheels can be installed.
+        arch = "armv7l"
     for minor in range(sys_musl.minor, -1, -1):
         yield f"musllinux_{sys_musl.major}_{minor}_{arch}"
 

--- a/src/packaging/tags.py
+++ b/src/packaging/tags.py
@@ -469,15 +469,21 @@ def mac_platforms(
 
 def _linux_platforms(is_32bit: bool = _32_BIT_INTERPRETER) -> Iterator[str]:
     linux = _normalize_string(sysconfig.get_platform())
+    if not linux.startswith("linux_"):
+        # we should never be here, just yield the sysconfig one and return
+        yield linux
+        return
     if is_32bit:
         if linux == "linux_x86_64":
             linux = "linux_i686"
         elif linux == "linux_aarch64":
             linux = "linux_armv8l"
     _, arch = linux.split("_", 1)
-    yield from _manylinux.platform_tags(linux, arch)
-    yield from _musllinux.platform_tags(arch)
-    yield linux
+    archs = {"armv8l": ["armv8l", "armv7l"]}.get(arch, [arch])
+    yield from _manylinux.platform_tags(archs)
+    yield from _musllinux.platform_tags(archs)
+    for arch in archs:
+        yield f"linux_{arch}"
 
 
 def _generic_platforms() -> Iterator[str]:

--- a/src/packaging/tags.py
+++ b/src/packaging/tags.py
@@ -473,7 +473,7 @@ def _linux_platforms(is_32bit: bool = _32_BIT_INTERPRETER) -> Iterator[str]:
         if linux == "linux_x86_64":
             linux = "linux_i686"
         elif linux == "linux_aarch64":
-            linux = "linux_armv7l"
+            linux = "linux_armv8l"
     _, arch = linux.split("_", 1)
     yield from _manylinux.platform_tags(linux, arch)
     yield from _musllinux.platform_tags(arch)


### PR DESCRIPTION
`aarch64` systems running under `linux32` emulation will report an `armv8l` machine rather than `armv7l`.
This shall not prevent packaging to report `musllinux/manylinux armv7l` compatibiility as long as the running python has a compatible ABI.

fix #476 (partial)

Some choices were made based on what PyPI accepts today to get a first level of support. A more generic approach would require to refactor some things but would probably be doable as well. I'll comment a bit more inline.