### PR TITLE
Detect invalid license expressions containing `()`

### DIFF
--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -710,11 +710,20 @@ class TestMetadata:
             "with mit",
             "(mit",
             "mit)",
+            ") mit",
+            "mit (",
             "mit or or apache-2.0",
             # Missing an operator before `(`.
             "mit or apache-2.0 (bsd-3-clause and MPL-2.0)",
             # "2-BSD-Clause is not a valid license.
             "Apache-2.0 OR 2-BSD-Clause",
+            # Empty parenthesis.
+            "()",
+            "( ) or mit",
+            "mit and ( )",
+            "( ) or mit and ( )",
+            "( ) with ( ) or mit",
+            "mit with ( ) with ( ) or mit",
         ],
     )
     def test_invalid_license_expression(self, license_expression):


### PR DESCRIPTION
The following condensed list of expressions are all currently mislabelled as valid by `canonicalize_license_expression()`.

    ( ) or MIT
    MIT and ( )
    ( ) and MIT or MIT
    ( ) with ( MIT )
    ( ) with ( ) or MIT
    MIT with ( ) with ( ) or MIT

The trick of converting license expressions to Python statements runs afoul of `()` being an empty tuple (i.e. valid syntax and falsy). Depending on how `()` is combined with real `False`s, it may or may not get caught by the subsequent `eval(python_expression) is False` check:

    MIT or ()  ->  False or ()  ->  ()     # Caught
    () or MIT  ->  () or False  ->  False  # Not caught

Consider a license expression invalid if a `)` comes immediately after a `(` token. This also removes the one case where the `eval()` would return something other than `False` so that `eval()` can now be downgraded to a `compile()` (which I find very anxiety relieving even though I can't think of any way the old `eval()` could ever have been exposed to more than `False`s or `()`s).