### PR TITLE
Improve performance in _manylinux.py

### DIFF
--- a/src/packaging/_manylinux.py
+++ b/src/packaging/_manylinux.py
@@ -252,11 +252,10 @@ def platform_tags(archs: Sequence[str]) -> Iterator[str]:
                 min_minor = -1
             for glibc_minor in range(glibc_max.minor, min_minor, -1):
                 glibc_version = _GLibCVersion(glibc_max.major, glibc_minor)
-                tag = "manylinux_{}_{}".format(*glibc_version)
                 if _is_compatible(arch, glibc_version):
-                    yield f"{tag}_{arch}"
-                # Handle the legacy manylinux1, manylinux2010, manylinux2014 tags.
-                if glibc_version in _LEGACY_MANYLINUX_MAP:
-                    legacy_tag = _LEGACY_MANYLINUX_MAP[glibc_version]
-                    if _is_compatible(arch, glibc_version):
+                    yield "manylinux_{}_{}_{}".format(*glibc_version, arch)
+
+                    # Handle the legacy manylinux1, manylinux2010, manylinux2014 tags.
+                    legacy_tag = _LEGACY_MANYLINUX_MAP.get(glibc_version)
+                    if legacy_tag:
                         yield f"{legacy_tag}_{arch}"

--- a/src/packaging/_manylinux.py
+++ b/src/packaging/_manylinux.py
@@ -256,6 +256,5 @@ def platform_tags(archs: Sequence[str]) -> Iterator[str]:
                     yield "manylinux_{}_{}_{}".format(*glibc_version, arch)
 
                     # Handle the legacy manylinux1, manylinux2010, manylinux2014 tags.
-                    legacy_tag = _LEGACY_MANYLINUX_MAP.get(glibc_version)
-                    if legacy_tag:
+                    if legacy_tag := _LEGACY_MANYLINUX_MAP.get(glibc_version):
                         yield f"{legacy_tag}_{arch}"


### PR DESCRIPTION
This PR makes a few performance improvements:

1. Reduces the doubled call to `_is_compatible(arch, glibc_version)`
2. Moves the assignment of the `tag` variable directly into the yield, reducing memory allocation in case this is never used when `_is_compatible(arch, glibc_version)` is false
3. Uses an assignment expression for dictionary lookup