### PR TITLE
Update URLs

### DIFF
--- a/docs/development/getting-started.rst
+++ b/docs/development/getting-started.rst
@@ -73,5 +73,5 @@ The HTML documentation index can now be found at
 .. _`virtualenv`: https://pypi.org/project/virtualenv/
 .. _`pip`: https://pypi.org/project/pip/
 .. _`sphinx`: https://pypi.org/project/Sphinx/
-.. _`reStructured Text`: http://sphinx-doc.org/rest.html
+.. _`reStructured Text`: https://www.sphinx-doc.org/en/master/usage/restructuredtext/
 .. _`pre-commit`: https://pre-commit.com

--- a/docs/development/index.rst
+++ b/docs/development/index.rst
@@ -16,4 +16,4 @@ bug check out `what to put in your bug report`_.
     release-process
 
 .. _`GitHub`: https://github.com/pypa/packaging
-.. _`what to put in your bug report`: http://www.contribution-guide.org/#what-to-put-in-your-bug-report
+.. _`what to put in your bug report`: https://www.contribution-guide.org/#what-to-put-in-your-bug-report

--- a/docs/development/submitting-patches.rst
+++ b/docs/development/submitting-patches.rst
@@ -70,5 +70,5 @@ So, specifically:
 .. |black| replace:: ``black``
 .. _black: https://pypi.org/project/black/
 .. _`Write comments as complete sentences.`: https://nedbatchelder.com/blog/201401/comments_should_be_sentences.html
-.. _`syntax`: http://sphinx-doc.org/domains.html#info-field-lists
-.. _`Studies have shown`: http://www.ibm.com/developerworks/rational/library/11-proven-practices-for-peer-review/
+.. _`syntax`: https://www.sphinx-doc.org/en/master/usage/restructuredtext/field-lists.html
+.. _`Studies have shown`: https://www.microsoft.com/en-us/research/publication/characteristics-of-useful-code-reviews-an-empirical-study-at-microsoft/


### PR DESCRIPTION
- http:// → https://
- The Sphinx documentation has changed, update relevant links.
- The cited IBM "study" does not seem to be visible online any more. I was merely able to find a short reference here:
  https://wiki.dirkjanswagerman.nl/index.php?title=11_proven_practices_for_more_effective,_efficient_peer_code_review
  Instead, point to a Microsoft academic paper. I could find it both on the Microsoft web site:
  https://www.microsoft.com/en-us/research/publication/characteristics-of-useful-code-reviews-an-empirical-study-at-microsoft/
  and in the ACM proceedings:
  https://dl.acm.org/doi/10.5555/2820518.2820538
  I chose a link to the Microsoft web site, although it lacks a DOI, because the PDF of the paper is freely available there:
  https://www.microsoft.com/en-us/research/wp-content/uploads/2016/02/bosu2015useful.pdf