### PR TITLE
Add riscv64 as a supported manylinux architecture

### DIFF
--- a/src/packaging/_manylinux.py
+++ b/src/packaging/_manylinux.py
@@ -55,7 +55,15 @@ def _have_compatible_abi(executable: str, archs: Sequence[str]) -> bool:
         return _is_linux_armhf(executable)
     if "i686" in archs:
         return _is_linux_i686(executable)
-    allowed_archs = {"x86_64", "aarch64", "ppc64", "ppc64le", "s390x", "loongarch64"}
+    allowed_archs = {
+        "x86_64",
+        "aarch64",
+        "ppc64",
+        "ppc64le",
+        "s390x",
+        "loongarch64",
+        "riscv64",
+    }
     return any(arch in allowed_archs for arch in archs)
 
 


### PR DESCRIPTION
This will allow wheels with platform tags of the form manylinux_${GLIBCMAJOR}_${GLIBCMINOR}_riscv64 to be installed on riscv64 devices.