### PR TITLE
Fix code blocks in CHANGELOG.md

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,7 +11,7 @@ Changelog
 * Introduce ``metadata.Metadata`` (along with ``metadata.ExceptionGroup`` and ``metadata.InvalidMetadata``; :issue:`570`)
 * Introduce the ``validate`` keyword parameter to ``utils.validate_name()`` (:issue:`570`)
 * Introduce ``utils.is_normalized_name()`` (:issue:`570`)
-* Make ``utils.parse_sdist_filename()` and ``utils.parse_wheel_filename()`
+* Make ``utils.parse_sdist_filename()`` and ``utils.parse_wheel_filename()``
   raise ``InvalidSdistFilename`` and ``InvalidWheelFilename``, respectively,
   when the version component of the name is invalid
 


### PR DESCRIPTION
Previously the mixed single/double backtick usage meant the code block didn't end at the correct location and instead ran into the normal text.

<img width="804" alt="Screenshot before" src="https://github.com/pypa/packaging/assets/501702/8552fbbc-924a-469c-98fa-1f9350ba8bdc">
