### PR TITLE
markers: Consistently fallback to Python comparison rules

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,10 @@ Changelog
 *unreleased*
 ~~~~~~~~~~~~
 
-No unreleased changes.
+* Consistently fallback to Python string comparison behaviour when evaluating
+  a marker where there is no PEP 440 defined behaviour, notably when the right
+  side has PEP 440 defined semantics, but the left side is an invalid
+  version (:issue:`774`)
 
 24.1 - 2024-06-10
 ~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
In the dependency specifiers specification (originally PEP 508), when there is no PEP 440 defined behaviour for evaluating a marker because one or both sides are not valid versions [specifiers], [a fallback to Python comparison behaviour is mandated](https://packaging.python.org/en/latest/specifications/dependency-specifiers/#environment-markers):

> The <marker_op> operators that are not in <version_cmp> perform the same as they do for strings in Python. The <version_cmp> operators use the version comparison rules of the Version specifier specification when those are defined (that is when both sides have a valid version specifier). If there is no defined behaviour of this specification and the operator exists in Python, then the operator falls back to the Python behaviour. Otherwise an error should be raised.

However, this fallback has been broken for a while. When the right side has PEP 440 defined semantics (being a valid specifier), but the left side is an invalid version, an InvalidVersion error is raised.

This patch suppresses said InvalidVersion error and fallbacks as expected.

```python
>>> from packaging.markers import Marker
>>> m = Marker('platform_release >= "20.0"')
>>> m.evaluate({'platform_release': '6.7.0-gentoo'})
True
```

Fixes #774. Ref pypa/pip#12825.