### PR TITLE
Lazily evaluate markers to mitigate non-PEP 440 version errors

### DIFF
--- a/tests/test_markers.py
+++ b/tests/test_markers.py
@@ -317,6 +317,11 @@ class TestMarker:
                 {"extra": "different__punctuation_is_EQUAL"},
                 True,
             ),
+            (
+                "sys_platform == 'foo_os' and platform_release >= '4.5.6'",
+                {"sys_platform": "bar_os", "platform_release": "1.2.3-invalid"},
+                False,
+            )
         ],
     )
     def test_evaluates(self, marker_string, environment, expected):


### PR DESCRIPTION
Mitigation for pypa/packaging#774.

Some packages define markers in an order where short-circuiting the "and" expressions can skip the problematic version comparisons.

This PR changes the marker evaluation to be lazy so that the marker expressions not affecting the outcome are not evaluated.