### PR TITLE
Add support for PEP 730 iOS tags.

### DIFF
--- a/docs/tags.rst
+++ b/docs/tags.rst
@@ -153,6 +153,21 @@ to the implementation to provide.
           compatibility
 
 
+.. function:: ios_platforms(version=None, multiarch=None)
+
+    Yields the :attr:`~Tag.platform` tags for iOS.
+
+    :param tuple version: A two-item tuple representing the version of iOS.
+                          Defaults to the current system's version.
+    :param str multiarch: The CPU architecture+ABI to be used. This should be in
+                          the format by ``sys.implementation._multiarch`` (e.g.,
+                          ``arm64_iphoneos`` or ``x84_64_iphonesimulator``).
+                          Defaults to the current system's multiarch value.
+
+    .. note::
+        Behavior of this method is undefined if invoked on non-iOS platforms
+        without providing explicit version and multiarch arguments.
+
 .. function:: platform_tags(version=None, arch=None)
 
     Yields the :attr:`~Tag.platform` tags for the running interpreter.

--- a/src/packaging/tags.py
+++ b/src/packaging/tags.py
@@ -513,8 +513,8 @@ def ios_platforms(
 
     # Consider the actual X.Y version that was requested.
     yield ios_platform_template.format(
-            major=version[0], minor=version[1], multiarch=multiarch
-        )
+        major=version[0], minor=version[1], multiarch=multiarch
+    )
 
     # Consider every minor version from X.0 to the minor version prior to the
     # version requested by the platform.

--- a/src/packaging/tags.py
+++ b/src/packaging/tags.py
@@ -487,7 +487,10 @@ def ios_platforms(
         multiarch value.
     """
     if version is None:
-        _, release, _, _ = platform.ios_ver()
+        # if iOS is the current platform, ios_ver *must* be defined. However,
+        # it won't exist for CPython versions before 3.13, which causes a mypy
+        # error.
+        _, release, _, _ = platform.ios_ver()  # type: ignore[attr-defined]
         version = cast("AppleVersion", tuple(map(int, release.split(".")[:2])))
 
     if multiarch is None:

--- a/src/packaging/tags.py
+++ b/src/packaging/tags.py
@@ -499,30 +499,35 @@ def ios_platforms(
 
     ios_platform_template = "ios_{major}_{minor}_{multiarch}"
 
-    # Consider any major.minor version from iOS 12.0 to the version prior to the
-    # version requested by platform. 12.0 is the first iOS version that is known
-    # to have enough features to support CPython. Consider every possible minor
-    # release up to X.9. There highest the minor has ever gone is 8 (14.8 and
-    # 15.8) but having some extra candidates that won't ever match doesn't
-    # really hurt, and it saves us from having to keep an explicit list of known
-    # iOS versions in the code.
-    for major in range(12, version[0]):
-        for minor in range(0, 10):
-            yield ios_platform_template.format(
-                major=major, minor=minor, multiarch=multiarch
-            )
+    # Consider any iOS major.minor version from the version requested, down to
+    # 12.0. 12.0 is the first iOS version that is known to have enough features
+    # to support CPython. Consider every possible minor release up to X.9. There
+    # highest the minor has ever gone is 8 (14.8 and 15.8) but having some extra
+    # candidates that won't ever match doesn't really hurt, and it saves us from
+    # having to keep an explicit list of known iOS versions in the code. Return
+    # the results descending order of version number.
+
+    # If the requested major version is less than 12, there won't be any matches.
+    if version[0] < 12:
+        return
+
+    # Consider the actual X.Y version that was requested.
+    yield ios_platform_template.format(
+            major=version[0], minor=version[1], multiarch=multiarch
+        )
 
     # Consider every minor version from X.0 to the minor version prior to the
     # version requested by the platform.
-    for minor in range(0, version[1]):
+    for minor in range(version[1] - 1, -1, -1):
         yield ios_platform_template.format(
             major=version[0], minor=minor, multiarch=multiarch
         )
 
-    # Consider the actual X.Y version that was requested.
-    yield ios_platform_template.format(
-        major=version[0], minor=version[1], multiarch=multiarch
-    )
+    for major in range(version[0] - 1, 11, -1):
+        for minor in range(9, -1, -1):
+            yield ios_platform_template.format(
+                major=major, minor=minor, multiarch=multiarch
+            )
 
 
 def _linux_platforms(is_32bit: bool = _32_BIT_INTERPRETER) -> Iterator[str]:

--- a/src/packaging/tags.py
+++ b/src/packaging/tags.py
@@ -25,7 +25,7 @@ from . import _manylinux, _musllinux
 logger = logging.getLogger(__name__)
 
 PythonVersion = Sequence[int]
-MacVersion = Tuple[int, int]
+AppleVersion = Tuple[int, int]
 
 INTERPRETER_SHORT_NAMES: dict[str, str] = {
     "python": "py",  # Generic.
@@ -362,7 +362,7 @@ def _mac_arch(arch: str, is_32bit: bool = _32_BIT_INTERPRETER) -> str:
     return "i386"
 
 
-def _mac_binary_formats(version: MacVersion, cpu_arch: str) -> list[str]:
+def _mac_binary_formats(version: AppleVersion, cpu_arch: str) -> list[str]:
     formats = [cpu_arch]
     if cpu_arch == "x86_64":
         if version < (10, 4):
@@ -395,7 +395,7 @@ def _mac_binary_formats(version: MacVersion, cpu_arch: str) -> list[str]:
 
 
 def mac_platforms(
-    version: MacVersion | None = None, arch: str | None = None
+    version: AppleVersion | None = None, arch: str | None = None
 ) -> Iterator[str]:
     """
     Yields the platform tags for a macOS system.
@@ -407,7 +407,7 @@ def mac_platforms(
     """
     version_str, _, cpu_arch = platform.mac_ver()
     if version is None:
-        version = cast("MacVersion", tuple(map(int, version_str.split(".")[:2])))
+        version = cast("AppleVersion", tuple(map(int, version_str.split(".")[:2])))
         if version == (10, 16):
             # When built against an older macOS SDK, Python will report macOS 10.16
             # instead of the real version.
@@ -423,7 +423,7 @@ def mac_platforms(
                 stdout=subprocess.PIPE,
                 text=True,
             ).stdout
-            version = cast("MacVersion", tuple(map(int, version_str.split(".")[:2])))
+            version = cast("AppleVersion", tuple(map(int, version_str.split(".")[:2])))
     else:
         version = version
     if arch is None:
@@ -473,6 +473,54 @@ def mac_platforms(
                 yield f"macosx_{major_version}_{minor_version}_{binary_format}"
 
 
+def ios_platforms(
+    version: AppleVersion | None = None, multiarch: str | None = None
+) -> Iterator[str]:
+    """
+    Yields the platform tags for an iOS system.
+
+    :param version: A two-item tuple specifying the iOS version to generate
+        platform tags for. Defaults to the current iOS version.
+    :param multiarch: The CPU architecture+ABI to generate platform tags for -
+        (the value used by `sys.implementation._multiarch` e.g.,
+        `arm64_iphoneos` or `x84_64_iphonesimulator`). Defaults to the current
+        multiarch value.
+    """
+    if version is None:
+        _, release, _, _ = platform.ios_ver()
+        version = cast("AppleVersion", tuple(map(int, release.split(".")[:2])))
+
+    if multiarch is None:
+        multiarch = sys.implementation._multiarch
+
+    ios_platform_template = "ios_{major}_{minor}_{multiarch}"
+
+    # Consider any major.minor version from iOS 12.0 to the version prior to the
+    # version requested by platform. 12.0 is the first iOS version that is known
+    # to have enough features to support CPython. Consider every possible minor
+    # release up to X.9. There highest the minor has ever gone is 8 (14.8 and
+    # 15.8) but having some extra candidates that won't ever match doesn't
+    # really hurt, and it saves us from having to keep an explicit list of known
+    # iOS versions in the code.
+    for major in range(12, version[0]):
+        for minor in range(0, 10):
+            yield ios_platform_template.format(
+                major=major, minor=minor, multiarch=multiarch
+            )
+
+    # Consider every minor version from X.0 to the minor version prior to the
+    # version requested by the platform.
+    for minor in range(0, version[1]):
+        yield ios_platform_template.format(
+            major=version[0], minor=minor, multiarch=multiarch
+        )
+
+    # Consider the actual X.Y version that was requested.
+    yield ios_platform_template.format(
+        major=version[0], minor=version[1], multiarch=multiarch
+    )
+
+
 def _linux_platforms(is_32bit: bool = _32_BIT_INTERPRETER) -> Iterator[str]:
     linux = _normalize_string(sysconfig.get_platform())
     if not linux.startswith("linux_"):
@@ -502,6 +550,8 @@ def platform_tags() -> Iterator[str]:
     """
     if platform.system() == "Darwin":
         return mac_platforms()
+    if platform.system() == "iOS":
+        return ios_platforms()
     elif platform.system() == "Linux":
         return _linux_platforms()
     else:

--- a/src/packaging/tags.py
+++ b/src/packaging/tags.py
@@ -553,7 +553,7 @@ def platform_tags() -> Iterator[str]:
     """
     if platform.system() == "Darwin":
         return mac_platforms()
-    if platform.system() == "iOS":
+    elif platform.system() == "iOS":
         return ios_platforms()
     elif platform.system() == "Linux":
         return _linux_platforms()

--- a/src/packaging/tags.py
+++ b/src/packaging/tags.py
@@ -495,6 +495,7 @@ def ios_platforms(
 
     if multiarch is None:
         multiarch = sys.implementation._multiarch
+    multiarch = multiarch.replace("-", "_")
 
     ios_platform_template = "ios_{major}_{minor}_{multiarch}"
 

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -59,8 +59,13 @@ def mock_ios(monkeypatch):
     monkeypatch.setattr(sys, "platform", "ios")
 
     # Mock a fake architecture that will fit the expected pattern, but
-    # wont actually be a legal multiarch
-    monkeypatch.setattr(sys.implementation, "_multiarch", "gothic-iphoneos")
+    # wont actually be a legal multiarch.
+    monkeypatch.setattr(
+        sys.implementation,
+        "_multiarch",
+        "gothic-iphoneos",
+        raising=False,
+    )
 
     # Mock the return value of platform.ios_ver.
     def mock_ios_ver(*args):

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -60,7 +60,7 @@ def mock_ios(monkeypatch):
 
     # Mock a fake architecture that will fit the expected pattern, but
     # wont actually be a legal multiarch
-    monkeypatch.setattr(sys.implementation, "_multiarch", "gothic_iphoneos")
+    monkeypatch.setattr(sys.implementation, "_multiarch", "gothic-iphoneos")
 
     # Mock the return value of platform.ios_ver.
     def mock_ios_ver(*args):
@@ -356,7 +356,7 @@ class TestMacOSPlatforms:
 
 class TestIOSPlatforms:
     def test_version_detection(self, mock_ios):
-        platforms = list(tags.ios_platforms(multiarch="arm64_iphoneos"))
+        platforms = list(tags.ios_platforms(multiarch="arm64-iphoneos"))
         assert platforms == [
             "ios_12_0_arm64_iphoneos",
             "ios_12_1_arm64_iphoneos",
@@ -378,10 +378,10 @@ class TestIOSPlatforms:
         assert platforms == ["ios_12_0_gothic_iphoneos"]
 
     def test_ios_platforms(self, mock_ios):
-        platforms = list(tags.ios_platforms((12, 0), "arm64_iphoneos"))
+        platforms = list(tags.ios_platforms((12, 0), "arm64-iphoneos"))
         assert platforms == ["ios_12_0_arm64_iphoneos"]
 
-        platforms = list(tags.ios_platforms((13, 0), "x86_64_iphonesimulator"))
+        platforms = list(tags.ios_platforms((13, 0), "x86_64-iphonesimulator"))
         assert platforms == [
             "ios_12_0_x86_64_iphonesimulator",
             "ios_12_1_x86_64_iphonesimulator",
@@ -396,7 +396,7 @@ class TestIOSPlatforms:
             "ios_13_0_x86_64_iphonesimulator",
         ]
 
-        platforms = list(tags.ios_platforms((14, 3), "arm64_iphoneos"))
+        platforms = list(tags.ios_platforms((14, 3), "arm64-iphoneos"))
         assert platforms == [
             "ios_12_0_arm64_iphoneos",
             "ios_12_1_arm64_iphoneos",

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -363,19 +363,19 @@ class TestIOSPlatforms:
     def test_version_detection(self, mock_ios):
         platforms = list(tags.ios_platforms(multiarch="arm64-iphoneos"))
         assert platforms == [
-            "ios_12_0_arm64_iphoneos",
-            "ios_12_1_arm64_iphoneos",
-            "ios_12_2_arm64_iphoneos",
-            "ios_12_3_arm64_iphoneos",
-            "ios_12_4_arm64_iphoneos",
-            "ios_12_5_arm64_iphoneos",
-            "ios_12_6_arm64_iphoneos",
-            "ios_12_7_arm64_iphoneos",
-            "ios_12_8_arm64_iphoneos",
-            "ios_12_9_arm64_iphoneos",
-            "ios_13_0_arm64_iphoneos",
-            "ios_13_1_arm64_iphoneos",
             "ios_13_2_arm64_iphoneos",
+            "ios_13_1_arm64_iphoneos",
+            "ios_13_0_arm64_iphoneos",
+            "ios_12_9_arm64_iphoneos",
+            "ios_12_8_arm64_iphoneos",
+            "ios_12_7_arm64_iphoneos",
+            "ios_12_6_arm64_iphoneos",
+            "ios_12_5_arm64_iphoneos",
+            "ios_12_4_arm64_iphoneos",
+            "ios_12_3_arm64_iphoneos",
+            "ios_12_2_arm64_iphoneos",
+            "ios_12_1_arm64_iphoneos",
+            "ios_12_0_arm64_iphoneos",
         ]
 
     def test_multiarch_detection(self, mock_ios):
@@ -383,50 +383,57 @@ class TestIOSPlatforms:
         assert platforms == ["ios_12_0_gothic_iphoneos"]
 
     def test_ios_platforms(self, mock_ios):
+        # Pre-iOS 12.0 releases won't match anything
+        platforms = list(tags.ios_platforms((7, 0), "arm64-iphoneos"))
+        assert platforms == []
+
+        # iOS 12.0 returns exactly 1 match
         platforms = list(tags.ios_platforms((12, 0), "arm64-iphoneos"))
         assert platforms == ["ios_12_0_arm64_iphoneos"]
 
+        # iOS 13.0 returns a match for 13.0, plus every 12.X
         platforms = list(tags.ios_platforms((13, 0), "x86_64-iphonesimulator"))
         assert platforms == [
-            "ios_12_0_x86_64_iphonesimulator",
-            "ios_12_1_x86_64_iphonesimulator",
-            "ios_12_2_x86_64_iphonesimulator",
-            "ios_12_3_x86_64_iphonesimulator",
-            "ios_12_4_x86_64_iphonesimulator",
-            "ios_12_5_x86_64_iphonesimulator",
-            "ios_12_6_x86_64_iphonesimulator",
-            "ios_12_7_x86_64_iphonesimulator",
-            "ios_12_8_x86_64_iphonesimulator",
-            "ios_12_9_x86_64_iphonesimulator",
             "ios_13_0_x86_64_iphonesimulator",
+            "ios_12_9_x86_64_iphonesimulator",
+            "ios_12_8_x86_64_iphonesimulator",
+            "ios_12_7_x86_64_iphonesimulator",
+            "ios_12_6_x86_64_iphonesimulator",
+            "ios_12_5_x86_64_iphonesimulator",
+            "ios_12_4_x86_64_iphonesimulator",
+            "ios_12_3_x86_64_iphonesimulator",
+            "ios_12_2_x86_64_iphonesimulator",
+            "ios_12_1_x86_64_iphonesimulator",
+            "ios_12_0_x86_64_iphonesimulator",
         ]
 
+        # iOS 14.3 returns a match for 14.3-14.0, plus every 13.X and every 12.X
         platforms = list(tags.ios_platforms((14, 3), "arm64-iphoneos"))
         assert platforms == [
-            "ios_12_0_arm64_iphoneos",
-            "ios_12_1_arm64_iphoneos",
-            "ios_12_2_arm64_iphoneos",
-            "ios_12_3_arm64_iphoneos",
-            "ios_12_4_arm64_iphoneos",
-            "ios_12_5_arm64_iphoneos",
-            "ios_12_6_arm64_iphoneos",
-            "ios_12_7_arm64_iphoneos",
-            "ios_12_8_arm64_iphoneos",
-            "ios_12_9_arm64_iphoneos",
-            "ios_13_0_arm64_iphoneos",
-            "ios_13_1_arm64_iphoneos",
-            "ios_13_2_arm64_iphoneos",
-            "ios_13_3_arm64_iphoneos",
-            "ios_13_4_arm64_iphoneos",
-            "ios_13_5_arm64_iphoneos",
-            "ios_13_6_arm64_iphoneos",
-            "ios_13_7_arm64_iphoneos",
-            "ios_13_8_arm64_iphoneos",
-            "ios_13_9_arm64_iphoneos",
-            "ios_14_0_arm64_iphoneos",
-            "ios_14_1_arm64_iphoneos",
-            "ios_14_2_arm64_iphoneos",
             "ios_14_3_arm64_iphoneos",
+            "ios_14_2_arm64_iphoneos",
+            "ios_14_1_arm64_iphoneos",
+            "ios_14_0_arm64_iphoneos",
+            "ios_13_9_arm64_iphoneos",
+            "ios_13_8_arm64_iphoneos",
+            "ios_13_7_arm64_iphoneos",
+            "ios_13_6_arm64_iphoneos",
+            "ios_13_5_arm64_iphoneos",
+            "ios_13_4_arm64_iphoneos",
+            "ios_13_3_arm64_iphoneos",
+            "ios_13_2_arm64_iphoneos",
+            "ios_13_1_arm64_iphoneos",
+            "ios_13_0_arm64_iphoneos",
+            "ios_12_9_arm64_iphoneos",
+            "ios_12_8_arm64_iphoneos",
+            "ios_12_7_arm64_iphoneos",
+            "ios_12_6_arm64_iphoneos",
+            "ios_12_5_arm64_iphoneos",
+            "ios_12_4_arm64_iphoneos",
+            "ios_12_3_arm64_iphoneos",
+            "ios_12_2_arm64_iphoneos",
+            "ios_12_1_arm64_iphoneos",
+            "ios_12_0_arm64_iphoneos",
         ]
 
 


### PR DESCRIPTION
[PEP 730](https://peps.python.org/pep-0730/) adds support for iOS as a supported platform. This PR adds support for determining the platform tags compatible with the current iOS installation.

iOS version support is similar to macOS; if the current platform specifies a version of X.Y, any wheel tagged with a binary version <= X.Y should be compatible. This PR uses 12.0 as the minimum possible iOS version tag to check, as that is the oldest version that is known to have sufficient features to run CPython. 

It will check every possible minor version X.0 - X.9; this does result in iOS minor versions that don't exist (e.g., there was no version 12.6-12.9). Having *only* legal versions would require constant updating of the source; having an extra few tags should only a represent a minor overhead when evaluating candidate wheels, and there's never been an iOS version with a minor > 8 (14.8 and 15.8).