### PR TITLE
Add support for Python 3.13 and drop EOL 3.7

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,6 +14,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+env:
+  FORCE_COLOR: 1
+
 jobs:
   docs:
     name: nox -s docs

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,6 +16,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+env:
+  FORCE_COLOR: 1
+
 jobs:
   lint:
     name: nox -s lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         os: [Ubuntu, Windows, macOS]
         python_version:
-          ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "pypy3.8", "pypy3.9", "pypy3.10"]
+          ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "pypy3.8", "pypy3.9", "pypy3.10"]
 
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+env:
+  FORCE_COLOR: 1
+
 jobs:
   test:
     name: ${{ matrix.os }} / ${{ matrix.python_version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
       matrix:
         os: [Ubuntu, Windows, macOS]
         python_version:
-          ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "pypy3.8", "pypy3.9", "pypy3.10"]
+          ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "pypy3.8", "pypy3.9", "pypy3.10"]
 
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,9 +19,9 @@ repos:
     rev: v3.3.1
     hooks:
       - id: pyupgrade
-        args: [--py37-plus]
+        args: [--py38-plus]
 
-  - repo: https://github.com/psf/black
+  - repo: https://github.com/psf/black-pre-commit-mirror
     rev: 22.12.0
     hooks:
       - id: black

--- a/docs/development/getting-started.rst
+++ b/docs/development/getting-started.rst
@@ -30,11 +30,15 @@ each supported Python version and run the tests. For example:
     $ nox -s tests
     ...
     nox > Ran multiple sessions:
-    nox > * tests-3.7: success
     nox > * tests-3.8: success
     nox > * tests-3.9: success
     nox > * tests-3.10: success
-    nox > * tests-pypy3: skipped
+    nox > * tests-3.11: success
+    nox > * tests-3.12: success
+    nox > * tests-3.13: success
+    nox > * tests-pypy3.8: skipped
+    nox > * tests-pypy3.9: skipped
+    nox > * tests-pypy3.10: skipped
 
 You may not have all the required Python versions installed, in which case you
 will see one or more ``InterpreterNotFound`` errors.

--- a/noxfile.py
+++ b/noxfile.py
@@ -29,6 +29,7 @@ nox.options.reuse_existing_virtualenvs = True
         "3.10",
         "3.11",
         "3.12",
+        "3.13",
         "pypy3.8",
         "pypy3.9",
         "pypy3.10",

--- a/noxfile.py
+++ b/noxfile.py
@@ -23,7 +23,6 @@ nox.options.reuse_existing_virtualenvs = True
 
 @nox.session(
     python=[
-        "3.7",
         "3.8",
         "3.9",
         "3.10",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ name = "packaging"
 description = "Core utilities for Python packages"
 dynamic = ["version"]
 readme = "README.rst"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 authors = [{name = "Donald Stufft", email = "donald@stufft.io"}]
 classifiers = [
   "Development Status :: 5 - Production/Stable",
@@ -18,7 +18,6 @@ classifiers = [
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.7",
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
   "Typing :: Typed",

--- a/src/packaging/_manylinux.py
+++ b/src/packaging/_manylinux.py
@@ -167,7 +167,7 @@ def _parse_glibc_version(version_str: str) -> Tuple[int, int]:
     return int(m.group("major")), int(m.group("minor"))
 
 
-@functools.lru_cache()
+@functools.lru_cache
 def _get_glibc_version() -> Tuple[int, int]:
     version_str = _glibc_version_string()
     if version_str is None:

--- a/src/packaging/_musllinux.py
+++ b/src/packaging/_musllinux.py
@@ -28,7 +28,7 @@ def _parse_musl_version(output: str) -> Optional[_MuslVersion]:
     return _MuslVersion(major=int(m.group(1)), minor=int(m.group(2)))
 
 
-@functools.lru_cache()
+@functools.lru_cache
 def _get_musl_version(executable: str) -> Optional[_MuslVersion]:
     """Detect currently-running musl runtime version.
 

--- a/src/packaging/metadata.py
+++ b/src/packaging/metadata.py
@@ -3,7 +3,6 @@ import email.header
 import email.message
 import email.parser
 import email.policy
-import sys
 import typing
 from typing import (
     Any,
@@ -11,9 +10,11 @@ from typing import (
     Dict,
     Generic,
     List,
+    Literal,
     Optional,
     Tuple,
     Type,
+    TypedDict,
     Union,
     cast,
 )
@@ -21,23 +22,6 @@ from typing import (
 from . import requirements, specifiers, utils, version as version_module
 
 T = typing.TypeVar("T")
-if sys.version_info[:2] >= (3, 8):  # pragma: no cover
-    from typing import Literal, TypedDict
-else:  # pragma: no cover
-    if typing.TYPE_CHECKING:
-        from typing_extensions import Literal, TypedDict
-    else:
-        try:
-            from typing_extensions import Literal, TypedDict
-        except ImportError:
-
-            class Literal:
-                def __init_subclass__(*_args, **_kwargs):
-                    pass
-
-            class TypedDict:
-                def __init_subclass__(*_args, **_kwargs):
-                    pass
 
 
 try:


### PR DESCRIPTION
pip has already dropped 3.7 in `main`: https://github.com/pypa/pip/pull/11944