### PR TITLE
fix: Update copyright date for docs

### DIFF
--- a/src/packaging/__init__.py
+++ b/src/packaging/__init__.py
@@ -12,4 +12,4 @@ __author__ = "Donald Stufft and individual contributors"
 __email__ = "donald@stufft.io"
 
 __license__ = "BSD-2-Clause or Apache-2.0"
-__copyright__ = "2014-2023 %s" % __author__
+__copyright__ = "2014 %s" % __author__

--- a/src/packaging/__init__.py
+++ b/src/packaging/__init__.py
@@ -12,4 +12,4 @@ __author__ = "Donald Stufft and individual contributors"
 __email__ = "donald@stufft.io"
 
 __license__ = "BSD-2-Clause or Apache-2.0"
-__copyright__ = "2014-2019 %s" % __author__
+__copyright__ = "2014-2023 %s" % __author__


### PR DESCRIPTION
Updating copyright date for docs so readers will more easily be able to tell updates have happened in recent years.