### PR TITLE
[BugFix] `packaging.metadata.Metadata.from_raw(validate=True/False)` may return empty result

### DIFF
--- a/src/packaging/metadata.py
+++ b/src/packaging/metadata.py
@@ -742,6 +742,7 @@ class Metadata:
                             )
                             exceptions.append(exc)
                             continue
+                    # Access the attribute to trigger validation.
                 except InvalidMetadata as exc:
                     exceptions.append(exc)
 

--- a/src/packaging/metadata.py
+++ b/src/packaging/metadata.py
@@ -746,6 +746,7 @@ class Metadata:
             if exceptions:
                 raise ExceptionGroup("invalid metadata", exceptions)
 
+        del ins._raw
         return ins
 
     @classmethod

--- a/src/packaging/metadata.py
+++ b/src/packaging/metadata.py
@@ -512,10 +512,6 @@ class _Validator(Generic[T]):
                 value = converter(value)
 
         cache[self.name] = value
-        try:
-            del instance._raw[self.name]  # type: ignore[misc]
-        except KeyError:
-            pass
 
         return cast(T, value)
 
@@ -743,6 +739,7 @@ class Metadata:
                             exceptions.append(exc)
                             continue
                     # Access the attribute to trigger validation.
+                    getattr(ins, key)
                 except InvalidMetadata as exc:
                     exceptions.append(exc)
 

--- a/src/packaging/metadata.py
+++ b/src/packaging/metadata.py
@@ -742,7 +742,6 @@ class Metadata:
                             )
                             exceptions.append(exc)
                             continue
-                    getattr(ins, key)
                 except InvalidMetadata as exc:
                     exceptions.append(exc)
 


### PR DESCRIPTION
I found either a bug or a very unexpected results inside `packaging.metadata.Metadata.from_raw(validate=True/False)`

This function behaves totally different if `validate is True`. Which clearly does not make intuitive sense.

Here is a demonstration of the bug.

Long story short, if `validate is True`, `from_raw()` returns an empty dictionary. Which is incorrect.
`getattr()` is the part that actually cause this trouble. So removing it should fix the problem, I'm not entirely clear why it was here in the first place though.

https://colab.research.google.com/drive/151JEthOIXDKV1gdFLaJ-MFpPBFQbN1Q_#scrollTo=a54IxVQgS9HP