### PR TITLE
Correct comment and simplify implicit prerelease handling in Specifier.prereleases

### DIFF
--- a/src/packaging/specifiers.py
+++ b/src/packaging/specifiers.py
@@ -251,11 +251,10 @@ class Specifier(BaseSpecifier):
         if self._prereleases is not None:
             return self._prereleases
 
-        # Look at all of our specifiers and determine if they are inclusive
-        # operators, and if they are if they are including an explicit
-        # prerelease.
+        # Only the "!=" operator does not imply prereleases when
+        # the version in the specifier is a prerelease.
         operator, version = self._spec
-        if operator in ["==", ">=", "<=", "~=", "===", ">", "<"]:
+        if operator != "!=":
             # The == specifier can include a trailing .*, if it does we
             # want to remove before parsing.
             if operator == "==" and version.endswith(".*"):


### PR DESCRIPTION
This one is trivial, it corrects the comment on what specifiers imply prereleases and simplifies the code to make it more obvious.

See previously https://github.com/pypa/packaging/pull/794.