### PR TITLE
Add monthly downloads badge to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,10 @@
 packaging
 =========
 
+.. image:: https://assets.piptrends.com/get-last-month-downloads-badge/packaging.svg
+    :alt: packaging Downloads Last Month by pip Trends
+    :target: https://piptrends.com/package/packaging
+
 .. start-intro
 
 Reusable core utilities for various Python Packaging


### PR DESCRIPTION
Added a badge to the README that shows the package's monthly download counts. View more at - https://piptrends.com/widgets/packaging