### PR TITLE
Extraneous quotes

### DIFF
--- a/src/packaging/specifiers.py
+++ b/src/packaging/specifiers.py
@@ -234,7 +234,7 @@ class Specifier(BaseSpecifier):
         """
         match = self._regex.search(spec)
         if not match:
-            raise InvalidSpecifier(f"Invalid specifier: '{spec}'")
+            raise InvalidSpecifier(f"Invalid specifier: {spec!r}")
 
         self._spec: tuple[str, str] = (
             match.group("operator").strip(),

--- a/src/packaging/utils.py
+++ b/src/packaging/utils.py
@@ -125,7 +125,7 @@ def parse_wheel_filename(
         build_match = _build_tag_regex.match(build_part)
         if build_match is None:
             raise InvalidWheelFilename(
-                f"Invalid build number: {build_part} in '{filename!r}'"
+                f"Invalid build number: {build_part} in {filename!r}"
             )
         build = cast(BuildTag, (int(build_match.group(1)), build_match.group(2)))
     else:

--- a/src/packaging/version.py
+++ b/src/packaging/version.py
@@ -199,7 +199,7 @@ class Version(_BaseVersion):
         # Validate the version and parse it into pieces
         match = self._regex.search(version)
         if not match:
-            raise InvalidVersion(f"Invalid version: '{version}'")
+            raise InvalidVersion(f"Invalid version: {version!r}")
 
         # Store the parsed out pieces of the version
         self._version = _Version(


### PR DESCRIPTION
While integrating latest commit in https://github.com/pypi/warehouse/pull/16949/commits/a00fdef74695e73353c8a0fd9ad654467e743fee I noticed double `'` were necessary and went to find out why.

#844 didn't catch one place where `'` were being wrapped manually -> ad20c6bb91dfaa3ffb6957187e38fbbb9dbd16fd
I addressed a couple of other places where `!r` is relevant in -> 2226d1a5f5ef5f15a96825ea511936c0c3122766