### PR TITLE
Work around platform.python_version() returning non PEP 440 compliant version for non-tagged Python builds

### DIFF
--- a/src/packaging/markers.py
+++ b/src/packaging/markers.py
@@ -309,6 +309,12 @@ class Marker:
         """
         current_environment = cast("dict[str, str]", default_environment())
         current_environment["extra"] = ""
+        # Work around platform.python_version() returning something that is not PEP 440
+        # compliant for non-tagged Python builds. We preserve default_environment()'s
+        # behavior of returning platform.python_version() verbatim, and leave it to the
+        # caller to provide a syntactically valid version if they want to override it.
+        if current_environment["python_full_version"].endswith("+"):
+            current_environment["python_full_version"] += "local"
         if environment is not None:
             current_environment.update(environment)
             # The API used to allow setting extra to None. We need to handle this

--- a/tests/test_markers.py
+++ b/tests/test_markers.py
@@ -8,6 +8,7 @@ import os
 import platform
 import sys
 from typing import cast
+from unittest import mock
 
 import pytest
 
@@ -19,6 +20,7 @@ from packaging.markers import (
     default_environment,
     format_full_version,
 )
+from packaging.version import InvalidVersion
 
 VARIABLES = [
     "extra",
@@ -384,3 +386,14 @@ class TestMarker:
 
         assert str(Marker(lhs)) == f'"{normalized_name}" == extra'
         assert str(Marker(rhs)) == f'extra == "{normalized_name}"'
+
+    def test_python_full_version_untagged_user_provided(self):
+        """A user-provider python_full_version ending with a + fails to parse."""
+        with pytest.raises(InvalidVersion):
+            Marker("python_full_version < '3.12'").evaluate(
+                {"python_full_version": "3.11.1+"}
+            )
+
+    def test_python_full_version_untagged(self):
+        with mock.patch("platform.python_version", return_value="3.11.1+"):
+            assert Marker("python_full_version < '3.12'").evaluate()

--- a/tests/test_markers.py
+++ b/tests/test_markers.py
@@ -388,7 +388,7 @@ class TestMarker:
         assert str(Marker(rhs)) == f'extra == "{normalized_name}"'
 
     def test_python_full_version_untagged_user_provided(self):
-        """A user-provider python_full_version ending with a + fails to parse."""
+        """A user-provided python_full_version ending with a + fails to parse."""
         with pytest.raises(InvalidVersion):
             Marker("python_full_version < '3.12'").evaluate(
                 {"python_full_version": "3.11.1+"}


### PR DESCRIPTION
Fixes #678 

Since #678 will make things difficult for pip 24.1 users using non-tagged python builds, I'm proposing this solution.

We could also work around it in pip but this would be messier and would not solve the problem for `packaging` users.

CPython could also be changed, but it is likely more complex to achieve and probably not doable for older CPython versions.
