### PR TITLE
Skip `test_glibc_version_string_ctypes_raise_oserror` if `ctypes` is unavailable

### DIFF
--- a/tests/test_manylinux.py
+++ b/tests/test_manylinux.py
@@ -140,7 +140,7 @@ def test_glibc_version_string_ctypes_missing(monkeypatch):
     assert _glibc_version_string_ctypes() is None
 
 
-@pytest.mark.skipif(not ctypes, reason="requires ctypes")
+@pytest.mark.xfail(ctypes is None, reason="ctypes not available")
 def test_glibc_version_string_ctypes_raise_oserror(monkeypatch):
     def patched_cdll(name):
         raise OSError("Dynamic loading not supported")

--- a/tests/test_manylinux.py
+++ b/tests/test_manylinux.py
@@ -140,6 +140,7 @@ def test_glibc_version_string_ctypes_missing(monkeypatch):
     assert _glibc_version_string_ctypes() is None
 
 
+@pytest.mark.skipif(not ctypes, reason="requires ctypes")
 def test_glibc_version_string_ctypes_raise_oserror(monkeypatch):
     def patched_cdll(name):
         raise OSError("Dynamic loading not supported")


### PR DESCRIPTION
Implements the requested changes in #666. Namely, `test_glibc_version_string_ctypes_raise_oserror` failed under WASI because it assumed that `ctypes` is always available. This adds the appropriate `skipIf` decorator to skip the test if `ctypes` is not available. 