### PR TITLE
fix(markers): apply lazy evaluation to markers

### DIFF
--- a/src/packaging/markers.py
+++ b/src/packaging/markers.py
@@ -10,7 +10,7 @@ import platform
 import sys
 from typing import Any, Callable, TypedDict, cast
 
-from ._parser import MarkerAtom, MarkerList, Op, Value, Variable
+from ._parser import MarkerAtom, MarkerItem, MarkerList, Op, Value, Variable
 from ._parser import parse_marker as _parse_marker
 from ._tokenizer import ParserSyntaxError
 from .specifiers import InvalidSpecifier, Specifier
@@ -201,34 +201,41 @@ def _normalize(*values: str, key: str) -> tuple[str, ...]:
     return values
 
 
+def _evaluate_marker_item(marker: MarkerItem, environment: dict[str, str]) -> bool:
+    lhs, op, rhs = marker
+    if isinstance(lhs, Variable):
+        environment_key = lhs.value
+        lhs_value = environment[environment_key]
+        rhs_value = rhs.value
+    else:
+        lhs_value = lhs.value
+        environment_key = rhs.value
+        rhs_value = environment[environment_key]
+
+    lhs_value, rhs_value = _normalize(lhs_value, rhs_value, key=environment_key)
+    return _eval_op(lhs_value, op, rhs_value)
+
+
 def _evaluate_markers(markers: MarkerList, environment: dict[str, str]) -> bool:
-    groups: list[list[bool]] = [[]]
+    groups: list[list[Callable[[], bool]]] = [[]]
 
     for marker in markers:
         assert isinstance(marker, (list, tuple, str))
 
         if isinstance(marker, list):
-            groups[-1].append(_evaluate_markers(marker, environment))
+            groups[-1].append(
+                lambda marker=marker: _evaluate_markers(marker, environment)
+            )
         elif isinstance(marker, tuple):
-            lhs, op, rhs = marker
-
-            if isinstance(lhs, Variable):
-                environment_key = lhs.value
-                lhs_value = environment[environment_key]
-                rhs_value = rhs.value
-            else:
-                lhs_value = lhs.value
-                environment_key = rhs.value
-                rhs_value = environment[environment_key]
-
-            lhs_value, rhs_value = _normalize(lhs_value, rhs_value, key=environment_key)
-            groups[-1].append(_eval_op(lhs_value, op, rhs_value))
+            groups[-1].append(
+                lambda marker=marker: _evaluate_marker_item(marker, environment)
+            )
         else:
             assert marker in ["and", "or"]
             if marker == "or":
                 groups.append([])
 
-    return any(all(item) for item in groups)
+    return any(all(item() for item in group) for group in groups)
 
 
 def format_full_version(info: sys._version_info) -> str:

--- a/tests/test_markers.py
+++ b/tests/test_markers.py
@@ -92,6 +92,16 @@ class TestOperatorEvaluation:
             {"python_full_version": "3.11.0a5"}
         )
 
+    def test_boolean_shortcut_and(self):
+        assert not Marker("sys_platform == 'foo' and platform_release >= '6'").evaluate(
+            {"platform_release": "foo-bar-baz"}
+        )
+
+    def test_boolean_shortcut_or(self):
+        assert Marker("python_version >= '2.6' or platform_release >= '6'").evaluate(
+            {"platform_release": "foo-bar-baz"}
+        )
+
 
 FakeVersionInfo = collections.namedtuple(
     "FakeVersionInfo", ["major", "minor", "micro", "releaselevel", "serial"]


### PR DESCRIPTION
Signed-off-by: Frost Ming <me@frostming.com>

Fix #774

Change the marker evaluation to lazy evaluation so it is possible for boolean shorts.