### PR TITLE
fix: platform tag for GraalPy

### DIFF
--- a/src/packaging/tags.py
+++ b/src/packaging/tags.py
@@ -4,6 +4,7 @@
 
 import logging
 import platform
+import struct
 import subprocess
 import sys
 import sysconfig
@@ -37,7 +38,7 @@ INTERPRETER_SHORT_NAMES: Dict[str, str] = {
 }
 
 
-_32_BIT_INTERPRETER = sys.maxsize <= 2**32
+_32_BIT_INTERPRETER = struct.calcsize("P") == 4
 
 
 class Tag:

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -1352,12 +1352,12 @@ class TestBitness:
     @pytest.mark.parametrize(
         "maxsize, sizeof_voidp, expected",
         [
-            # CPython, PyPy, pyston 64bit
+            # 64-bit
             (9223372036854775807, 8, False),
-            # GraalPy, IronPython, Jython 64bit
-            (2147483647, 8, False),
-            # CPython, PyPy, IronPython, Jython, pyodide 32bit
+            # 32-bit
             (2147483647, 4, True),
+            # 64-bit w/ 32-bit sys.maxsize: GraalPy, IronPython, Jython
+            (2147483647, 8, False),
         ],
     )
     def test_32bit_interpreter(self, maxsize, sizeof_voidp, expected, monkeypatch):


### PR DESCRIPTION
When running a 64-bit version of GraalPy (either x86_64 or aarch64), packaging returns the wrong platform tag (either i686 or armv8l).

Fix this by using the same default implementation as found in stdlib platform.architecture https://github.com/python/cpython/blob/4d4393139fae39db26dead33529b6ae0bafbfc58/Lib/platform.py#L713-L716

fixes #710 

cc @timfel