### PR TITLE
Fix version pattern pre-releases

### DIFF
--- a/src/packaging/version.py
+++ b/src/packaging/version.py
@@ -119,7 +119,7 @@ _VERSION_PATTERN = r"""
         (?P<release>[0-9]+(?:\.[0-9]+)*)                  # release segment
         (?P<pre>                                          # pre-release
             [-_\.]?
-            (?P<pre_l>(a|b|c|rc|alpha|beta|pre|preview))
+            (?P<pre_l>alpha|a|beta|b|preview|pre|c|rc)
             [-_\.]?
             (?P<pre_n>[0-9]+)?
         )?


### PR DESCRIPTION
This commit fixes a precedence issue with version pre-release tags.

Relational
---

The `version` module exports `VERSION_PATTERN`.

Directly using it, might not produce expected results for pre-releases.

```py
>>> import re
>>> from packaging.version import VERSION_PATTERN

>>> re.match(VERSION_PATTERN, "1.0.0-alpha1")
<re.Match object; span=(0, 7), match='1.0.0-a'>
```

Trailing `1` from `-alpha1` is not matched, because previous pattern preferred consuming only `a` instead of `alpha` due to missing word boundary checks.

Simplest solution is to re-order tokens, so regexp prefers longer tokens over their abbreviation.

```py
>>> import re
>>> from packaging.version import VERSION_PATTERN

>>> re.match(VERSION_PATTERN, "1.0.0-alpha1")
<re.Match object; span=(0, 12), match='1.0.0-alpha1'>
```

Note: This commit also removes an unnecessary capture group.