### PR TITLE
Add platform tag support for LoongArch

### DIFF
--- a/src/packaging/_manylinux.py
+++ b/src/packaging/_manylinux.py
@@ -55,7 +55,7 @@ def _have_compatible_abi(executable: str, arch: str) -> bool:
         return _is_linux_armhf(executable)
     if arch == "i686":
         return _is_linux_i686(executable)
-    return arch in {"x86_64", "aarch64", "ppc64", "ppc64le", "s390x"}
+    return arch in {"x86_64", "aarch64", "ppc64", "ppc64le", "s390x", "loongarch64"}
 
 
 # If glibc ever changes its major version, we need to know what the last


### PR DESCRIPTION
Whl format：
`{distribution}-{version}(-{build tag})?-{python tag}-{abi tag}-{platform tag}.whl
`

When I run `python setup.py bdist_wheel --plat-name=manylinux_2_28_loongarch64` to product wheel, but install error:
```
user$ pip3 install ./test1-16.1-py2.py3-none-manylinux_2_28_loongarch64.whl 
Defaulting to user installation because normal site-packages is not writeable
WARNING: Ignoring invalid distribution -andas (/home/zn/.local/lib/python3.7/site-packages)
ERROR: test1-16.1-py2.py3-none-manylinux_2_28_loongarch64.whl is not a supported wheel on this platform.
```
Add this patch  can solve this error:
```
user$ pip3 install ./test1-16.1-py2.py3-none-manylinux_2_28_loongarch64.whl 
Defaulting to user installation because normal site-packages is not writeable
Processing ./test1-16.1-py2.py3-none-manylinux_2_28_loongarch64.whl 
Installing collected packages: test1
Successfully installed test1-16.1

```