### PR TITLE
Remove unused argument in `_manylinux._is_compatible`

### DIFF
--- a/src/packaging/_manylinux.py
+++ b/src/packaging/_manylinux.py
@@ -167,7 +167,7 @@ def _get_glibc_version() -> Tuple[int, int]:
 
 
 # From PEP 513, PEP 600
-def _is_compatible(name: str, arch: str, version: _GLibCVersion) -> bool:
+def _is_compatible(arch: str, version: _GLibCVersion) -> bool:
     sys_glibc = _get_glibc_version()
     if sys_glibc < version:
         return False
@@ -231,10 +231,10 @@ def platform_tags(linux: str, arch: str) -> Iterator[str]:
         for glibc_minor in range(glibc_max.minor, min_minor, -1):
             glibc_version = _GLibCVersion(glibc_max.major, glibc_minor)
             tag = "manylinux_{}_{}".format(*glibc_version)
-            if _is_compatible(tag, arch, glibc_version):
+            if _is_compatible(arch, glibc_version):
                 yield linux.replace("linux", tag)
             # Handle the legacy manylinux1, manylinux2010, manylinux2014 tags.
             if glibc_version in _LEGACY_MANYLINUX_MAP:
                 legacy_tag = _LEGACY_MANYLINUX_MAP[glibc_version]
-                if _is_compatible(legacy_tag, arch, glibc_version):
+                if _is_compatible(arch, glibc_version):
                     yield linux.replace("linux", legacy_tag)

--- a/tests/test_manylinux.py
+++ b/tests/test_manylinux.py
@@ -46,7 +46,7 @@ def manylinux_module(monkeypatch):
 def test_module_declaration(monkeypatch, manylinux_module, attribute, glibc, tf):
     manylinux = f"manylinux{attribute}_compatible"
     monkeypatch.setattr(manylinux_module, manylinux, tf, raising=False)
-    res = _is_compatible(manylinux, "x86_64", glibc)
+    res = _is_compatible("x86_64", glibc)
     assert tf is res
 
 
@@ -58,7 +58,7 @@ def test_module_declaration_missing_attribute(
 ):
     manylinux = f"manylinux{attribute}_compatible"
     monkeypatch.delattr(manylinux_module, manylinux, raising=False)
-    assert _is_compatible(manylinux, "x86_64", glibc)
+    assert _is_compatible("x86_64", glibc)
 
 
 @pytest.mark.parametrize(
@@ -67,7 +67,7 @@ def test_module_declaration_missing_attribute(
 def test_is_manylinux_compatible_glibc_support(version, compatible, monkeypatch):
     monkeypatch.setitem(sys.modules, "_manylinux", None)
     monkeypatch.setattr(_manylinux, "_get_glibc_version", lambda: (2, 5))
-    assert bool(_is_compatible("manylinux1", "any", version)) == compatible
+    assert bool(_is_compatible("any", version)) == compatible
 
 
 @pytest.mark.parametrize("version_str", ["glibc-2.4.5", "2"])
@@ -152,17 +152,17 @@ def test_glibc_version_string_ctypes_raise_oserror(monkeypatch):
 def test_is_manylinux_compatible_old():
     # Assuming no one is running this test with a version of glibc released in
     # 1997.
-    assert _is_compatible("any", "any", (2, 0))
+    assert _is_compatible("any", (2, 0))
 
 
 def test_is_manylinux_compatible(monkeypatch):
     monkeypatch.setattr(_manylinux, "_glibc_version_string", lambda: "2.4")
-    assert _is_compatible("", "any", (2, 4))
+    assert _is_compatible("any", (2, 4))
 
 
 def test_glibc_version_string_none(monkeypatch):
     monkeypatch.setattr(_manylinux, "_glibc_version_string", lambda: None)
-    assert not _is_compatible("any", "any", (2, 4))
+    assert not _is_compatible("any", (2, 4))
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
The `name` argument in `_manylinux._is_compatible` is unused however, it was used in mocking some tests.
Remove the unused argument & update tests not to rely on this unused & now removed argument.