### PR TITLE
Bump pip version to avoid known vulnerabilities

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,4 @@
 coverage[toml]>=5.0.0
-pip>=9.0.2
+pip>=21.1
 pretend
 pytest>=6.2.0


### PR DESCRIPTION
Closes #719 

Bumping pip version to be greater or equal to 21.1 to avoid known vulnerabilities. 