### PR TITLE
fix(markers): when left hand value is non-version string, fallback to python behavior

### DIFF
--- a/src/packaging/markers.py
+++ b/src/packaging/markers.py
@@ -15,6 +15,7 @@ from ._parser import parse_marker as _parse_marker
 from ._tokenizer import ParserSyntaxError
 from .specifiers import InvalidSpecifier, Specifier
 from .utils import canonicalize_name
+from .version import InvalidVersion
 
 __all__ = [
     "InvalidMarker",
@@ -180,7 +181,10 @@ def _eval_op(lhs: str, op: Op, rhs: str) -> bool:
     except InvalidSpecifier:
         pass
     else:
-        return spec.contains(lhs, prereleases=True)
+        try:
+            return spec.contains(lhs, prereleases=True)
+        except InvalidVersion:
+            pass
 
     oper: Operator | None = _operators.get(op.serialize())
     if oper is None:

--- a/tests/test_markers.py
+++ b/tests/test_markers.py
@@ -304,6 +304,7 @@ class TestMarker:
                 {"os_name": "other", "python_version": "2.7.4"},
                 False,
             ),
+            ("platform_release >= '6'", {"platform_release": "6.1-foobar"}, True),
             ("extra == 'security'", {"extra": "quux"}, False),
             ("extra == 'security'", {"extra": "security"}, True),
             ("extra == 'SECURITY'", {"extra": "security"}, True),


### PR DESCRIPTION
Signed-off-by: Frost Ming <me@frostming.com>