### PR TITLE
chore: speed up mypy a little

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
       - id: mypy
         exclude: '^(docs|tasks|tests)|setup\.py'
         args: []
-        additional_dependencies: [pyparsing, nox]
+        additional_dependencies: [pyparsing, nox, orjson]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.11.8

--- a/src/packaging/version.py
+++ b/src/packaging/version.py
@@ -494,7 +494,6 @@ def _parse_letter_version(
 
         return letter, int(number)
 
-    assert not letter
     if number:
         # We assume if we are given a number, but we are not given a letter
         # then this is using the implicit post release syntax (e.g. 1.0-1)


### PR DESCRIPTION
Bumps things like Ruff and MyPy and applied the simplest (minimal change) fixes for the issues. Longer term, asserts could remove some of the type ignores.
