### PR TITLE
Patch python_full_version unconditionally

### DIFF
--- a/src/packaging/markers.py
+++ b/src/packaging/markers.py
@@ -309,12 +309,7 @@ class Marker:
         """
         current_environment = cast("dict[str, str]", default_environment())
         current_environment["extra"] = ""
-        # Work around platform.python_version() returning something that is not PEP 440
-        # compliant for non-tagged Python builds. We preserve default_environment()'s
-        # behavior of returning platform.python_version() verbatim, and leave it to the
-        # caller to provide a syntactically valid version if they want to override it.
-        if current_environment["python_full_version"].endswith("+"):
-            current_environment["python_full_version"] += "local"
+        _repair_python_full_version(current_environment)
         if environment is not None:
             current_environment.update(environment)
             # The API used to allow setting extra to None. We need to handle this
@@ -323,3 +318,15 @@ class Marker:
                 current_environment["extra"] = ""
 
         return _evaluate_markers(self._markers, current_environment)
+
+
+def _repair_python_full_version(env: dict[str, str]) -> dict[str, str]:
+    """
+    Work around platform.python_version() returning something that is not PEP 440
+    compliant for non-tagged Python builds. Preserve default_environment()'s
+    behavior of returning platform.python_version() verbatim, and leave it to the
+    caller to provide a syntactically valid version if they want to override it.
+    """
+    if env["python_full_version"].endswith("+"):
+        env["python_full_version"] += "local"
+    return env

--- a/src/packaging/markers.py
+++ b/src/packaging/markers.py
@@ -309,7 +309,6 @@ class Marker:
         """
         current_environment = cast("dict[str, str]", default_environment())
         current_environment["extra"] = ""
-        _repair_python_full_version(current_environment)
         if environment is not None:
             current_environment.update(environment)
             # The API used to allow setting extra to None. We need to handle this
@@ -317,15 +316,15 @@ class Marker:
             if current_environment["extra"] is None:
                 current_environment["extra"] = ""
 
-        return _evaluate_markers(self._markers, current_environment)
+        return _evaluate_markers(
+            self._markers, _repair_python_full_version(current_environment)
+        )
 
 
 def _repair_python_full_version(env: dict[str, str]) -> dict[str, str]:
     """
     Work around platform.python_version() returning something that is not PEP 440
-    compliant for non-tagged Python builds. Preserve default_environment()'s
-    behavior of returning platform.python_version() verbatim, and leave it to the
-    caller to provide a syntactically valid version if they want to override it.
+    compliant for non-tagged Python builds.
     """
     if env["python_full_version"].endswith("+"):
         env["python_full_version"] += "local"

--- a/tests/test_markers.py
+++ b/tests/test_markers.py
@@ -20,7 +20,6 @@ from packaging.markers import (
     default_environment,
     format_full_version,
 )
-from packaging.version import InvalidVersion
 
 VARIABLES = [
     "extra",
@@ -391,11 +390,10 @@ class TestMarker:
         assert str(Marker(rhs)) == f'extra == "{normalized_name}"'
 
     def test_python_full_version_untagged_user_provided(self):
-        """A user-provided python_full_version ending with a + fails to parse."""
-        with pytest.raises(InvalidVersion):
-            Marker("python_full_version < '3.12'").evaluate(
-                {"python_full_version": "3.11.1+"}
-            )
+        """A user-provided python_full_version ending with a + is also repaired."""
+        assert Marker("python_full_version < '3.12'").evaluate(
+            {"python_full_version": "3.11.1+"}
+        )
 
     def test_python_full_version_untagged(self):
         with mock.patch("platform.python_version", return_value="3.11.1+"):


### PR DESCRIPTION
Closes #678 .  Reprise of #802.

- **Extract a method for repairing the python_full_version.**
- **Repair the version even if passed in.**
- **Update test to reflect the new expectation.**
