### PR TITLE
SpecifierSet.filter should allow pre-release when no final version matches specifiers, same as Specifier.filter

### DIFF
--- a/src/packaging/specifiers.py
+++ b/src/packaging/specifiers.py
@@ -962,7 +962,7 @@ class SpecifierSet(BaseSpecifier):
         >>> list(SpecifierSet(">=1.2.3").filter(["1.2", "1.3", Version("1.4")]))
         ['1.3', <Version('1.4')>]
         >>> list(SpecifierSet(">=1.2.3").filter(["1.2", "1.5a1"]))
-        []
+        ["1.5a1"]
         >>> list(SpecifierSet(">=1.2.3").filter(["1.3", "1.5a1"], prereleases=True))
         ['1.3', '1.5a1']
         >>> list(SpecifierSet(">=1.2.3", prereleases=True).filter(["1.3", "1.5a1"]))
@@ -980,6 +980,11 @@ class SpecifierSet(BaseSpecifier):
         >>> list(SpecifierSet("").filter(["1.3", "1.5a1"], prereleases=True))
         ['1.3', '1.5a1']
         """
+        # Allow a fallback to prereleases=True under the following conditions:
+        # - prereleases was not passed in this call
+        # - prereleases was not passed in the constructor
+        prereleases_fallback = prereleases is None and self._prereleases is None
+
         # Determine if we're forcing a prerelease or not, if we're not forcing
         # one for this particular filter call, then we'll use whatever the
         # SpecifierSet thinks for whether or not we should support prereleases.
@@ -990,9 +995,28 @@ class SpecifierSet(BaseSpecifier):
         # filter method for each one, this will act as a logical AND amongst
         # each specifier.
         if self._specs:
+            current_iter = iterable
             for spec in self._specs:
-                iterable = spec.filter(iterable, prereleases=bool(prereleases))
-            return iter(iterable)
+                current_iter = spec.filter(current_iter, prereleases=bool(prereleases))
+
+            # If prereleases is True there is no need for fallback logic.
+            if not prereleases_fallback or prereleases is True:
+                yield from current_iter
+            else:
+                # If prereleases was not explicitly set, we need to do a similar
+                # check to Specifier.filter to see if any final releases are yielded.
+                yielded = False
+                for version in current_iter:
+                    yield version
+                    yielded = True
+
+                # Fall back to prereleases if no final releases were found.
+                if not yielded:
+                    fallback_iter = iterable
+                    for spec in self._specs:
+                        fallback_iter = spec.filter(fallback_iter, prereleases=True)
+                    yield from fallback_iter
+
         # If we do not have any specifiers, then we need to have a rough filter
         # which will filter out any pre-releases, unless there are no final
         # releases.
@@ -1014,6 +1038,6 @@ class SpecifierSet(BaseSpecifier):
             # If we've found no items except for pre-releases, then we'll go
             # ahead and use the pre-releases
             if not filtered and found_prereleases and prereleases is None:
-                return iter(found_prereleases)
+                yield from found_prereleases
 
-            return iter(filtered)
+            yield from filtered

--- a/tests/test_specifiers.py
+++ b/tests/test_specifiers.py
@@ -584,7 +584,7 @@ class TestSpecifier:
         ],
     )
     def test_specifier_filter(
-        self, specifier_prereleases, specifier, prereleases, input, expected
+        self, specifier, specifier_prereleases, prereleases, input, expected
     ):
         if specifier_prereleases is None:
             spec = Specifier(specifier)
@@ -777,7 +777,7 @@ class TestSpecifierSet:
         ],
     )
     def test_specifier_filter(
-        self, specifier_prereleases, specifier, prereleases, input, expected
+        self, specifier, specifier_prereleases, prereleases, input, expected
     ):
         if specifier_prereleases is None:
             spec = SpecifierSet(specifier)

--- a/tests/test_specifiers.py
+++ b/tests/test_specifiers.py
@@ -559,20 +559,32 @@ class TestSpecifier:
             assert version in spec
 
     @pytest.mark.parametrize(
-        ("specifier", "prereleases", "input", "expected"),
+        ("specifier", "specifier_prereleases", "prereleases", "input", "expected"),
         [
-            (">=1.0", None, ["2.0a1"], ["2.0a1"]),
-            (">=1.0.dev1", None, ["1.0", "2.0a1"], ["1.0", "2.0a1"]),
-            (">=1.0.dev1", False, ["1.0", "2.0a1"], ["1.0"]),
-            ("!=2.0a1", None, ["1.0a2", "1.0", "2.0a1"], ["1.0"]),
-            ("==2.0a1", None, ["2.0a1"], ["2.0a1"]),
-            (">2.0a1", None, ["2.0a1", "3.0a2", "3.0"], ["3.0a2", "3.0"]),
-            ("<2.0a1", None, ["1.0a2", "1.0", "2.0a1"], ["1.0a2", "1.0"]),
-            ("~=2.0a1", None, ["1.0", "2.0a1", "3.0a2", "3.0"], ["2.0a1"]),
+            # General test of the filter method
+            (">=1.0.dev1", None, None, ["1.0", "2.0a1"], ["1.0", "2.0a1"]),
+            (">=1.2.3", None, None, ["1.2", "1.5a1"], ["1.5a1"]),
+            (">=1.2.3", None, None, ["1.3", "1.5a1"], ["1.3"]),
+            (">=1.0", None, None, ["2.0a1"], ["2.0a1"]),
+            ("!=2.0a1", None, None, ["1.0a2", "1.0", "2.0a1"], ["1.0"]),
+            ("==2.0a1", None, None, ["2.0a1"], ["2.0a1"]),
+            (">2.0a1", None, None, ["2.0a1", "3.0a2", "3.0"], ["3.0a2", "3.0"]),
+            ("<2.0a1", None, None, ["1.0a2", "1.0", "2.0a1"], ["1.0a2", "1.0"]),
+            ("~=2.0a1", None, None, ["1.0", "2.0a1", "3.0a2", "3.0"], ["2.0a1"]),
+            # Test overriding with the prereleases parameter on filter
+            (">=1.0.dev1", None, False, ["1.0", "2.0a1"], ["1.0"]),
+            # Test overriding with the overall specifier
+            (">=1.0.dev1", True, None, ["1.0", "2.0a1"], ["1.0", "2.0a1"]),
+            (">=1.0.dev1", False, None, ["1.0", "2.0a1"], ["1.0"]),
         ],
     )
-    def test_specifier_filter(self, specifier, prereleases, input, expected):
-        spec = Specifier(specifier)
+    def test_specifier_filter(
+        self, specifier_prereleases, specifier, prereleases, input, expected
+    ):
+        if specifier_prereleases is None:
+            spec = Specifier(specifier)
+        else:
+            spec = Specifier(specifier, prereleases=specifier_prereleases)
 
         kwargs = {"prereleases": prereleases} if prereleases is not None else {}
 
@@ -720,6 +732,12 @@ class TestSpecifierSet:
             (">=1.2.3", None, None, ["1.2", "1.5a1"], ["1.5a1"]),
             (">=1.2.3", None, None, ["1.3", "1.5a1"], ["1.3"]),
             ("", None, None, ["1.0", Version("2.0")], ["1.0", Version("2.0")]),
+            (">=1.0", None, None, ["2.0a1"], ["2.0a1"]),
+            ("!=2.0a1", None, None, ["1.0a2", "1.0", "2.0a1"], ["1.0"]),
+            ("==2.0a1", None, None, ["2.0a1"], ["2.0a1"]),
+            (">2.0a1", None, None, ["2.0a1", "3.0a2", "3.0"], ["3.0a2", "3.0"]),
+            ("<2.0a1", None, None, ["1.0a2", "1.0", "2.0a1"], ["1.0a2", "1.0"]),
+            ("~=2.0a1", None, None, ["1.0", "2.0a1", "3.0a2", "3.0"], ["2.0a1"]),
             # Test overriding with the prereleases parameter on filter
             ("", None, False, ["1.0a1"], []),
             (">=1.0.dev1", None, False, ["1.0", "2.0a1"], ["1.0"]),

--- a/tests/test_specifiers.py
+++ b/tests/test_specifiers.py
@@ -717,6 +717,8 @@ class TestSpecifierSet:
             ("", None, None, ["1.0", "2.0a1"], ["1.0"]),
             (">=1.0.dev1", None, None, ["1.0", "2.0a1"], ["1.0", "2.0a1"]),
             ("", None, None, ["1.0a1"], ["1.0a1"]),
+            (">=1.2.3", None, None, ["1.2", "1.5a1"], ["1.5a1"]),
+            (">=1.2.3", None, None, ["1.3", "1.5a1"], ["1.3"]),
             ("", None, None, ["1.0", Version("2.0")], ["1.0", Version("2.0")]),
             # Test overriding with the prereleases parameter on filter
             ("", None, False, ["1.0a1"], []),

--- a/tests/test_specifiers.py
+++ b/tests/test_specifiers.py
@@ -576,6 +576,11 @@ class TestSpecifier:
             # Test overriding with the overall specifier
             (">=1.0.dev1", True, None, ["1.0", "2.0a1"], ["1.0", "2.0a1"]),
             (">=1.0.dev1", False, None, ["1.0", "2.0a1"], ["1.0"]),
+            # Test when both specifier and filter have prerelease value
+            (">=1.0", True, False, ["1.0", "2.0a1"], ["1.0"]),
+            (">=1.0", False, True, ["1.0", "2.0a1"], ["1.0", "2.0a1"]),
+            (">=1.0", True, True, ["1.0", "2.0a1"], ["1.0", "2.0a1"]),
+            (">=1.0", False, False, ["1.0", "2.0a1"], ["1.0"]),
         ],
     )
     def test_specifier_filter(
@@ -749,6 +754,26 @@ class TestSpecifierSet:
             (">=1.0.dev1", False, None, ["1.0", "2.0a1"], ["1.0"]),
             ("", True, None, ["1.0a1"], ["1.0a1"]),
             ("", False, None, ["1.0a1"], []),
+            # Test when both specifier and filter have prerelease value
+            (">=1.0", True, False, ["1.0", "2.0a1"], ["1.0"]),
+            (">=1.0", False, True, ["1.0", "2.0a1"], ["1.0", "2.0a1"]),
+            (">=1.0", True, True, ["1.0", "2.0a1"], ["1.0", "2.0a1"]),
+            (">=1.0", False, False, ["1.0", "2.0a1"], ["1.0"]),
+            # Test when there are multiple specifiers
+            (">=1.0,<=2.0", None, None, ["1.0", "1.5a1"], ["1.0"]),
+            (">=1.0,<=2.0dev", None, None, ["1.0", "1.5a1"], ["1.0", "1.5a1"]),
+            (">=1.0,<=2.0", True, None, ["1.0", "1.5a1"], ["1.0", "1.5a1"]),
+            (">=1.0,<=2.0", False, None, ["1.0", "1.5a1"], ["1.0"]),
+            (">=1.0,<=2.0dev", False, None, ["1.0", "1.5a1"], ["1.0"]),
+            (">=1.0,<=2.0dev", True, None, ["1.0", "1.5a1"], ["1.0", "1.5a1"]),
+            (">=1.0,<=2.0", None, False, ["1.0", "1.5a1"], ["1.0"]),
+            (">=1.0,<=2.0", None, True, ["1.0", "1.5a1"], ["1.0", "1.5a1"]),
+            (">=1.0,<=2.0dev", None, False, ["1.0", "1.5a1"], ["1.0"]),
+            (">=1.0,<=2.0dev", None, True, ["1.0", "1.5a1"], ["1.0", "1.5a1"]),
+            (">=1.0,<=2.0", True, False, ["1.0", "1.5a1"], ["1.0"]),
+            (">=1.0,<=2.0", False, True, ["1.0", "1.5a1"], ["1.0", "1.5a1"]),
+            (">=1.0,<=2.0dev", True, False, ["1.0", "1.5a1"], ["1.0"]),
+            (">=1.0,<=2.0dev", False, True, ["1.0", "1.5a1"], ["1.0", "1.5a1"]),
         ],
     )
     def test_specifier_filter(


### PR DESCRIPTION
Fixes https://github.com/pypa/packaging/issues/856

This brings `SpecifierSet` in-line with `Specifier` and the spec. I believe this behavior was incorrectly created from https://github.com/pypa/packaging/pull/29, which determined ahead of filtering whether to allow pre-releases or not, but did not introduce a fallback when only pre-releases matched the specifiers.

Interestingly, even though the old behavior is listed in the doc string there were previously no tests for this behavior:
```python
>>> list(SpecifierSet(">=1.2.3").filter(["1.2", "1.5a1"]))
[]
```

The docstring has been updated and the equivalent tests are added.