### PR TITLE
Use !r formatter for error messages with filenames.

### DIFF
--- a/src/packaging/utils.py
+++ b/src/packaging/utils.py
@@ -96,28 +96,28 @@ def parse_wheel_filename(
 ) -> tuple[NormalizedName, Version, BuildTag, frozenset[Tag]]:
     if not filename.endswith(".whl"):
         raise InvalidWheelFilename(
-            f"Invalid wheel filename (extension must be '.whl'): {filename}"
+            f"Invalid wheel filename (extension must be '.whl'): {filename!r}"
         )
 
     filename = filename[:-4]
     dashes = filename.count("-")
     if dashes not in (4, 5):
         raise InvalidWheelFilename(
-            f"Invalid wheel filename (wrong number of parts): {filename}"
+            f"Invalid wheel filename (wrong number of parts): {filename!r}"
         )
 
     parts = filename.split("-", dashes - 2)
     name_part = parts[0]
     # See PEP 427 for the rules on escaping the project name.
     if "__" in name_part or re.match(r"^[\w\d._]*$", name_part, re.UNICODE) is None:
-        raise InvalidWheelFilename(f"Invalid project name: {filename}")
+        raise InvalidWheelFilename(f"Invalid project name: {filename!r}")
     name = canonicalize_name(name_part)
 
     try:
         version = Version(parts[1])
     except InvalidVersion as e:
         raise InvalidWheelFilename(
-            f"Invalid wheel filename (invalid version): {filename}"
+            f"Invalid wheel filename (invalid version): {filename!r}"
         ) from e
 
     if dashes == 5:
@@ -125,7 +125,7 @@ def parse_wheel_filename(
         build_match = _build_tag_regex.match(build_part)
         if build_match is None:
             raise InvalidWheelFilename(
-                f"Invalid build number: {build_part} in '{filename}'"
+                f"Invalid build number: {build_part} in '{filename!r}'"
             )
         build = cast(BuildTag, (int(build_match.group(1)), build_match.group(2)))
     else:
@@ -142,14 +142,14 @@ def parse_sdist_filename(filename: str) -> tuple[NormalizedName, Version]:
     else:
         raise InvalidSdistFilename(
             f"Invalid sdist filename (extension must be '.tar.gz' or '.zip'):"
-            f" {filename}"
+            f" {filename!r}"
         )
 
     # We are requiring a PEP 440 version, which cannot contain dashes,
     # so we split on the last dash.
     name_part, sep, version_part = file_stem.rpartition("-")
     if not sep:
-        raise InvalidSdistFilename(f"Invalid sdist filename: {filename}")
+        raise InvalidSdistFilename(f"Invalid sdist filename: {filename!r}")
 
     name = canonicalize_name(name_part)
 
@@ -157,7 +157,7 @@ def parse_sdist_filename(filename: str) -> tuple[NormalizedName, Version]:
         version = Version(version_part)
     except InvalidVersion as e:
         raise InvalidSdistFilename(
-            f"Invalid sdist filename (invalid version): {filename}"
+            f"Invalid sdist filename (invalid version): {filename!r}"
         ) from e
 
     return (name, version)


### PR DESCRIPTION
Because I've been tracking an empty filename for some time, and it took me a while to realise it was just here in my logs invisible.

So adding !r everywhere, so that at least there is a pair of quotes.