### PR TITLE
Add a changelog entry for dropping Python 3.7 support

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -38,6 +38,7 @@ No unreleased changes.
 * Make ``utils.parse_sdist_filename()`` and ``utils.parse_wheel_filename()``
   raise ``InvalidSdistFilename`` and ``InvalidWheelFilename``, respectively,
   when the version component of the name is invalid
+* Remove support for Python 3.7 (:issue:`783`)
 
 23.1 - 2023-04-12
 ~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Python 3.7 support was dropped in https://github.com/pypa/packaging/pull/783 but never documented, whereas e.g. 22.0 documents the dropping of Python 3.6 support.

A few of us still have to run Python 3.7 in a few places (😢) and it's helpful to have the dropped versions be explicitly documented.