### PR TITLE
Add PyPy 3.10 to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         os: [Ubuntu, Windows, macOS]
         python_version:
-          ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "pypy3.8", "pypy3.9"]
+          ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "pypy3.8", "pypy3.9", "pypy3.10"]
 
     steps:
       - uses: actions/checkout@v3

--- a/noxfile.py
+++ b/noxfile.py
@@ -21,7 +21,19 @@ nox.options.sessions = ["lint"]
 nox.options.reuse_existing_virtualenvs = True
 
 
-@nox.session(python=["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "pypy3.8", "pypy3.9"])
+@nox.session(
+    python=[
+        "3.7",
+        "3.8",
+        "3.9",
+        "3.10",
+        "3.11",
+        "3.12",
+        "pypy3.8",
+        "pypy3.9",
+        "pypy3.10",
+    ]
+)
 def tests(session):
     def coverage(*args):
         session.run("python", "-m", "coverage", *args)


### PR DESCRIPTION
PyPy 3.10 is now available, add it to CI tests.