### PR TITLE
Configure dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Related to #756 

This PR configures dependabot to do version updates monthly on the github actions. All updates will be submitted in a single PR.

It is good to also enable "Dependabot security updates" on [Code Security and analysis](https://github.com/pypa/packaging/settings/security_analysis) to receive security patches as soon as it is released instead having to wait for the next time dependabot will check them.