### PR TITLE
PEP 703: Rename `Py_NOGIL` to `Py_GIL_DISABLED`

### DIFF
--- a/src/packaging/tags.py
+++ b/src/packaging/tags.py
@@ -164,7 +164,7 @@ def _cpython_abis(py_version: PythonVersion, warn: bool = False) -> List[str]:
     has_ext = "_d.pyd" in EXTENSION_SUFFIXES
     if with_debug or (with_debug is None and (has_refcount or has_ext)):
         debug = "d"
-    if py_version >= (3, 13) and _get_config_var("Py_NOGIL", warn):
+    if py_version >= (3, 13) and _get_config_var("Py_GIL_DISABLED", warn):
         threading = "t"
     if py_version < (3, 8):
         with_pymalloc = _get_config_var("WITH_PYMALLOC", warn)

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -907,7 +907,7 @@ class TestGenericTags:
             "Py_DEBUG": False,
             "EXT_SUFFIX": ".cpython-313t-x86_64-linux-gnu.so",
             "WITH_PYMALLOC": 0,
-            "Py_NOGIL": 1,
+            "Py_GIL_DISABLED": 1,
         }
         monkeypatch.setattr(sysconfig, "get_config_var", config.__getitem__)
         assert tags._generic_abi() == ["cp313t"]
@@ -941,7 +941,7 @@ class TestGenericTags:
             "EXT_SUFFIX": ".pyd",
             "Py_DEBUG": 0,
             "WITH_PYMALLOC": 0,
-            "Py_NOGIL": 0,
+            "Py_GIL_DISABLED": 0,
         }
         monkeypatch.setattr(sysconfig, "get_config_var", config.__getitem__)
         assert tags._generic_abi() == tags._cpython_abis(sys.version_info[:2])


### PR DESCRIPTION
Follow on from https://github.com/pypa/packaging/pull/728.

The steering council has chosen `Py_GIL_DISABLED` instead of `Py_NOGIL`:

* https://github.com/python/steering-council/issues/214#issuecomment-1817942256
* https://github.com/python/cpython/issues/111863

PR to update CPython:

* https://github.com/python/cpython/pull/111864

Let's update packaging to match.

cc @colesbury 