### PR TITLE
Document that this library uses a calendar-based versioning scheme

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog
 *unreleased*
 ~~~~~~~~~~~~
 
-* Document calendar-based versioning schema (:issue:`716`)
+* Document calendar-based versioning scheme (:issue:`716`)
 * Enforce that the entire marker string is parsed (:issue:`687`)
 * Requirement parsing no longer automatically validates the URL (:issue:`120`)
 * Canonicalize names for requirements comparison (:issue:`644`)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 *unreleased*
 ~~~~~~~~~~~~
 
+* Document calendar-based versioning schema (:issue:`716`)
 * Enforce that the entire marker string is parsed (:issue:`687`)
 * Requirement parsing no longer automatically validates the URL (:issue:`120`)
 * Canonicalize names for requirements comparison (:issue:`644`)

--- a/README.rst
+++ b/README.rst
@@ -34,6 +34,8 @@ Use ``pip`` to install these utilities::
 
     pip install packaging
 
+The ``packaging`` library uses calendar-based versioning (``YY.N``).
+
 Discussion
 ----------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,6 +15,8 @@ You can install packaging with ``pip``:
 
     $ pip install packaging
 
+The ``packaging`` library uses calendar-based versioning (``YY.N``).
+
 
 .. toctree::
     :maxdepth: 1


### PR DESCRIPTION
Following from discussion here: #716, I feel there is some benefit in explaining that `packaging` uses a calendar-based system. This would avoid developers interpreting versions like `22.0` as semver.