### PR TITLE
Fix typos found by codespell

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -17,6 +17,6 @@ https://packaging.pypa.io/en/latest/development/
 Security issues
 ---------------
 
-See `Security Policy`_ for informations about how to report security issues.
+See `Security Policy`_ for information about how to report security issues.
 
 .. _`Security Policy`: https://github.com/pypa/packaging/security

--- a/src/packaging/metadata.py
+++ b/src/packaging/metadata.py
@@ -77,7 +77,7 @@ class RawMetadata(TypedDict, total=False):
     # but got stuck without ever being able to build consensus on
     # it and ultimately ended up withdrawn.
     #
-    # However, a number of tools had started emiting METADATA with
+    # However, a number of tools had started emitting METADATA with
     # `2.0` Metadata-Version, so for historical reasons, this version
     # was skipped.
 


### PR DESCRIPTION
While `(un)parseable` is debatable, `(un)parsable` appears to be the preferred spelling:
* The word is missing from online dictionaries (Oxford Learner's, Cambridge, Collins, Longman, Merriam-Webster).
* The [Google Ngram Viewer](https://books.google.com/ngrams/graph?content=unparseable%2Cunparsable&year_start=1900) shows `unparsable` is more common than `unparseable`, although the latter has been gaining ground in the 21st century.
* [Rules for removing last vowel when adding "-able"?](https://english.stackexchange.com/questions/76043/rules-for-removing-last-vowel-when-adding-able#76044)