### PR TITLE
Use `typing.NamedTuple` instead of `collections.namedtuple`

### DIFF
--- a/tests/test_markers.py
+++ b/tests/test_markers.py
@@ -2,12 +2,11 @@
 # 2.0, and the BSD License. See the LICENSE file in the root of this repository
 # for complete details.
 
-import collections
 import itertools
 import os
 import platform
 import sys
-from typing import cast
+from typing import NamedTuple, cast
 from unittest import mock
 
 import pytest
@@ -94,7 +93,7 @@ class TestOperatorEvaluation:
         )
 
 
-FakeVersionInfo = collections.namedtuple(
+FakeVersionInfo = NamedTuple(
     "FakeVersionInfo", ["major", "minor", "micro", "releaselevel", "serial"]
 )
 

--- a/tests/test_musllinux.py
+++ b/tests/test_musllinux.py
@@ -1,6 +1,6 @@
-import collections
 import pathlib
 import subprocess
+from typing import NamedTuple
 
 import pretend
 import pytest
@@ -60,7 +60,7 @@ def test_parse_musl_version(output, version):
 )
 def test_get_musl_version(monkeypatch, executable, output, version, ld_musl):
     def mock_run(*args, **kwargs):
-        return collections.namedtuple("Proc", "stderr")(output)
+        return NamedTuple("Proc", "stderr")(output)
 
     run_recorder = pretend.call_recorder(mock_run)
     monkeypatch.setattr(_musllinux.subprocess, "run", run_recorder)


### PR DESCRIPTION
Inheriting from `typing.NamedTuple` creates a custom `tuple` subclass in the same way as using the `collections.namedtuple` factory function. However, using `typing.NamedTuple` allows you to provide a type annotation for each field in the class.