### PR TITLE
Reuse SPDX license ids in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,8 +13,8 @@ authors = [{name = "Donald Stufft", email = "donald@stufft.io"}]
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",
-  "License :: OSI Approved :: Apache Software License",
-  "License :: OSI Approved :: BSD License",
+  "License :: OSI Approved :: Apache-2.0",
+  "License :: OSI Approved :: BSD-2-Clause",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3 :: Only",


### PR DESCRIPTION
[ORT](https://github.com/oss-review-toolkit/ort) searchs for license classifiers in `pyproject.toml`, and it will throw a license violation if the license is not found or it is umapped. 

For pypa:packaging, the license `BSD License` is umapped. To avoid umbiguity, I am suggesting to replace both license classifiers to SPDX ids.