### PR TITLE
Add support for PEP 738 Android tags

### DIFF
--- a/docs/tags.rst
+++ b/docs/tags.rst
@@ -168,6 +168,21 @@ to the implementation to provide.
         Behavior of this method is undefined if invoked on non-iOS platforms
         without providing explicit version and multiarch arguments.
 
+
+.. function:: android_platforms(api_level=None, abi=None)
+
+    Yields the :attr:`~Tag.platform` tags for Android. If this function is invoked on
+    non-Android platforms, the ``api_level`` and ``abi`` arguments are required.
+
+    :param int api_level: The maximum `API level
+        <https://developer.android.com/tools/releases/platforms>`__ to return. Defaults
+        to the current system's version, as returned by ``platform.android_ver``.
+    :param str abi: The `Android ABI <https://developer.android.com/ndk/guides/abis>`__,
+        e.g. ``arm64_v8a``. Defaults to the current system's ABI , as returned by
+        ``sysconfig.get_platform``. Hyphens and periods will be replaced with
+        underscores.
+
+
 .. function:: platform_tags(version=None, arch=None)
 
     Yields the :attr:`~Tag.platform` tags for the running interpreter.

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -458,9 +458,6 @@ class TestAndroidPlatforms:
     def test_non_android(self):
         non_android_error = pytest.raises(
             TypeError,
-            match=(
-                "on non-Android platforms, the api_level and abi arguments are required"
-            ),
         )
         with non_android_error:
             list(tags.android_platforms())

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -456,9 +456,7 @@ class TestIOSPlatforms:
 
 class TestAndroidPlatforms:
     def test_non_android(self):
-        non_android_error = pytest.raises(
-            TypeError,
-        )
+        non_android_error = pytest.raises(TypeError)
         with non_android_error:
             list(tags.android_platforms())
         with non_android_error:

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -77,6 +77,23 @@ def mock_ios(monkeypatch):
         monkeypatch.setattr(platform, "ios_ver", mock_ios_ver)
 
 
+@pytest.fixture
+def mock_android(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "android")
+    monkeypatch.setattr(platform, "system", lambda: "Android")
+    monkeypatch.setattr(sysconfig, "get_platform", lambda: "android-21-arm64_v8a")
+
+    AndroidVer = collections.namedtuple(
+        "AndroidVer", "release api_level manufacturer model device is_emulator"
+    )
+    monkeypatch.setattr(
+        platform,
+        "android_ver",
+        lambda: AndroidVer("5.0", 21, "Google", "sdk_gphone64_arm64", "emu64a", True),
+        raising=False,  # This function was added in Python 3.13.
+    )
+
+
 class TestTag:
     def test_lowercasing(self):
         tag = tags.Tag("PY3", "None", "ANY")
@@ -437,6 +454,74 @@ class TestIOSPlatforms:
         ]
 
 
+class TestAndroidPlatforms:
+    def test_non_android(self):
+        non_android_error = pytest.raises(
+            TypeError,
+            match=(
+                "on non-Android platforms, the api_level and abi arguments are required"
+            ),
+        )
+        with non_android_error:
+            list(tags.android_platforms())
+        with non_android_error:
+            list(tags.android_platforms(api_level=18))
+        with non_android_error:
+            list(tags.android_platforms(abi="x86_64"))
+
+        # The function can only be called on non-Android platforms if both arguments are
+        # provided.
+        assert list(tags.android_platforms(api_level=18, abi="x86_64")) == [
+            "android_18_x86_64",
+            "android_17_x86_64",
+            "android_16_x86_64",
+        ]
+
+    def test_detection(self, mock_android):
+        assert list(tags.android_platforms()) == [
+            "android_21_arm64_v8a",
+            "android_20_arm64_v8a",
+            "android_19_arm64_v8a",
+            "android_18_arm64_v8a",
+            "android_17_arm64_v8a",
+            "android_16_arm64_v8a",
+        ]
+
+    def test_api_level(self):
+        # API levels below the minimum should return nothing.
+        assert list(tags.android_platforms(api_level=14, abi="x86")) == []
+        assert list(tags.android_platforms(api_level=15, abi="x86")) == []
+
+        assert list(tags.android_platforms(api_level=16, abi="x86")) == [
+            "android_16_x86",
+        ]
+        assert list(tags.android_platforms(api_level=17, abi="x86")) == [
+            "android_17_x86",
+            "android_16_x86",
+        ]
+        assert list(tags.android_platforms(api_level=18, abi="x86")) == [
+            "android_18_x86",
+            "android_17_x86",
+            "android_16_x86",
+        ]
+
+    def test_abi(self):
+        # Real ABI, normalized.
+        assert list(tags.android_platforms(api_level=16, abi="armeabi_v7a")) == [
+            "android_16_armeabi_v7a",
+        ]
+
+        # Real ABI, not normalized.
+        assert list(tags.android_platforms(api_level=16, abi="armeabi-v7a")) == [
+            "android_16_armeabi_v7a",
+        ]
+
+        # Nonexistent ABIs should still be accepted and normalized.
+        assert list(tags.android_platforms(api_level=16, abi="myarch-4.2")) == [
+            "android_16_myarch_4_2",
+        ]
+
+
 class TestManylinuxPlatform:
     def teardown_method(self):
         # Clear the version cache
@@ -722,6 +807,7 @@ class TestManylinuxPlatform:
     [
         ("Darwin", "mac_platforms"),
         ("iOS", "ios_platforms"),
+        ("Android", "android_platforms"),
         ("Linux", "_linux_platforms"),
         ("Generic", "_generic_platforms"),
     ],


### PR DESCRIPTION
This tag format was originally defined in PEP 738, and is now documented in the [compatibility tag spec](https://packaging.python.org/en/latest/specifications/platform-compatibility-tags/#android).

Like macOS and iOS, we define a public function which yields a sequence of tags from a maximum platform version down to a minimum. However, Android is a bit simpler because its version is expressed as an integer.