### PR TITLE
packaging.version as a CLI tool

### DIFF
--- a/src/packaging/version.py
+++ b/src/packaging/version.py
@@ -561,3 +561,43 @@ def _cmpkey(
         )
 
     return epoch, _release, _pre, _post, _dev, _local
+
+
+if __name__ == "__main__":
+    import argparse
+    import sys
+
+    operations = {
+        "lt": lambda v1, v2: v1 < v2,
+        "le": lambda v1, v2: v1 <= v2,
+        "eq": lambda v1, v2: v1 == v2,
+        "ne": lambda v1, v2: v1 != v2,
+        "ge": lambda v1, v2: v1 >= v2,
+        "gt": lambda v1, v2: v1 > v2,
+        "lt-nl": lambda v1, v2: (v1 < v2) if v1 and v2 else True,
+        "le-nl": lambda v1, v2: (v1 <= v2) if v1 and v2 else True,
+        "ge-nl": lambda v1, v2: (v1 >= v2) if v1 and v2 else False,
+        "gt-nl": lambda v1, v2: (v1 > v2) if v1 and v2 else False,
+        "<": lambda v1, v2: v1 < v2,
+        "<<": lambda v1, v2: v1 < v2,
+        "<=": lambda v1, v2: v1 <= v2,
+        "=": lambda v1, v2: v1 == v2,
+        ">=": lambda v1, v2: v1 >= v2,
+        ">>": lambda v1, v2: v1 > v2,
+        ">": lambda v1, v2: v1 > v2,
+    }
+
+    parser = argparse.ArgumentParser(description="Compare two semantic versions.")
+    parser.add_argument("version1", type=Version, help="First version to compare")
+    parser.add_argument(
+        "operator",
+        type=str,
+        choices=operations.keys(),
+        help="Comparison operator",
+    )
+    parser.add_argument("version2", type=Version, help="Second version to compare")
+
+    args = parser.parse_args()
+    result = operations[args.operator](args.version1, args.version2)
+
+    sys.exit(0 if result else 1)


### PR DESCRIPTION
I want to propose this simple CLI tool in the `packaging.version` module to perform semantic version comparisons directly from the command line. This utility is modeled after `dpkg --compare-versions` but designed to be platform-agnostic, filling a gap for non-Debian users and providing a Python-native solution.

Version comparison is a common requirement in deployment scripts, package management, and development workflows. Currently, developers resort to complex shell scripts or third-party tools to compare versions. Examples of community solutions include intricate bash functions and snippets found on Stack Overflow and GitHub Gists that, while functional for basic cases, vary in reliability and can be unnecessarily complex [1](https://stackoverflow.com/questions/4023830/how-to-compare-two-strings-in-dot-separated-version-format-in-bash), [2](https://gist.github.com/Ariel-Rodriguez/9e3c2163f4644d7a389759b224bfe7f3), [3](https://unix.stackexchange.com/questions/285924/how-to-compare-a-programs-version-in-a-shell-script).

My proposal leverages the robustness of the `packaging.version.Version` class for parsing and comparing semantic versions, supporting standard comparison operators (e.g., lt, gt, eq) and provide straightforward syntax that resembles the mentioned dpkg command

## Usage

```
$ python -m packaging.version --help
usage: version.py [-h] version1 {lt,le,eq,ne,ge,gt,lt-nl,le-nl,ge-nl,gt-nl,<,<<,<=,=,>=,>>,>} version2

Compare two semantic versions.

positional arguments:
  version1              First version to compare
  {lt,le,eq,ne,ge,gt,lt-nl,le-nl,ge-nl,gt-nl,<,<<,<=,=,>=,>>,>}
                        Comparison operator
  version2              Second version to compare

options:
  -h, --help            show this help message and exit

$ python -m packaging.version 1.0b gt 0.9   
$ echo $?
0

$ python -m packaging.version 1.0b eq 0.9   # Should exit with status 1
$ echo $?
1

$ python -m packaging.version 1.0b foo 0.9
usage: version.py [-h] version1 {lt,le,eq,ne,ge,gt,lt-nl,le-nl,ge-nl,gt-nl,<,<<,<=,=,>=,>>,>} version2
version.py: error: argument operator: invalid choice: 'foo' (choose from 'lt', 'le', 'eq', 'ne', 'ge', 'gt', 'lt-nl', 'le-nl', 'ge-nl', 'gt-nl', '<', '<<', '<=', '=', '>=', '>>', '>')
$ echo $?
2

$ python -m packaging.version non-version eq 0.9
usage: version.py [-h] version1 {lt,le,eq,ne,ge,gt,lt-nl,le-nl,ge-nl,gt-nl,<,<<,<=,=,>=,>>,>} version2
version.py: error: argument version1: invalid Version value: 'non-version'
$ echo $?
2
```