### PR TITLE
Remove coverage ignore for non-existent file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,6 @@ exclude = ["docs/_build", "tests/manylinux/build-hello-world.sh", "tests/musllin
 
 [tool.coverage.run]
 branch = true
-omit = ["packaging/_compat.py"]
 
 [tool.coverage.report]
 exclude_lines = ["pragma: no cover", "@abc.abstractmethod", "@abc.abstractproperty"]


### PR DESCRIPTION
The ignore was added in #1, and was migrated from `.coveragerc` to `pyproject.toml` in #586, even though the file had already been deleted over a year ago in #376.

Since the file no longer exists, the ignore should just be removed.