### PR TITLE
fix incorrectly pluralised field names

### DIFF
--- a/src/packaging/metadata.py
+++ b/src/packaging/metadata.py
@@ -100,7 +100,7 @@ class RawMetadata(TypedDict, total=False):
     metadata_version: str
     name: str
     version: str
-    platforms: List[str]
+    platform: List[str]
     summary: str
     description: str
     keywords: List[str]
@@ -110,9 +110,9 @@ class RawMetadata(TypedDict, total=False):
     license: str
 
     # Metadata 1.1 - PEP 314
-    supported_platforms: List[str]
+    supported_platform: List[str]
     download_url: str
-    classifiers: List[str]
+    classifier: List[str]
     requires: List[str]
     provides: List[str]
     obsoletes: List[str]
@@ -125,7 +125,7 @@ class RawMetadata(TypedDict, total=False):
     obsoletes_dist: List[str]
     requires_python: str
     requires_external: List[str]
-    project_urls: Dict[str, str]
+    project_url: Dict[str, str]
 
     # Metadata 2.0
     # PEP 426 attempted to completely revamp the metadata format
@@ -160,7 +160,7 @@ def _parse_keywords(data: str) -> List[str]:
     return [k.strip() for k in data.split(",")]
 
 
-def _parse_project_urls(data: List[str]) -> Dict[str, str]:
+def _parse_project_url(data: List[str]) -> Dict[str, str]:
     """Parse a list of label/URL string pairings separated by a comma."""
     urls = {}
     for pair in data:
@@ -368,9 +368,9 @@ def parse_email(data: Union[bytes, str]) -> Tuple[RawMetadata, Dict[str, List[st
         #
         # We will do a little light data massaging to turn this into a map as
         # it logically should be.
-        elif raw_name == "project_urls":
+        elif raw_name == "project_url":
             try:
-                raw[raw_name] = _parse_project_urls(value)
+                raw[raw_name] = _parse_project_url(value)
             except KeyError:
                 unparsed[name] = value
         # Nothing that we've done has managed to parse this, so it'll just
@@ -706,9 +706,9 @@ class Metadata:
     )
     """:external:ref:`core-metadata-dynamic`
     (validated against core metadata field names and lowercased)"""
-    platforms: _Validator[Optional[List[str]]] = _Validator()
+    platform: _Validator[Optional[List[str]]] = _Validator()
     """:external:ref:`core-metadata-platform`"""
-    supported_platforms: _Validator[Optional[List[str]]] = _Validator(added="1.1")
+    supported_platform: _Validator[Optional[List[str]]] = _Validator(added="1.1")
     """:external:ref:`core-metadata-supported-platform`"""
     summary: _Validator[Optional[str]] = _Validator()
     """:external:ref:`core-metadata-summary` (validated to contain no newlines)"""
@@ -732,7 +732,7 @@ class Metadata:
     """:external:ref:`core-metadata-maintainer-email`"""
     license: _Validator[Optional[str]] = _Validator()
     """:external:ref:`core-metadata-license`"""
-    classifiers: _Validator[Optional[List[str]]] = _Validator(added="1.1")
+    classifier: _Validator[Optional[List[str]]] = _Validator(added="1.1")
     """:external:ref:`core-metadata-classifier`"""
     requires_dist: _Validator[Optional[List[requirements.Requirement]]] = _Validator(
         added="1.2"
@@ -746,7 +746,7 @@ class Metadata:
     # don't do any processing on the values.
     requires_external: _Validator[Optional[List[str]]] = _Validator(added="1.2")
     """:external:ref:`core-metadata-requires-external`"""
-    project_urls: _Validator[Optional[Dict[str, str]]] = _Validator(added="1.2")
+    project_url: _Validator[Optional[Dict[str, str]]] = _Validator(added="1.2")
     """:external:ref:`core-metadata-project-url`"""
     # PEP 685 lets us raise an error if an extra doesn't pass `Name` validation
     # regardless of metadata version.

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -5,9 +5,13 @@ import pytest
 from packaging import metadata, requirements, specifiers, utils, version
 from packaging.metadata import ExceptionGroup
 
+_TYPE_FIELDS = {}
+for key, cls in metadata._FIELD_TYPES.items():
+    _TYPE_FIELDS.setdefault(cls, set()).add(key)
+
 
 class TestRawMetadata:
-    @pytest.mark.parametrize("raw_field", metadata._STRING_FIELDS)
+    @pytest.mark.parametrize("raw_field", _TYPE_FIELDS[str])
     def test_non_repeating_fields_only_once(self, raw_field):
         data = "VaLuE"
         header_field = metadata._RAW_TO_EMAIL_MAPPING[raw_field]
@@ -18,7 +22,7 @@ class TestRawMetadata:
         assert raw_field in raw
         assert raw[raw_field] == data
 
-    @pytest.mark.parametrize("raw_field", metadata._STRING_FIELDS)
+    @pytest.mark.parametrize("raw_field", _TYPE_FIELDS[str])
     def test_non_repeating_fields_repeated(self, raw_field):
         header_field = metadata._RAW_TO_EMAIL_MAPPING[raw_field]
         data = "VaLuE"
@@ -30,7 +34,7 @@ class TestRawMetadata:
         assert header_field in unparsed
         assert unparsed[header_field] == [data] * 2
 
-    @pytest.mark.parametrize("raw_field", metadata._LIST_FIELDS)
+    @pytest.mark.parametrize("raw_field", _TYPE_FIELDS[list])
     def test_repeating_fields_only_once(self, raw_field):
         data = "VaLuE"
         header_field = metadata._RAW_TO_EMAIL_MAPPING[raw_field]
@@ -41,7 +45,7 @@ class TestRawMetadata:
         assert raw_field in raw
         assert raw[raw_field] == [data]
 
-    @pytest.mark.parametrize("raw_field", metadata._LIST_FIELDS)
+    @pytest.mark.parametrize("raw_field", _TYPE_FIELDS[list])
     def test_repeating_fields_repeated(self, raw_field):
         header_field = metadata._RAW_TO_EMAIL_MAPPING[raw_field]
         data = "VaLuE"

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -90,13 +90,13 @@ class TestRawMetadata:
             ("A,B,C", {"A": "B,C"}),
         ],
     )
-    def test_project_urls_parsing(self, given, expected):
+    def test_project_url_parsing(self, given, expected):
         header = f"project-url: {given}"
         raw, unparsed = metadata.parse_email(header)
         assert not unparsed
         assert len(raw) == 1
-        assert "project_urls" in raw
-        assert raw["project_urls"] == expected
+        assert "project_url" in raw
+        assert raw["project_url"] == expected
 
     def test_duplicate_project_urls(self):
         header = "project-url: A, B\nproject-url: A, C"
@@ -194,8 +194,8 @@ class TestRawMetadata:
         assert raw["metadata_version"] == "2.3"
         assert raw["name"] == "BeagleVote"
         assert raw["version"] == "1.0a2"
-        assert raw["platforms"] == ["ObscureUnix", "RareDOS"]
-        assert raw["supported_platforms"] == ["RedHat 7.2", "i386-win32-2791"]
+        assert raw["platform"] == ["ObscureUnix", "RareDOS"]
+        assert raw["supported_platform"] == ["RedHat 7.2", "i386-win32-2791"]
         assert raw["summary"] == "A module for collecting votes from beagles."
         assert (
             raw["description_content_type"]
@@ -219,7 +219,7 @@ class TestRawMetadata:
             "        author a postcard, and then the user promises not\n"
             "        to redistribute it."
         )
-        assert raw["classifiers"] == [
+        assert raw["classifier"] == [
             "Development Status :: 4 - Beta",
             "Environment :: Console (Text Based)",
         ]
@@ -237,7 +237,7 @@ class TestRawMetadata:
             "libpng (>=1.5)",
             'make; sys_platform != "win32"',
         ]
-        assert raw["project_urls"] == {
+        assert raw["project_url"] == {
             "Bug Tracker": "http://bitbucket.org/tarek/distribute/issues/",
             "Documentation": "https://example.com/BeagleVote",
         }
@@ -404,9 +404,9 @@ class TestMetadata:
     @pytest.mark.parametrize(
         "attribute",
         [
-            "supported_platforms",
-            "platforms",
-            "classifiers",
+            "supported_platform",
+            "platform",
+            "classifier",
             "provides_dist",
             "obsoletes_dist",
             "requires",
@@ -523,9 +523,9 @@ class TestMetadata:
             "Documentation": "https://example.com/BeagleVote",
             "Bug Tracker": "http://bitbucket.org/tarek/distribute/issues/",
         }
-        meta = metadata.Metadata.from_raw({"project_urls": urls}, validate=False)
+        meta = metadata.Metadata.from_raw({"project_url": urls}, validate=False)
 
-        assert meta.project_urls == urls
+        assert meta.project_url == urls
 
     @pytest.mark.parametrize("specifier", [">=3", ">2.6,!=3.0.*,!=3.1.*", "~=2.6"])
     def test_valid_requires_python(self, specifier):


### PR DESCRIPTION
These names are incorrectly pluralised per the Core Metadata specification.

This also cleans up the metadata module by using annotations for field names and types.