### PR TITLE
Fix uninformative error message

### DIFF
--- a/src/packaging/metadata.py
+++ b/src/packaging/metadata.py
@@ -589,10 +589,12 @@ class _Validator(Generic[T]):
         for dynamic_field in map(str.lower, value):
             if dynamic_field in {"name", "version", "metadata-version"}:
                 raise self._invalid_metadata(
-                    f"{value!r} is not allowed as a dynamic field"
+                    f"{dynamic_field!r} is not allowed as a dynamic field"
                 )
             elif dynamic_field not in _EMAIL_TO_RAW_MAPPING:
-                raise self._invalid_metadata(f"{value!r} is not a valid dynamic field")
+                raise self._invalid_metadata(
+                    f"{dynamic_field!r} is not a valid dynamic field"
+                )
         return list(map(str.lower, value))
 
     def _process_provides_extra(

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -608,8 +608,12 @@ class TestMetadata:
     def test_disallowed_dynamic(self, field_name):
         meta = metadata.Metadata.from_raw({"dynamic": [field_name]}, validate=False)
 
-        with pytest.raises(metadata.InvalidMetadata):
+        message = f"{field_name!r} is not allowed"
+        with pytest.raises(metadata.InvalidMetadata, match=message) as execinfo:
             meta.dynamic  # noqa: B018
+            # The name of the specific offending field should be used,
+            # not a list with all fields:
+            assert "[" not in str(execinfo.value)
 
     @pytest.mark.parametrize(
         "field_name",


### PR DESCRIPTION
It seems that there was an easy oversight when implementing the error message for invalid dynamic fields.

Right now, it shows the name of all fields that are listed (including the valid ones), instead of showing only the name of the invalid field.

For example, exception looks like the following:

> packaging.metadata.InvalidMetadata: ['author', 'author-email', 'classifier', 'description', 'description-content-type', 'download-url', 'home-page', 'keywords', 'license', 'license-file', 'maintainer', 'maintainer-email', 'obsoletes', 'platform', 'project-url', 'provides', 'provides-extra', 'requires', 'requires-dist', 'requires-python', 'summary'] is not a valid dynamic field

... which is not very great, because it lets to the user the work of figuring out which one of these fields is invalid..

A better error message (which I believe to be the original intent) would be:

> packaging.metadata.InvalidMetadata: 'license-file' is not a valid dynamic field