### PR TITLE
feat: pyproject-metadata

### DIFF
--- a/src/packaging/_pyproject.py
+++ b/src/packaging/_pyproject.py
@@ -1,0 +1,445 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+
+from __future__ import annotations
+
+import dataclasses
+import pathlib
+import re
+import typing
+
+import packaging.requirements
+
+from .errors import ErrorCollector
+
+if typing.TYPE_CHECKING:
+    from collections.abc import Generator, Iterable, Sequence
+
+    from .project_table import ContactTable, Dynamic, ProjectTable
+    from .requirements import Requirement
+
+
+__all__ = [
+    "License",
+    "Readme",
+]
+
+
+def __dir__() -> list[str]:
+    return __all__
+
+
+@dataclasses.dataclass(frozen=True)
+class License:
+    """
+    This represents a classic license, which contains text, and optionally a
+    file path. Modern licenses are just SPDX identifiers, which are strings.
+    """
+
+    text: str
+    file: pathlib.Path | None
+
+
+@dataclasses.dataclass(frozen=True)
+class Readme:
+    """
+    This represents a readme, which contains text and a content type, and
+    optionally a file path.
+    """
+
+    text: str
+    file: pathlib.Path | None
+    content_type: str
+
+
+T = typing.TypeVar("T")
+
+
+@dataclasses.dataclass
+class PyProjectReader(ErrorCollector):
+    """Class for reading pyproject.toml fields with error collection.
+
+    Unrelated errors are collected and raised at once if the `collect_errors`
+    parameter is set to `True`. Some methods will return None if an error was
+    raised. Most of them expect a non-None value as input to enforce the caller
+    to handle missing vs. error correctly. The exact design is based on usage,
+    as this is an internal class.
+    """
+
+    def ensure_str(self, value: str, key: str) -> str | None:
+        """Ensure that a value is a string."""
+        if isinstance(value, str):
+            return value
+
+        msg = "Field {key} has an invalid type, expecting a string"
+        self.config_error(msg, key=key, got_type=type(value))
+        return None
+
+    def ensure_list(self, val: list[T], key: str) -> list[T] | None:
+        """Ensure that a value is a list of strings."""
+        if not isinstance(val, list):
+            msg = "Field {key} has an invalid type, expecting a list of strings"
+            self.config_error(msg, key=key, got_type=type(val))
+            return None
+        for item in val:
+            if not isinstance(item, str):
+                msg = "Field {key} contains item with invalid type, expecting a string"
+                self.config_error(msg, key=key, got_type=type(item))
+                return None
+
+        return val
+
+    def ensure_dict(self, val: dict[str, str], key: str) -> dict[str, str] | None:
+        """Ensure that a value is a dictionary of strings."""
+        if not isinstance(val, dict):
+            msg = "Field {key} has an invalid type, expecting a table of strings"
+            self.config_error(msg, key=key, got_type=type(val))
+            return None
+        for subkey, item in val.items():
+            if not isinstance(item, str):
+                msg = "Field {key} has an invalid type, expecting a string"
+                self.config_error(msg, key=f"{key}.{subkey}", got_type=type(item))
+                return None
+        return val
+
+    def ensure_people(
+        self, val: Sequence[ContactTable], key: str
+    ) -> list[tuple[str, str | None]]:
+        """Ensure that a value is a list of tables with optional "name" and "email" keys."""
+        if not isinstance(val, list):
+            msg = (
+                "Field {key} has an invalid type, expecting a list of "
+                'tables containing the "name" and/or "email" keys'
+            )
+            self.config_error(msg, key=key, got_type=type(val))
+            return []
+        for each in val:
+            if not isinstance(each, dict):
+                msg = (
+                    "Field {key} has an invalid type, expecting a list of "
+                    'tables containing the "name" and/or "email" keys'
+                    " (got list with {type_name})"
+                )
+                self.config_error(msg, key=key, type_name=type(each).__name__)
+                return []
+            for value in each.values():
+                if not isinstance(value, str):
+                    msg = (
+                        "Field {key} has an invalid type, expecting a list of "
+                        'tables containing the "name" and/or "email" keys'
+                        " (got list with dict with {type_name})"
+                    )
+                    self.config_error(msg, key=key, type_name=type(value).__name__)
+                    return []
+            extra_keys = set(each) - {"name", "email"}
+            if extra_keys:
+                msg = (
+                    "Field {key} has an invalid type, expecting a list of "
+                    'tables containing the "name" and/or "email" keys'
+                    " (got list with dict with extra keys {extra_keys})"
+                )
+                self.config_error(
+                    msg,
+                    key=key,
+                    extra_keys=", ".join(sorted(f'"{k}"' for k in extra_keys)),
+                )
+                return []
+        return [(entry.get("name", "Unknown"), entry.get("email")) for entry in val]
+
+    def get_license(
+        self, project: ProjectTable, project_dir: pathlib.Path
+    ) -> License | str | None:
+        """Get the license field from the project table. Handles PEP 639 style license too.
+
+        None is returned if the license field is not present or if an error occurred.
+        """
+        val = project.get("license")
+        if val is None:
+            return None
+        if isinstance(val, str):
+            return val
+
+        if isinstance(val, dict):
+            _license = self.ensure_dict(val, "project.license")  # type: ignore[arg-type]
+            if _license is None:
+                return None
+        else:
+            msg = "Field {key} has an invalid type, expecting a string or table of strings"
+            self.config_error(msg, key="project.license", got_type=type(val))
+            return None
+
+        for field in _license:
+            if field not in ("file", "text"):
+                msg = "Unexpected field {key}"
+                self.config_error(msg, key=f"project.license.{field}")
+                return None
+
+        file: pathlib.Path | None = None
+        filename = _license.get("file")
+        text = _license.get("text")
+
+        if (filename and text) or (not filename and not text):
+            msg = (
+                'Invalid {key} contents, expecting a string or one key "file" or "text"'
+            )
+            self.config_error(msg, key="project.license", got=_license)
+            return None
+
+        if filename:
+            file = project_dir.joinpath(filename)
+            if not file.is_file():
+                msg = f"License file not found ({filename!r})"
+                self.config_error(msg, key="project.license.file")
+                return None
+            text = file.read_text(encoding="utf-8")
+
+        assert text is not None
+        return License(text, file)
+
+    def get_license_files(
+        self, project: ProjectTable, project_dir: pathlib.Path
+    ) -> list[pathlib.Path] | None:
+        """Get the license-files list of files from the project table.
+
+        Returns None if an error occurred (including invalid globs, etc) or if
+        not present.
+        """
+        license_files = project.get("license-files")
+        if license_files is None:
+            return None
+        if self.ensure_list(license_files, "project.license-files") is None:
+            return None
+
+        return list(self._get_files_from_globs(project_dir, license_files))
+
+    def get_readme(
+        self, project: ProjectTable, project_dir: pathlib.Path
+    ) -> Readme | None:
+        """Get the text of the readme from the project table.
+
+        Returns None if an error occurred or if the readme field is not present.
+        """
+        if "readme" not in project:
+            return None
+
+        filename: str | None = None
+        file: pathlib.Path | None = None
+        text: str | None = None
+        content_type: str | None = None
+
+        readme = project["readme"]
+        if isinstance(readme, str):
+            # readme is a file
+            text = None
+            filename = readme
+            if filename.endswith(".md"):
+                content_type = "text/markdown"
+            elif filename.endswith(".rst"):
+                content_type = "text/x-rst"
+            else:
+                msg = "Could not infer content type for readme file {filename!r}"
+                self.config_error(msg, key="project.readme", filename=filename)
+                return None
+        elif isinstance(readme, dict):
+            # readme is a dict containing either 'file' or 'text', and content-type
+            for field in readme:
+                if field not in ("content-type", "file", "text"):
+                    msg = "Unexpected field {key}"
+                    self.config_error(msg, key=f"project.readme.{field}")
+                    return None
+
+            content_type_raw = readme.get("content-type")
+            if content_type_raw is not None:
+                content_type = self.ensure_str(
+                    content_type_raw, "project.readme.content-type"
+                )
+                if content_type is None:
+                    return None
+            filename_raw = readme.get("file")
+            if filename_raw is not None:
+                filename = self.ensure_str(filename_raw, "project.readme.file")
+                if filename is None:
+                    return None
+
+            text_raw = readme.get("text")
+            if text_raw is not None:
+                text = self.ensure_str(text_raw, "project.readme.text")
+                if text is None:
+                    return None
+
+            if (filename and text) or (not filename and not text):
+                msg = 'Invalid {key} contents, expecting either "file" or "text"'
+                self.config_error(msg, key="project.readme", got=readme)
+                return None
+            if not content_type:
+                msg = "Field {key} missing"
+                self.config_error(msg, key="project.readme.content-type")
+                return None
+        else:
+            msg = "Field {key} has an invalid type, expecting either a string or table of strings"
+            self.config_error(msg, key="project.readme", got_type=type(readme))
+            return None
+
+        if filename:
+            file = project_dir.joinpath(filename)
+            if not file.is_file():
+                msg = "Readme file not found ({filename!r})"
+                self.config_error(msg, key="project.readme.file", filename=filename)
+                return None
+            text = file.read_text(encoding="utf-8")
+
+        assert text is not None
+        return Readme(text, file, content_type)
+
+    def get_dependencies(self, project: ProjectTable) -> list[Requirement]:
+        """Get the dependencies from the project table."""
+
+        requirement_strings: list[str] | None = None
+        requirement_strings_raw = project.get("dependencies")
+        if requirement_strings_raw is not None:
+            requirement_strings = self.ensure_list(
+                requirement_strings_raw, "project.dependencies"
+            )
+        if requirement_strings is None:
+            return []
+
+        requirements: list[Requirement] = []
+        for req in requirement_strings:
+            try:
+                requirements.append(packaging.requirements.Requirement(req))
+            except packaging.requirements.InvalidRequirement as e:
+                msg = "Field {key} contains an invalid PEP 508 requirement string {req!r} ({error!r})"
+                self.config_error(msg, key="project.dependencies", req=req, error=e)
+                return []
+        return requirements
+
+    def get_optional_dependencies(
+        self,
+        project: ProjectTable,
+    ) -> dict[str, list[Requirement]]:
+        """Get the optional dependencies from the project table."""
+
+        val = project.get("optional-dependencies")
+        if not val:
+            return {}
+
+        requirements_dict: dict[str, list[Requirement]] = {}
+        if not isinstance(val, dict):
+            msg = "Field {key} has an invalid type, expecting a table of PEP 508 requirement strings"
+            self.config_error(
+                msg, key="project.optional-dependencies", got_type=type(val)
+            )
+            return {}
+        for extra, requirements in val.copy().items():
+            assert isinstance(extra, str)
+            if not isinstance(requirements, list):
+                msg = "Field {key} has an invalid type, expecting a table of PEP 508 requirement strings"
+                self.config_error(
+                    msg,
+                    key=f"project.optional-dependencies.{extra}",
+                    got_type=type(requirements),
+                )
+                return {}
+            requirements_dict[extra] = []
+            for req in requirements:
+                if not isinstance(req, str):
+                    msg = "Field {key} has an invalid type, expecting a PEP 508 requirement string"
+                    self.config_error(
+                        msg,
+                        key=f"project.optional-dependencies.{extra}",
+                        got_type=type(req),
+                    )
+                    return {}
+                try:
+                    requirements_dict[extra].append(
+                        packaging.requirements.Requirement(req)
+                    )
+                except packaging.requirements.InvalidRequirement as e:
+                    msg = (
+                        "Field {key} contains "
+                        "an invalid PEP 508 requirement string {req!r} ({error!r})"
+                    )
+                    self.config_error(
+                        msg,
+                        key=f"project.optional-dependencies.{extra}",
+                        req=req,
+                        error=e,
+                    )
+                    return {}
+        return dict(requirements_dict)
+
+    def get_entrypoints(self, project: ProjectTable) -> dict[str, dict[str, str]]:
+        """Get the entrypoints from the project table."""
+
+        val = project.get("entry-points", None)
+        if val is None:
+            return {}
+        if not isinstance(val, dict):
+            msg = "Field {key} has an invalid type, expecting a table of entrypoint sections"
+            self.config_error(msg, key="project.entry-points", got_type=type(val))
+            return {}
+        for section, entrypoints in val.items():
+            assert isinstance(section, str)
+            if not re.match(r"^\w+(\.\w+)*$", section):
+                msg = (
+                    "Field {key} has an invalid value, expecting a name "
+                    "containing only alphanumeric, underscore, or dot characters"
+                )
+                self.config_error(msg, key="project.entry-points", got=section)
+                return {}
+            if not isinstance(entrypoints, dict):
+                msg = (
+                    "Field {key} has an invalid type, expecting a table of entrypoints"
+                )
+                self.config_error(
+                    msg,
+                    key=f"project.entry-points.{section}",
+                    got_type=type(entrypoints),
+                )
+                return {}
+            for name, entrypoint in entrypoints.items():
+                assert isinstance(name, str)
+                if not isinstance(entrypoint, str):
+                    msg = "Field {key} has an invalid type, expecting a string"
+                    self.config_error(
+                        msg,
+                        key=f"project.entry-points.{section}.{name}",
+                        got_type=type(entrypoint),
+                    )
+                    return {}
+        return val
+
+    def get_dynamic(self, project: ProjectTable) -> list[Dynamic]:
+        """Get the dynamic fields from the project table.
+
+        Returns an empty list if the field is not present or if an error occurred.
+        """
+        dynamic = project.get("dynamic", [])
+
+        self.ensure_list(dynamic, "project.dynamic")
+
+        if "name" in dynamic:
+            msg = "Unsupported field 'name' in {key}"
+            self.config_error(msg, key="project.dynamic")
+            return []
+
+        return dynamic
+
+    def _get_files_from_globs(
+        self, project_dir: pathlib.Path, globs: Iterable[str]
+    ) -> Generator[pathlib.Path, None, None]:
+        """Given a list of globs, get files that match."""
+
+        for glob in globs:
+            if glob.startswith(("..", "/")):
+                msg = "{glob!r} is an invalid {key} glob: the pattern must match files within the project directory"
+                self.config_error(msg, key="project.license-files", glob=glob)
+                break
+            files = [f for f in project_dir.glob(glob) if f.is_file()]
+            if not files:
+                msg = "Every pattern in {key} must match at least one file: {glob!r} did not match any"
+                self.config_error(msg, key="project.license-files", glob=glob)
+                break
+            for f in files:
+                yield f.relative_to(project_dir)

--- a/src/packaging/errors.py
+++ b/src/packaging/errors.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import contextlib
+import dataclasses
+import sys
+from collections.abc import Generator
+from typing import Any, NoReturn
+
+__all__ = ["ExceptionGroup", "ConfigurationError", "ConfigurationWarning"]
+
+
+if sys.version_info >= (3, 11):  # pragma: no cover
+    from builtins import ExceptionGroup
+else:  # pragma: no cover
+
+    class ExceptionGroup(Exception):
+        """A minimal implementation of :external:exc:`ExceptionGroup` from Python 3.11.
+
+        If :external:exc:`ExceptionGroup` is already defined by Python itself,
+        that version is used instead.
+        """
+
+        message: str
+        exceptions: list[Exception]
+
+        def __init__(self, message: str, exceptions: list[Exception]) -> None:
+            self.message = message
+            self.exceptions = exceptions
+
+        def __repr__(self) -> str:
+            return f"{self.__class__.__name__}({self.message!r}, {self.exceptions!r})"
+
+
+class ConfigurationError(Exception):
+    """Error in the backend metadata. Has an optional key attribute, which will be non-None
+    if the error is related to a single key in the pyproject.toml file."""
+
+    def __init__(self, msg: str, *, key: str | None = None):
+        super().__init__(msg)
+        self._key = key
+
+    @property
+    def key(self) -> str | None:  # pragma: no cover
+        return self._key
+
+
+class ConfigurationWarning(UserWarning):
+    """Warnings about backend metadata."""
+
+
+@dataclasses.dataclass
+class ErrorCollector:
+    """
+    Collect errors and raise them as a group at the end (if collect_errors is True),
+    otherwise raise them immediately.
+    """
+
+    errors: list[Exception] = dataclasses.field(default_factory=list)
+
+    def config_error(
+        self,
+        msg: str,
+        *,
+        key: str | None = None,
+        got: Any = None,
+        got_type: type[Any] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Raise a configuration error, or add it to the error list."""
+        msg = msg.format(key=f'"{key}"', **kwargs)
+        if got is not None:
+            msg = f"{msg} (got {got!r})"
+        if got_type is not None:
+            msg = f"{msg} (got {got_type.__name__})"
+
+        self.errors.append(ConfigurationError(msg, key=key))
+
+    def finalize(self, msg: str) -> NoReturn:
+        """Raise a group exception if there are any errors."""
+        raise ExceptionGroup(msg, self.errors)
+
+    @contextlib.contextmanager
+    def collect(self) -> Generator[None, None, None]:
+        """Support nesting; add any grouped errors to the error list."""
+        try:
+            yield
+        except ExceptionGroup as error:
+            self.errors.extend(error.exceptions)

--- a/src/packaging/metadata.py
+++ b/src/packaging/metadata.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import builtins
+import dataclasses
 import email.feedparser
 import email.header
 import email.message
@@ -269,6 +270,72 @@ _EMAIL_TO_RAW_MAPPING = {
     "version": "version",
 }
 _RAW_TO_EMAIL_MAPPING = {raw: email for email, raw in _EMAIL_TO_RAW_MAPPING.items()}
+_MULTI_FIELDS = {_RAW_TO_EMAIL_MAPPING[x] for x in _LIST_FIELDS | _DICT_FIELDS}
+
+
+@dataclasses.dataclass
+class _JSonMessageSetter:
+    """
+    This provides an API to build a JSON message output in the same way as the
+    classic Message. Line breaks are preserved this way.
+    """
+
+    data: dict[str, str | list[str]]
+
+    def __setitem__(self, name: str, value: str | None) -> None:
+        key = name.replace("-", "_")
+        if value is None:
+            return
+
+        if name == "keywords":
+            values = (x.strip() for x in value.split(","))
+            self.data[key] = [x for x in values if x]
+        elif name in _MULTI_FIELDS:
+            entry = self.data.setdefault(key, [])
+            assert isinstance(entry, list)
+            entry.append(value)
+        else:
+            self.data[key] = value
+
+    def set_payload(self, payload: str) -> None:
+        self["description"] = payload
+
+
+# This class is for writing RFC822 messages
+class RFC822Policy(email.policy.EmailPolicy):
+    """
+    This is :class:`email.policy.EmailPolicy`, but with a simple ``header_store_parse``
+    implementation that handles multiline values, and some nice defaults.
+    """
+
+    utf8 = True
+    mangle_from_ = False
+    max_line_length = 0
+
+    def header_store_parse(self, name: str, value: str) -> tuple[str, str]:
+        size = len(name) + 2
+        value = value.replace("\n", "\n" + " " * size)
+        return (name, value)
+
+
+# This class is for writing RFC822 messages
+class RFC822Message(email.message.EmailMessage):
+    """
+    This is :class:`email.message.EmailMessage` with two small changes: it defaults to
+    our `RFC822Policy`, and it correctly writes unicode when being called
+    with `bytes()`.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(policy=RFC822Policy())
+
+    def as_bytes(
+        self, unixfrom: bool = False, policy: email.policy.Policy | None = None
+    ) -> bytes:
+        """
+        This handles unicode encoding.
+        """
+        return self.as_string(unixfrom, policy=policy).encode("utf-8")
 
 
 def parse_email(data: bytes | str) -> tuple[RawMetadata, dict[str, list[str]]]:
@@ -806,3 +873,44 @@ class Metadata:
     """``Provides`` (deprecated)"""
     obsoletes: _Validator[list[str] | None] = _Validator(added="1.1")
     """``Obsoletes`` (deprecated)"""
+
+    def as_rfc822(self) -> RFC822Message:
+        """
+        Return an RFC822 message with the metadata.
+        """
+        message = RFC822Message()
+        self._write_metadata(message)
+        return message
+
+    def as_json(self) -> dict[str, str | list[str]]:
+        """
+        Return a JSON message with the metadata.
+        """
+        message: dict[str, str | list[str]] = {}
+        smart_message = _JSonMessageSetter(message)
+        self._write_metadata(smart_message)
+        return message
+
+    def _write_metadata(self, message: RFC822Message | _JSonMessageSetter) -> None:
+        """
+        Return an RFC822 message with the metadata.
+        """
+        for name, validator in self.__class__.__dict__.items():
+            if isinstance(validator, _Validator) and name != "description":
+                value = getattr(self, name)
+                email_name = _RAW_TO_EMAIL_MAPPING[name]
+                if value is not None:
+                    if email_name == "project-url":
+                        for label, url in value.items():
+                            message[email_name] = f"{label}, {url}"
+                    elif email_name == "keywords":
+                        message[email_name] = ",".join(value)
+                    elif isinstance(value, list):
+                        for item in value:
+                            message[email_name] = str(item)
+                    else:
+                        message[email_name] = str(value)
+
+        # The description is a special case because it is in the body of the message.
+        if self.description is not None:
+            message.set_payload(self.description)

--- a/src/packaging/metadata.py
+++ b/src/packaging/metadata.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import builtins
-import dataclasses
 import email.feedparser
 import email.header
 import email.message
@@ -271,34 +270,6 @@ _EMAIL_TO_RAW_MAPPING = {
 }
 _RAW_TO_EMAIL_MAPPING = {raw: email for email, raw in _EMAIL_TO_RAW_MAPPING.items()}
 _MULTI_FIELDS = {_RAW_TO_EMAIL_MAPPING[x] for x in _LIST_FIELDS | _DICT_FIELDS}
-
-
-@dataclasses.dataclass
-class _JSonMessageSetter:
-    """
-    This provides an API to build a JSON message output in the same way as the
-    classic Message. Line breaks are preserved this way.
-    """
-
-    data: dict[str, str | list[str]]
-
-    def __setitem__(self, name: str, value: str | None) -> None:
-        key = name.replace("-", "_")
-        if value is None:
-            return
-
-        if name == "keywords":
-            values = (x.strip() for x in value.split(","))
-            self.data[key] = [x for x in values if x]
-        elif name in _MULTI_FIELDS:
-            entry = self.data.setdefault(key, [])
-            assert isinstance(entry, list)
-            entry.append(value)
-        else:
-            self.data[key] = value
-
-    def set_payload(self, payload: str) -> None:
-        self["description"] = payload
 
 
 # This class is for writing RFC822 messages
@@ -882,16 +853,7 @@ class Metadata:
         self._write_metadata(message)
         return message
 
-    def as_json(self) -> dict[str, str | list[str]]:
-        """
-        Return a JSON message with the metadata.
-        """
-        message: dict[str, str | list[str]] = {}
-        smart_message = _JSonMessageSetter(message)
-        self._write_metadata(smart_message)
-        return message
-
-    def _write_metadata(self, message: RFC822Message | _JSonMessageSetter) -> None:
+    def _write_metadata(self, message: RFC822Message) -> None:
         """
         Return an RFC822 message with the metadata.
         """

--- a/src/packaging/metadata.py
+++ b/src/packaging/metadata.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import builtins
 import email.feedparser
 import email.header
 import email.message
@@ -18,30 +17,9 @@ from typing import (
 
 from . import requirements, specifiers, utils
 from . import version as version_module
+from .errors import ExceptionGroup
 
 T = typing.TypeVar("T")
-
-
-if "ExceptionGroup" in builtins.__dict__:  # pragma: no cover
-    ExceptionGroup = ExceptionGroup
-else:  # pragma: no cover
-
-    class ExceptionGroup(Exception):
-        """A minimal implementation of :external:exc:`ExceptionGroup` from Python 3.11.
-
-        If :external:exc:`ExceptionGroup` is already defined by Python itself,
-        that version is used instead.
-        """
-
-        message: str
-        exceptions: list[Exception]
-
-        def __init__(self, message: str, exceptions: list[Exception]) -> None:
-            self.message = message
-            self.exceptions = exceptions
-
-        def __repr__(self) -> str:
-            return f"{self.__class__.__name__}({self.message!r}, {self.exceptions!r})"
 
 
 class InvalidMetadata(ValueError):
@@ -162,6 +140,7 @@ _LIST_FIELDS = {
 _DICT_FIELDS = {
     "project_urls",
 }
+ALL_FIELDS = _STRING_FIELDS | _LIST_FIELDS | _DICT_FIELDS
 
 
 def _parse_keywords(data: str) -> list[str]:

--- a/src/packaging/project.py
+++ b/src/packaging/project.py
@@ -1,0 +1,495 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+
+from __future__ import annotations
+
+import copy
+import dataclasses
+import email.message
+import email.policy
+import email.utils
+import os
+import os.path
+import pathlib
+import sys
+import typing
+import warnings
+
+from . import markers, specifiers, utils
+from . import metadata as packaging_metadata
+from . import version as packaging_version
+from ._pyproject import License, PyProjectReader, Readme
+from .errors import ConfigurationError, ConfigurationWarning, ErrorCollector
+
+if typing.TYPE_CHECKING:
+    from collections.abc import Mapping
+    from typing import Any
+
+    from .requirements import Requirement
+
+    if sys.version_info < (3, 11):
+        from typing_extensions import Self
+    else:
+        from typing import Self
+
+    from .project_table import Dynamic, PyProjectTable
+
+__all__ = [
+    "ConfigurationError",
+    "License",
+    "Readme",
+    "StandardMetadata",
+    "extras_build_system",
+    "extras_project",
+    "extras_top_level",
+]
+
+KNOWN_TOPLEVEL_FIELDS = {"build-system", "project", "tool", "dependency-groups"}
+KNOWN_BUILD_SYSTEM_FIELDS = {"backend-path", "build-backend", "requires"}
+KNOWN_PROJECT_FIELDS = {
+    "authors",
+    "classifiers",
+    "dependencies",
+    "description",
+    "dynamic",
+    "entry-points",
+    "gui-scripts",
+    "keywords",
+    "license",
+    "license-files",
+    "maintainers",
+    "name",
+    "optional-dependencies",
+    "readme",
+    "requires-python",
+    "scripts",
+    "urls",
+    "version",
+}
+PRE_SPDX_METADATA_VERSIONS = {"2.1", "2.2", "2.3"}
+
+
+def extras_top_level(pyproject_table: Mapping[str, Any]) -> set[str]:
+    """
+    Return any extra keys in the top-level of the pyproject table.
+    """
+    return set(pyproject_table) - KNOWN_TOPLEVEL_FIELDS
+
+
+def extras_build_system(pyproject_table: Mapping[str, Any]) -> set[str]:
+    """
+    Return any extra keys in the build-system table.
+    """
+    return set(pyproject_table.get("build-system", [])) - KNOWN_BUILD_SYSTEM_FIELDS
+
+
+def extras_project(pyproject_table: Mapping[str, Any]) -> set[str]:
+    """
+    Return any extra keys in the project table.
+    """
+    return set(pyproject_table.get("project", [])) - KNOWN_PROJECT_FIELDS
+
+
+@dataclasses.dataclass
+class StandardMetadata:
+    """
+    This class represents the standard metadata fields for a project. It can be
+    used to read metadata from a pyproject.toml table, validate it, and write it
+    to an RFC822 message or JSON.
+    """
+
+    name: str
+    version: packaging_version.Version | None = None
+    description: str | None = None
+    license: License | str | None = None
+    license_files: list[pathlib.Path] | None = None
+    readme: Readme | None = None
+    requires_python: specifiers.SpecifierSet | None = None
+    dependencies: list[Requirement] = dataclasses.field(default_factory=list)
+    optional_dependencies: dict[str, list[Requirement]] = dataclasses.field(
+        default_factory=dict
+    )
+    entrypoints: dict[str, dict[str, str]] = dataclasses.field(default_factory=dict)
+    authors: list[tuple[str, str | None]] = dataclasses.field(default_factory=list)
+    maintainers: list[tuple[str, str | None]] = dataclasses.field(default_factory=list)
+    urls: dict[str, str] = dataclasses.field(default_factory=dict)
+    classifiers: list[str] = dataclasses.field(default_factory=list)
+    keywords: list[str] = dataclasses.field(default_factory=list)
+    scripts: dict[str, str] = dataclasses.field(default_factory=dict)
+    gui_scripts: dict[str, str] = dataclasses.field(default_factory=dict)
+    dynamic: list[Dynamic] = dataclasses.field(default_factory=list)
+    """
+    This field is used to track dynamic fields. You can't set a field not in this list.
+    """
+
+    def __post_init__(self) -> None:
+        self.validate()
+
+    @property
+    def canonical_name(self) -> str:
+        """
+        Return the canonical name of the project.
+        """
+        return utils.canonicalize_name(self.name)
+
+    @classmethod
+    def from_pyproject(
+        cls,
+        data: Mapping[str, Any],
+        project_dir: str | os.PathLike[str] = os.path.curdir,
+    ) -> Self:
+        """
+        Read metadata from a pyproject.toml table. This is the main method for
+        creating an instance of this class. It also supports two additional
+        fields: ``allow_extra_keys`` to control what happens when extra keys are
+        present in the pyproject table, and ``all_errors``, to  raise all errors
+        in an ExceptionGroup instead of raising the first one.
+        """
+        pyproject = PyProjectReader()
+
+        pyproject_table: PyProjectTable = data  # type: ignore[assignment]
+        if "project" not in pyproject_table:
+            msg = "Section {key} missing in pyproject.toml"
+            pyproject.config_error(msg, key="project")
+            pyproject.finalize("Failed to parse pyproject.toml")
+            msg = "Unreachable code"  # pragma: no cover
+            raise AssertionError(msg)  # pragma: no cover
+
+        project = pyproject_table["project"]
+        project_dir = pathlib.Path(project_dir)
+
+        extra_keys = extras_project(data)
+        if extra_keys:
+            extra_keys_str = ", ".join(sorted(f"{k!r}" for k in extra_keys))
+            msg = "Extra keys present in {key}: {extra_keys}"
+            pyproject.config_error(
+                msg,
+                key="project",
+                extra_keys=extra_keys_str,
+            )
+
+        dynamic = pyproject.get_dynamic(project)
+
+        for field in dynamic:
+            if field in data["project"]:
+                msg = 'Field {key} declared as dynamic in "project.dynamic" but is defined'
+                pyproject.config_error(msg, key=f"project.{field}")
+
+        raw_name = project.get("name")
+        name = "UNKNOWN"
+        if raw_name is None:
+            msg = "Field {key} missing"
+            pyproject.config_error(msg, key="project.name")
+        else:
+            tmp_name = pyproject.ensure_str(raw_name, "project.name")
+            if tmp_name is not None:
+                name = tmp_name
+
+        version: packaging_version.Version | None = packaging_version.Version("0.0.0")
+        raw_version = project.get("version")
+        if raw_version is not None:
+            version_string = pyproject.ensure_str(raw_version, "project.version")
+            if version_string is not None:
+                try:
+                    version = (
+                        packaging_version.Version(version_string)
+                        if version_string
+                        else None
+                    )
+                except packaging_version.InvalidVersion:
+                    msg = "Invalid {key} value, expecting a valid PEP 440 version"
+                    pyproject.config_error(
+                        msg, key="project.version", got=version_string
+                    )
+        elif "version" not in dynamic:
+            msg = (
+                "Field {key} missing and 'version' not specified in \"project.dynamic\""
+            )
+            pyproject.config_error(msg, key="project.version")
+
+        # Description fills Summary, which cannot be multiline
+        # However, throwing an error isn't backward compatible,
+        # so leave it up to the users for now.
+        project_description_raw = project.get("description")
+        description = (
+            pyproject.ensure_str(project_description_raw, "project.description")
+            if project_description_raw is not None
+            else None
+        )
+
+        requires_python_raw = project.get("requires-python")
+        requires_python = None
+        if requires_python_raw is not None:
+            requires_python_string = pyproject.ensure_str(
+                requires_python_raw, "project.requires-python"
+            )
+            if requires_python_string is not None:
+                try:
+                    requires_python = specifiers.SpecifierSet(requires_python_string)
+                except specifiers.InvalidSpecifier:
+                    msg = "Invalid {key} value, expecting a valid specifier set"
+                    pyproject.config_error(
+                        msg, key="project.requires-python", got=requires_python_string
+                    )
+
+        self = None
+        with pyproject.collect():
+            self = cls(
+                name=name,
+                version=version,
+                description=description,
+                license=pyproject.get_license(project, project_dir),
+                license_files=pyproject.get_license_files(project, project_dir),
+                readme=pyproject.get_readme(project, project_dir),
+                requires_python=requires_python,
+                dependencies=pyproject.get_dependencies(project),
+                optional_dependencies=pyproject.get_optional_dependencies(project),
+                entrypoints=pyproject.get_entrypoints(project),
+                authors=pyproject.ensure_people(
+                    project.get("authors", []), "project.authors"
+                ),
+                maintainers=pyproject.ensure_people(
+                    project.get("maintainers", []), "project.maintainers"
+                ),
+                urls=pyproject.ensure_dict(project.get("urls", {}), "project.urls")
+                or {},
+                classifiers=pyproject.ensure_list(
+                    project.get("classifiers", []), "project.classifiers"
+                )
+                or [],
+                keywords=pyproject.ensure_list(
+                    project.get("keywords", []), "project.keywords"
+                )
+                or [],
+                scripts=pyproject.ensure_dict(
+                    project.get("scripts", {}), "project.scripts"
+                )
+                or {},
+                gui_scripts=pyproject.ensure_dict(
+                    project.get("gui-scripts", {}), "project.gui-scripts"
+                )
+                or {},
+                dynamic=dynamic,
+            )
+
+        pyproject.finalize("Failed to parse pyproject.toml")
+        assert self is not None
+        return self
+
+    def validate_metdata(self, metadata_version: str) -> None:
+        errors = ErrorCollector()
+
+        if not self.version:
+            msg = "Missing {key} field"
+            errors.config_error(msg, key="project.version")
+
+        if metadata_version not in PRE_SPDX_METADATA_VERSIONS:
+            if isinstance(self.license, License):
+                warnings.warn(
+                    'Set "project.license" to an SPDX license expression for metadata >= 2.4',
+                    ConfigurationWarning,
+                    stacklevel=2,
+                )
+            elif any(c.startswith("License ::") for c in self.classifiers):
+                warnings.warn(
+                    "'License ::' classifiers are deprecated for metadata >= 2.4"
+                    ', use a SPDX license expression for "project.license" instead',
+                    ConfigurationWarning,
+                    stacklevel=2,
+                )
+
+        if (
+            isinstance(self.license, str)
+            and metadata_version in PRE_SPDX_METADATA_VERSIONS
+        ):
+            msg = "Setting {key} to an SPDX license expression is supported only when emitting metadata version >= 2.4"
+            errors.config_error(msg, key="project.license")
+
+        if (
+            self.license_files is not None
+            and metadata_version in PRE_SPDX_METADATA_VERSIONS
+        ):
+            msg = "{key} is supported only when emitting metadata version >= 2.4"
+            errors.config_error(msg, key="project.license-files")
+
+        errors.finalize("Metadata validation failed")
+
+    def validate(self) -> None:
+        """
+        Validate metadata for consistency and correctness. Will also produce
+        warnings if ``warn`` is given. Respects ``all_errors``. This is called
+        when loading a pyproject.toml, and when making metadata. Checks:
+
+        - ``metadata_version`` is a known version or None
+        - ``name`` is a valid project name
+        - ``license_files`` can't be used with classic ``license``
+        - License classifiers can't be used with SPDX license
+        - ``description`` is a single line (warning)
+        - ``license`` is not an SPDX license expression if metadata_version >= 2.4 (warning)
+        - License classifiers deprecated for metadata_version >= 2.4 (warning)
+        - ``license`` is an SPDX license expression if metadata_version >= 2.4
+        - ``license_files`` is supported only for metadata_version >= 2.4
+        - ``project_url`` can't contain keys over 32 characters
+        """
+        errors = ErrorCollector()
+
+        try:
+            utils.canonicalize_name(self.name, validate=True)
+        except utils.InvalidName:
+            msg = (
+                "Invalid project name {name!r}. A valid name consists only of ASCII letters and "
+                "numbers, period, underscore and hyphen. It must start and end with a letter or number"
+            )
+            errors.config_error(msg, key="project.name", name=self.name)
+
+        if self.license_files is not None and isinstance(self.license, License):
+            msg = '{key} must not be used when "project.license" is not a SPDX license expression'
+            errors.config_error(msg, key="project.license-files")
+
+        if isinstance(self.license, str) and any(
+            c.startswith("License ::") for c in self.classifiers
+        ):
+            msg = "Setting {key} to an SPDX license expression is not compatible with 'License ::' classifiers"
+            errors.config_error(msg, key="project.license")
+
+        if self.description and "\n" in self.description:
+            msg = (
+                'The one-line summary "project.description" should not contain more '
+                "than one line. Readers might merge or truncate newlines."
+            )
+            errors.config_error(msg, key="project.description")
+
+        for name in self.urls:
+            if len(name) > 32:
+                msg = "{key} names cannot be more than 32 characters long"
+                errors.config_error(msg, key="project.urls", got=name)
+
+        errors.finalize("[project] table validation failed")
+
+    def metadata(
+        self, metadata_version: str, dynamic_metadata: list[str]
+    ) -> packaging_metadata.Metadata:
+        """
+        Return an Message with the metadata.
+        """
+        self.validate_metdata(metadata_version)
+
+        assert self.version is not None
+        message = packaging_metadata.RawMetadata(
+            metadata_version=metadata_version, name=self.name, version=str(self.version)
+        )
+
+        # skip 'Platform'
+        # skip 'Supported-Platform'
+        if self.description:
+            message["summary"] = self.description
+        if self.keywords:
+            message["keywords"] = self.keywords
+        # skip 'Home-page'
+        # skip 'Download-URL'
+        if authors := _name_list(self.authors):
+            message["author"] = authors
+
+        if authors_email := _email_list(self.authors):
+            message["author_email"] = authors_email
+
+        if maintainers := _name_list(self.maintainers):
+            message["maintainer"] = maintainers
+
+        if maintainers_email := _email_list(self.maintainers):
+            message["maintainer_email"] = maintainers_email
+
+        if isinstance(self.license, License):
+            message["license"] = self.license.text
+        elif isinstance(self.license, str):
+            message["license_expression"] = self.license
+
+        if self.license_files is not None:
+            license_files = [
+                os.fspath(license_file.as_posix())
+                for license_file in sorted(set(self.license_files))
+            ]
+            message["license_file"] = license_files
+        elif (
+            metadata_version not in PRE_SPDX_METADATA_VERSIONS
+            and isinstance(self.license, License)
+            and self.license.file
+        ):
+            message["license_file"] = [os.fspath(self.license.file.as_posix())]
+
+        if self.classifiers:
+            message["classifiers"] = self.classifiers
+        # skip 'Provides-Dist'
+        # skip 'Obsoletes-Dist'
+        # skip 'Requires-External'
+        if self.urls:
+            message["project_urls"] = self.urls
+        if self.requires_python:
+            message["requires_python"] = str(self.requires_python)
+        if self.dependencies:
+            message["requires_dist"] = [str(d) for d in self.dependencies]
+        for extra, requirements in self.optional_dependencies.items():
+            norm_extra = extra.replace(".", "-").replace("_", "-").lower()
+            message.get("provides_extra", []).append(norm_extra)
+            message.get("requires_dist", []).extend(
+                str(_build_extra_req(norm_extra, requirement))
+                for requirement in requirements
+            )
+        if self.readme:
+            if self.readme.content_type:
+                message["description_content_type"] = self.readme.content_type
+            message["description"] = self.readme.text
+        # Core Metadata 2.2
+        if metadata_version != "2.1":
+            for field in dynamic_metadata:
+                if field.lower() in {"name", "version", "dynamic"}:
+                    msg = f"Field cannot be set as dynamic metadata: {field}"
+                    raise ConfigurationError(msg)
+                if field.lower() not in packaging_metadata.ALL_FIELDS:
+                    msg = f"Field is not known: {field}"
+                    raise ConfigurationError(msg)
+            message["dynamic"] = dynamic_metadata
+
+        return packaging_metadata.Metadata.from_raw(message)
+
+
+def _name_list(people: list[tuple[str, str | None]]) -> str | None:
+    """
+    Build a comma-separated list of names.
+    """
+    return ", ".join(name for name, email_ in people if not email_) or None
+
+
+def _email_list(people: list[tuple[str, str | None]]) -> str | None:
+    """
+    Build a comma-separated list of emails.
+    """
+    return (
+        ", ".join(
+            email.utils.formataddr((name, _email)) for name, _email in people if _email
+        )
+        or None
+    )
+
+
+def _build_extra_req(
+    extra: str,
+    requirement: Requirement,
+) -> Requirement:
+    """
+    Build a new requirement with an extra marker.
+    """
+    requirement = copy.copy(requirement)
+    if requirement.marker:
+        if "or" in requirement.marker._markers:
+            requirement.marker = markers.Marker(
+                f"({requirement.marker}) and extra == {extra!r}"
+            )
+        else:
+            requirement.marker = markers.Marker(
+                f"{requirement.marker} and extra == {extra!r}"
+            )
+    else:
+        requirement.marker = markers.Marker(f"extra == {extra!r}")
+    return requirement

--- a/src/packaging/project_table.py
+++ b/src/packaging/project_table.py
@@ -1,0 +1,142 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+
+from __future__ import annotations
+
+import sys
+import typing
+from typing import Any, Dict, List, Literal, TypedDict, Union
+
+if typing.TYPE_CHECKING:
+    if sys.version_info < (3, 11):
+        from typing_extensions import Required
+    else:
+        from typing import Required
+
+
+__all__ = [
+    "BuildSystemTable",
+    "ContactTable",
+    "Dynamic",
+    "IncludeGroupTable",
+    "LicenseTable",
+    "ProjectTable",
+    "PyProjectTable",
+    "ReadmeTable",
+]
+
+
+def __dir__() -> list[str]:
+    return __all__
+
+
+class ContactTable(TypedDict, total=False):
+    name: str
+    email: str
+
+
+class LicenseTable(TypedDict, total=False):
+    text: str
+    file: str
+
+
+ReadmeTable = TypedDict(
+    "ReadmeTable", {"file": str, "text": str, "content-type": str}, total=False
+)
+
+Dynamic = Literal[
+    "authors",
+    "classifiers",
+    "dependencies",
+    "description",
+    "dynamic",
+    "entry-points",
+    "gui-scripts",
+    "keywords",
+    "license",
+    "maintainers",
+    "optional-dependencies",
+    "readme",
+    "requires-python",
+    "scripts",
+    "urls",
+    "version",
+]
+
+ProjectTable = TypedDict(
+    "ProjectTable",
+    {
+        "name": Required[str],
+        "version": str,
+        "description": str,
+        "license": Union[LicenseTable, str],
+        "license-files": List[str],
+        "readme": Union[str, ReadmeTable],
+        "requires-python": str,
+        "dependencies": List[str],
+        "optional-dependencies": Dict[str, List[str]],
+        "entry-points": Dict[str, Dict[str, str]],
+        "authors": List[ContactTable],
+        "maintainers": List[ContactTable],
+        "urls": Dict[str, str],
+        "classifiers": List[str],
+        "keywords": List[str],
+        "scripts": Dict[str, str],
+        "gui-scripts": Dict[str, str],
+        "dynamic": List[Dynamic],
+    },
+    total=False,
+)
+
+BuildSystemTable = TypedDict(
+    "BuildSystemTable",
+    {
+        "build-backend": str,
+        "requires": List[str],
+        "backend-path": List[str],
+    },
+    total=False,
+)
+
+# total=False here because this could be
+# extended in the future
+IncludeGroupTable = TypedDict(
+    "IncludeGroupTable",
+    {"include-group": str},
+    total=False,
+)
+
+PyProjectTable = TypedDict(
+    "PyProjectTable",
+    {
+        "build-system": BuildSystemTable,
+        "project": ProjectTable,
+        "tool": Dict[str, Any],
+        "dependency-groups": Dict[str, List[Union[str, IncludeGroupTable]]],
+    },
+    total=False,
+)
+
+# Tests for type checking
+if typing.TYPE_CHECKING:
+    PyProjectTable(
+        {
+            "build-system": BuildSystemTable(
+                {"build-backend": "one", "requires": ["two"]}
+            ),
+            "project": ProjectTable(
+                {
+                    "name": "one",
+                    "version": "0.1.0",
+                }
+            ),
+            "tool": {"thing": object()},
+            "dependency-groups": {
+                "one": [
+                    "one",
+                    IncludeGroupTable({"include-group": "two"}),
+                ]
+            },
+        }
+    )

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -622,3 +622,169 @@ class TestMetadata:
     def test_optional_defaults_to_none(self, field_name):
         meta = metadata.Metadata.from_raw({}, validate=False)
         assert getattr(meta, field_name) is None
+
+
+class TestMetadataWriting:
+    def test_write_metadata(self):
+        meta = metadata.Metadata.from_raw(_RAW_EXAMPLE)
+        written = meta.as_rfc822().as_string()
+        assert (
+            written == "metadata-version: 2.3\nname: packaging\nversion: 2023.0.0\n\n"
+        )
+
+    def test_write_metadata_with_description(self):
+        # Intentionally out of order to make sure it is written in order
+        meta = metadata.Metadata.from_raw(
+            {
+                "version": "1.2.3",
+                "name": "Hello",
+                "description": "Hello\n\nWorld👋",
+                "metadata_version": "2.3",
+            }
+        )
+        written = meta.as_rfc822().as_string()
+        assert (
+            written == "metadata-version: 2.3\nname: Hello\n"
+            "version: 1.2.3\n\nHello\n\nWorld👋"
+        )
+        written = meta.as_rfc822().as_bytes()
+        assert (
+            written
+            == "metadata-version: 2.3\nname: Hello\n"
+            "version: 1.2.3\n\nHello\n\nWorld👋".encode()
+        )
+
+    def test_multiline_license(self):
+        meta = metadata.Metadata.from_raw(
+            {
+                "version": "1.2.3",
+                "name": "packaging",
+                "license": "Hello\nWorld🐍",
+                "metadata_version": "2.3",
+            }
+        )
+        written = meta.as_rfc822().as_string()
+        assert (
+            written == "metadata-version: 2.3\nname: packaging\nversion: 1.2.3"
+            "\nlicense: Hello\n         World🐍\n\n"
+        )
+        written = meta.as_rfc822().as_bytes()
+        assert (
+            written
+            == "metadata-version: 2.3\nname: packaging\nversion: 1.2.3"
+            "\nlicense: Hello\n         World🐍\n\n".encode()
+        )
+
+    def test_large(self):
+        meta = metadata.Metadata.from_raw(
+            {
+                "author": "Example!",
+                "author_email": "Unknown <example@example.com>",
+                "classifiers": [
+                    "Development Status :: 4 - Beta",
+                    "Programming Language :: Python",
+                ],
+                "description": "some readme 👋\n",
+                "description_content_type": "text/markdown",
+                "keywords": ["trampolim", "is", "interesting"],
+                "license": "some license text",
+                "maintainer_email": "Other Example <other@example.com>",
+                "metadata_version": "2.1",
+                "name": "full_metadata",
+                "project_urls": {
+                    "homepage": "example.com",
+                    "documentation": "readthedocs.org",
+                    "repository": "github.com/some/repo",
+                    "changelog": "github.com/some/repo/blob/master/CHANGELOG.rst",
+                },
+                "provides_extra": ["test"],
+                "requires_dist": [
+                    "dependency1",
+                    "dependency2>1.0.0",
+                    "dependency3[extra]",
+                    'dependency4; os_name != "nt"',
+                    'dependency5[other-extra]>1.0; os_name == "nt"',
+                    'test_dependency; extra == "test"',
+                    'test_dependency[test_extra]; extra == "test"',
+                    "test_dependency[test_extra2]>3.0; "
+                    'os_name == "nt" and extra == "test"',
+                ],
+                "requires_python": ">=3.8",
+                "summary": "A package with all the metadata :)",
+                "version": "3.2.1",
+            }
+        )
+
+        assert meta.as_json() == {
+            "author": "Example!",
+            "author_email": "Unknown <example@example.com>",
+            "classifier": [
+                "Development Status :: 4 - Beta",
+                "Programming Language :: Python",
+            ],
+            "description": "some readme 👋\n",
+            "description_content_type": "text/markdown",
+            "keywords": ["trampolim", "is", "interesting"],
+            "license": "some license text",
+            "maintainer_email": "Other Example <other@example.com>",
+            "metadata_version": "2.1",
+            "name": "full_metadata",
+            "project_url": [
+                "homepage, example.com",
+                "documentation, readthedocs.org",
+                "repository, github.com/some/repo",
+                "changelog, github.com/some/repo/blob/master/CHANGELOG.rst",
+            ],
+            "provides_extra": ["test"],
+            "requires_dist": [
+                "dependency1",
+                "dependency2>1.0.0",
+                "dependency3[extra]",
+                'dependency4; os_name != "nt"',
+                'dependency5[other-extra]>1.0; os_name == "nt"',
+                'test_dependency; extra == "test"',
+                'test_dependency[test_extra]; extra == "test"',
+                'test_dependency[test_extra2]>3.0; os_name == "nt" and extra == "test"',
+            ],
+            "requires_python": ">=3.8",
+            "summary": "A package with all the metadata :)",
+            "version": "3.2.1",
+        }
+
+        core_metadata = meta.as_rfc822()
+        assert core_metadata.items() == [
+            ("metadata-version", "2.1"),
+            ("name", "full_metadata"),
+            ("version", "3.2.1"),
+            ("summary", "A package with all the metadata :)"),
+            ("description-content-type", "text/markdown"),
+            ("keywords", "trampolim,is,interesting"),
+            ("author", "Example!"),
+            ("author-email", "Unknown <example@example.com>"),
+            ("maintainer-email", "Other Example <other@example.com>"),
+            ("license", "some license text"),
+            ("classifier", "Development Status :: 4 - Beta"),
+            ("classifier", "Programming Language :: Python"),
+            ("requires-dist", "dependency1"),
+            ("requires-dist", "dependency2>1.0.0"),
+            ("requires-dist", "dependency3[extra]"),
+            ("requires-dist", 'dependency4; os_name != "nt"'),
+            ("requires-dist", 'dependency5[other-extra]>1.0; os_name == "nt"'),
+            ("requires-dist", 'test_dependency; extra == "test"'),
+            ("requires-dist", 'test_dependency[test_extra]; extra == "test"'),
+            (
+                "requires-dist",
+                'test_dependency[test_extra2]>3.0; os_name == "nt" and extra == "test"',
+            ),
+            ("requires-python", ">=3.8"),
+            ("project-url", "homepage, example.com"),
+            ("project-url", "documentation, readthedocs.org"),
+            ("project-url", "repository, github.com/some/repo"),
+            (
+                "project-url",
+                "changelog, github.com/some/repo/blob/master/CHANGELOG.rst",
+            ),
+            ("provides-extra", "test"),
+        ]
+
+        assert core_metadata.get_payload() == "some readme 👋\n"

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -715,42 +715,6 @@ class TestMetadataWriting:
             }
         )
 
-        assert meta.as_json() == {
-            "author": "Example!",
-            "author_email": "Unknown <example@example.com>",
-            "classifier": [
-                "Development Status :: 4 - Beta",
-                "Programming Language :: Python",
-            ],
-            "description": "some readme 👋\n",
-            "description_content_type": "text/markdown",
-            "keywords": ["trampolim", "is", "interesting"],
-            "license": "some license text",
-            "maintainer_email": "Other Example <other@example.com>",
-            "metadata_version": "2.1",
-            "name": "full_metadata",
-            "project_url": [
-                "homepage, example.com",
-                "documentation, readthedocs.org",
-                "repository, github.com/some/repo",
-                "changelog, github.com/some/repo/blob/master/CHANGELOG.rst",
-            ],
-            "provides_extra": ["test"],
-            "requires_dist": [
-                "dependency1",
-                "dependency2>1.0.0",
-                "dependency3[extra]",
-                'dependency4; os_name != "nt"',
-                'dependency5[other-extra]>1.0; os_name == "nt"',
-                'test_dependency; extra == "test"',
-                'test_dependency[test_extra]; extra == "test"',
-                'test_dependency[test_extra2]>3.0; os_name == "nt" and extra == "test"',
-            ],
-            "requires_python": ">=3.8",
-            "summary": "A package with all the metadata :)",
-            "version": "3.2.1",
-        }
-
         core_metadata = meta.as_rfc822()
         assert core_metadata.items() == [
             ("metadata-version", "2.1"),


### PR DESCRIPTION
Start of adding the bulk of pyproject-metadata. Prerequisites:

- https://github.com/pypa/packaging/pull/846 (builds of that PR)
- https://github.com/pypa/packaging/pull/836 (needs MyPy bump)
- https://github.com/pypa/packaging/pull/828 (includes PEP 639) - Note, I'll probably add the (I believe) missing validation errors for packaging.metadata after that is merged.

TODO:

- [ ] Add tests ported from pyproject-metadata
- [ ] Ensure error style is consistent with other parts of packaging
- [ ] Ensure packaging.metadata throws all errors in `.validate_metadata`, and then remove `.validate_metadata`
- [ ] Add docs
