### PR TITLE
Fix Marker non-version-to-version comparison throwing InvalidVersion

### DIFF
--- a/src/packaging/markers.py
+++ b/src/packaging/markers.py
@@ -15,6 +15,7 @@ from ._parser import parse_marker as _parse_marker
 from ._tokenizer import ParserSyntaxError
 from .specifiers import InvalidSpecifier, Specifier
 from .utils import canonicalize_name
+from .version import InvalidVersion, Version
 
 __all__ = [
     "InvalidMarker",
@@ -175,12 +176,20 @@ _operators: dict[str, Operator] = {
 
 
 def _eval_op(lhs: str, op: Op, rhs: str) -> bool:
+    # PEP 508 - Environment Markers
+    # https://peps.python.org/pep-0508/#environment-markers
+    # > The <version_cmp> operators use the PEP 440 version comparison rules
+    # > when those are defined (that is when both sides have a valid version
+    # > specifier). If there is no defined PEP 440 behaviour and the operator
+    # > exists in Python, then the operator falls back to the Python behaviour.
+    # > Otherwise an error should be raised.
     try:
         spec = Specifier("".join([op.serialize(), rhs]))
-    except InvalidSpecifier:
+        lhs_ver = Version(lhs)
+    except (InvalidSpecifier, InvalidVersion):
         pass
     else:
-        return spec.contains(lhs, prereleases=True)
+        return spec.contains(lhs_ver, prereleases=True)
 
     oper: Operator | None = _operators.get(op.serialize())
     if oper is None:

--- a/tests/test_markers.py
+++ b/tests/test_markers.py
@@ -314,6 +314,14 @@ class TestMarker:
                 {"extra": "different__punctuation_is_EQUAL"},
                 True,
             ),
+            # extra name that is also a valid version - version comparison applies
+            # if both sides are valid versions
+            ("extra == 'v8'", {"extra": "quux"}, False),
+            ("extra == 'v8'", {"extra": "v8"}, True),
+            # LHS and RHS are valid versions, so equality uses normalized version
+            ("extra == 'v8-dev'", {"extra": "v8-dev.0"}, True),
+            # Only one side is a valid version, so values are not normalized as versions
+            ("extra == 'v-8-dev'", {"extra": "v-8-dev.0"}, False),
         ],
     )
     def test_evaluates(self, marker_string, environment, expected):


### PR DESCRIPTION
This PR adds (failing) test cases to cover version-to-version and non-version-to-version marker evaluation, according to [PEP 508 — Environment Markers](https://peps.python.org/pep-0508/#environment-markers). It also changes the Marker evaluation implementation to follow the spec's behaviour rather than crashing when evaluating Marker equality with a valid version on the RHS only.

---

## Current situation

Marker evaluation currently throws an InvalidVersion error when the rhs is a valid version but the lhs is not. For example, consider the dependency:

> Requires-Dist: typing-extensions (>=4,<5) ; extra == "v8"

The extra name "v8" is both a valid version and extra name. During evaluation of this requirement, the LHS of the marker can take on the value "", or some other extra name, which are not valid versions.

When this situation occurs, the comparison fails by throwing InvalidVersion, rather then returning False. This is causing pip to crash when attempting to install a package with such a requirement.

Currently, just one of these added cases is failing - the `"quux" == "v8"` case.

i.e. this is happening:
```python
>>> from packaging.markers import Marker
>>> Marker('extra == "v8"').evaluate({'extra': ''})
...
InvalidVersion: Invalid version: ''
>>> Marker('extra == "v8"').evaluate({'extra': 'foo'})
...
InvalidVersion: Invalid version: 'foo'
```

I've also added two cases to document the (perhaps surprising) behaviour that is a result of the PEP 508 spec requiring normalized version comparison to apply to extras when both sides are valid versions.

## Fix

[PEP 508 — Environment Markers](https://peps.python.org/pep-0508/#environment-markers) section specifies that markers are evaluated using version operator rules when both sides are valid versions, and otherwise regular python operator rules apply.

However, the implementation was failing to handle the case where the RHS was a valid version specifier, but the LHS was not a valid version. In this case, PEP 508 requires the comparison falls back to python rules, but the implementation was throwing InvalidVersion.

The implementation now matches the behaviour in the spec, as we now check that both the LHS and the RHS are versions before attempting version comparison (not just the RHS as before).