### PR TITLE
PEP 440 handling of prereleases for `Specifier.contains`, `SpecifierSet.contains`, and `SpecifierSet.filter`

### DIFF
--- a/src/packaging/specifiers.py
+++ b/src/packaging/specifiers.py
@@ -524,8 +524,8 @@ class Specifier(BaseSpecifier):
             :class:`Version` instance.
         :param prereleases:
             Whether or not to match prereleases with this Specifier. If set to
-            ``None`` (the default), it uses :attr:`prereleases` to determine
-            whether or not prereleases are allowed.
+            ``None`` (the default), it will follow the reccommendation from
+            :pep:`440` and match prereleases, as there are no other versions.
 
         >>> Specifier(">=1.2.3").contains("1.2.3")
         True
@@ -535,30 +535,13 @@ class Specifier(BaseSpecifier):
         False
         >>> Specifier(">=1.2.3").contains("1.3.0a1")
         False
-        >>> Specifier(">=1.2.3", prereleases=True).contains("1.3.0a1")
-        True
-        >>> Specifier(">=1.2.3").contains("1.3.0a1", prereleases=True)
+        >>> Specifier(">=1.2.3", prereleases=False).contains("1.3.0a1")
+        False
+        >>> Specifier(">=1.2.3").contains("1.3.0a1")
         True
         """
 
-        # Determine if prereleases are to be allowed or not.
-        if prereleases is None:
-            prereleases = self.prereleases
-
-        # Normalize item to a Version, this allows us to have a shortcut for
-        # "2.0" in Specifier(">=2")
-        normalized_item = _coerce_version(item)
-
-        # Determine if we should be supporting prereleases in this specifier
-        # or not, if we do not support prereleases than we can short circuit
-        # logic if this version is a prereleases.
-        if normalized_item.is_prerelease and not prereleases:
-            return False
-
-        # Actually do the comparison to determine if this item is contained
-        # within this Specifier or not.
-        operator_callable: CallableOperator = self._get_operator(self.operator)
-        return operator_callable(normalized_item, self.version)
+        return bool(list(self.filter([item], prereleases=prereleases)))
 
     def filter(
         self, iterable: Iterable[UnparsedVersionVar], prereleases: bool | None = None
@@ -570,13 +553,8 @@ class Specifier(BaseSpecifier):
             The items in the iterable will be filtered according to the specifier.
         :param prereleases:
             Whether or not to allow prereleases in the returned iterator. If set to
-            ``None`` (the default), it will be intelligently decide whether to allow
-            prereleases or not (based on the :attr:`prereleases` attribute, and
-            whether the only versions matching are prereleases).
-
-        This method is smarter than just ``filter(Specifier().contains, [...])``
-        because it implements the rule from :pep:`440` that a prerelease item
-        SHOULD be accepted if no other versions match the given specifier.
+            ``None`` (the default), it will follow the recommendation from :pep:`440`
+            and match prereleases if there are no other versions.
 
         >>> list(Specifier(">=1.2.3").filter(["1.2", "1.3", "1.5a1"]))
         ['1.3']
@@ -589,37 +567,38 @@ class Specifier(BaseSpecifier):
         >>> list(Specifier(">=1.2.3", prereleases=True).filter(["1.3", "1.5a1"]))
         ['1.3', '1.5a1']
         """
+        prereleases_versions = []
+        found_non_prereleases = False
 
-        yielded = False
-        found_prereleases = []
+        # Determine if to include prereleases by default
+        include_prereleases = (
+            prereleases if prereleases is not None else self.prereleases
+        )
 
-        kw = {"prereleases": prereleases if prereleases is not None else True}
+        # Get the matching operator
+        operator_callable = self._get_operator(self.operator)
 
-        # Attempt to iterate over all the values in the iterable and if any of
-        # them match, yield them.
+        # Filter versions
         for version in iterable:
             parsed_version = _coerce_version(version)
 
-            if self.contains(parsed_version, **kw):
-                # If our version is a prerelease, and we were not set to allow
-                # prereleases, then we'll store it for later in case nothing
-                # else matches this specifier.
-                if parsed_version.is_prerelease and not (
-                    prereleases or self.prereleases
-                ):
-                    found_prereleases.append(version)
-                # Either this is not a prerelease, or we should have been
-                # accepting prereleases from the beginning.
-                else:
-                    yielded = True
+            if operator_callable(parsed_version, self.version):
+                # If it's not a prerelease or prereleases are allowed, yield it directly
+                if not parsed_version.is_prerelease or include_prereleases:
+                    found_non_prereleases = True
                     yield version
+                # Otherwise collect prereleases for potential later use
+                elif prereleases is None and self._prereleases is not False:
+                    prereleases_versions.append(version)
 
-        # Now that we've iterated over everything, determine if we've yielded
-        # any values, and if we have not and we have any prereleases stored up
-        # then we will go ahead and yield the prereleases.
-        if not yielded and found_prereleases:
-            for version in found_prereleases:
-                yield version
+        # If no non-prereleases were found and prereleases weren't
+        # explicitly forbidden, yield the collected prereleases
+        if (
+            not found_non_prereleases
+            and prereleases is None
+            and self._prereleases is not False
+        ):
+            yield from prereleases_versions
 
 
 _prefix_regex = re.compile(r"^([0-9]+)((?:a|b|c|rc)[0-9]+)$")
@@ -745,7 +724,10 @@ class SpecifierSet(BaseSpecifier):
 
         # Otherwise we'll see if any of the given specifiers accept
         # prereleases, if any of them do we'll return True, otherwise False.
-        return any(s.prereleases for s in self._specs)
+        if any(s.prereleases for s in self._specs):
+            return True
+
+        return None
 
     @prereleases.setter
     def prereleases(self, value: bool) -> None:
@@ -893,8 +875,8 @@ class SpecifierSet(BaseSpecifier):
             :class:`Version` instance.
         :param prereleases:
             Whether or not to match prereleases with this SpecifierSet. If set to
-            ``None`` (the default), it uses :attr:`prereleases` to determine
-            whether or not prereleases are allowed.
+            ``None`` (the default), it will follow the recommendation from :pep:`440`
+            and match prereleases, as there are no other versions.
 
         >>> SpecifierSet(">=1.0.0,!=1.0.1").contains("1.2.3")
         True
@@ -903,9 +885,9 @@ class SpecifierSet(BaseSpecifier):
         >>> SpecifierSet(">=1.0.0,!=1.0.1").contains("1.0.1")
         False
         >>> SpecifierSet(">=1.0.0,!=1.0.1").contains("1.3.0a1")
-        False
-        >>> SpecifierSet(">=1.0.0,!=1.0.1", prereleases=True).contains("1.3.0a1")
         True
+        >>> SpecifierSet(">=1.0.0,!=1.0.1", prereleases=False).contains("1.3.0a1")
+        False
         >>> SpecifierSet(">=1.0.0,!=1.0.1").contains("1.3.0a1", prereleases=True)
         True
         """
@@ -913,29 +895,10 @@ class SpecifierSet(BaseSpecifier):
         if not isinstance(item, Version):
             item = Version(item)
 
-        # Determine if we're forcing a prerelease or not, if we're not forcing
-        # one for this particular filter call, then we'll use whatever the
-        # SpecifierSet thinks for whether or not we should support prereleases.
-        if prereleases is None:
-            prereleases = self.prereleases
-
-        # We can determine if we're going to allow pre-releases by looking to
-        # see if any of the underlying items supports them. If none of them do
-        # and this item is a pre-release then we do not allow it and we can
-        # short circuit that here.
-        # Note: This means that 1.0.dev1 would not be contained in something
-        #       like >=1.0.devabc however it would be in >=1.0.debabc,>0.0.dev0
-        if not prereleases and item.is_prerelease:
-            return False
-
         if installed and item.is_prerelease:
-            item = Version(item.base_version)
+            prereleases = True
 
-        # We simply dispatch to the underlying specs here to make sure that the
-        # given version is contained within all of them.
-        # Note: This use of all() here means that an empty set of specifiers
-        #       will always return True, this is an explicit design decision.
-        return all(s.contains(item, prereleases=prereleases) for s in self._specs)
+        return bool(list(self.filter([item], prereleases=prereleases)))
 
     def filter(
         self, iterable: Iterable[UnparsedVersionVar], prereleases: bool | None = None
@@ -947,13 +910,8 @@ class SpecifierSet(BaseSpecifier):
             The items in the iterable will be filtered according to the specifier.
         :param prereleases:
             Whether or not to allow prereleases in the returned iterator. If set to
-            ``None`` (the default), it will be intelligently decide whether to allow
-            prereleases or not (based on the :attr:`prereleases` attribute, and
-            whether the only versions matching are prereleases).
-
-        This method is smarter than just ``filter(SpecifierSet(...).contains, [...])``
-        because it implements the rule from :pep:`440` that a prerelease item
-        SHOULD be accepted if no other versions match the given specifier.
+            ``None`` (the default), it will follow the recommendation from :pep:`440`
+            and match prereleases if there are no other versions.
 
         >>> list(SpecifierSet(">=1.2.3").filter(["1.2", "1.3", "1.5a1"]))
         ['1.3']
@@ -978,43 +936,19 @@ class SpecifierSet(BaseSpecifier):
         >>> list(SpecifierSet("").filter(["1.3", "1.5a1"], prereleases=True))
         ['1.3', '1.5a1']
         """
-        # Allow a fallback to prereleases=True under the following conditions:
-        # - prereleases was not passed in this call
-        # - prereleases was not passed in the constructor
-        prereleases_fallback = prereleases is None and self._prereleases is None
-
         # Determine if we're forcing a prerelease or not, if we're not forcing
         # one for this particular filter call, then we'll use whatever the
         # SpecifierSet thinks for whether or not we should support prereleases.
-        if prereleases is None:
+        if prereleases is None and self.prereleases is not None:
             prereleases = self.prereleases
 
         # If we have any specifiers, then we want to wrap our iterable in the
         # filter method for each one, this will act as a logical AND amongst
         # each specifier.
         if self._specs:
-            current_iter = iterable
             for spec in self._specs:
-                current_iter = spec.filter(current_iter, prereleases=bool(prereleases))
-
-            # If prereleases is True there is no need for fallback logic.
-            if not prereleases_fallback or prereleases is True:
-                yield from current_iter
-            else:
-                # If prereleases was not explicitly set, we need to do a similar
-                # check to Specifier.filter to see if any final releases are yielded.
-                yielded = False
-                for version in current_iter:
-                    yield version
-                    yielded = True
-
-                # Fall back to prereleases if no final releases were found.
-                if not yielded:
-                    fallback_iter = iterable
-                    for spec in self._specs:
-                        fallback_iter = spec.filter(fallback_iter, prereleases=True)
-                    yield from fallback_iter
-
+                iterable = spec.filter(iterable, prereleases=prereleases)
+            return iter(iterable)
         # If we do not have any specifiers, then we need to have a rough filter
         # which will filter out any pre-releases, unless there are no final
         # releases.
@@ -1036,6 +970,6 @@ class SpecifierSet(BaseSpecifier):
             # If we've found no items except for pre-releases, then we'll go
             # ahead and use the pre-releases
             if not filtered and found_prereleases and prereleases is None:
-                yield from found_prereleases
+                return iter(found_prereleases)
 
-            yield from filtered
+            return iter(filtered)

--- a/src/packaging/specifiers.py
+++ b/src/packaging/specifiers.py
@@ -524,7 +524,7 @@ class Specifier(BaseSpecifier):
             :class:`Version` instance.
         :param prereleases:
             Whether or not to match prereleases with this Specifier. If set to
-            ``None`` (the default), it will follow the reccommendation from
+            ``None`` (the default), it will follow the recommendation from
             :pep:`440` and match prereleases, as there are no other versions.
 
         >>> Specifier(">=1.2.3").contains("1.2.3")

--- a/src/packaging/specifiers.py
+++ b/src/packaging/specifiers.py
@@ -877,6 +877,9 @@ class SpecifierSet(BaseSpecifier):
             Whether or not to match prereleases with this SpecifierSet. If set to
             ``None`` (the default), it will follow the recommendation from :pep:`440`
             and match prereleases, as there are no other versions.
+        :param installed:
+            Whether or not the item is installed. If set to ``True``, it will
+            accept prerelease versions even if the specifier does not allow them.
 
         >>> SpecifierSet(">=1.0.0,!=1.0.1").contains("1.2.3")
         True

--- a/tests/test_specifiers.py
+++ b/tests/test_specifiers.py
@@ -884,7 +884,7 @@ class TestSpecifierSet:
             # Test conflicting prereleases and contain_prereleases
             ("~=1.0", "1.1.0.dev1", True, False, False, False),
             ("~=1.0", "1.1.0.dev1", False, True, False, True),
-            # Test with specifiers that explicitly have prereleases overriden
+            # Test with specifiers that explicitly have prereleases overridden
             (">=1.0.dev1", "1.0.0.dev1", None, False, False, False),
             (">=1.0.dev1", "1.0.0.dev1", False, None, False, False),
         ],

--- a/tests/test_specifiers.py
+++ b/tests/test_specifiers.py
@@ -495,6 +495,72 @@ class TestSpecifier:
             assert not spec.contains(Version(version))
 
     @pytest.mark.parametrize(
+        (
+            "specifier",
+            "initial_prereleases",
+            "set_prereleases",
+            "version",
+            "initial_contains",
+            "final_contains",
+        ),
+        [
+            # Basic case: Default behavior includes prerelease versions
+            (">1.0", None, True, "1.0.dev1", False, False),
+            (">1.0", None, True, "2.0.dev1", True, True),
+            # Setting prereleases to True explicitly includes prerelease versions
+            (">1.0", None, True, "2.0.dev1", True, True),
+            (">1.0", False, True, "2.0.dev1", False, True),
+            # Setting prereleases to False explicitly excludes prerelease versions
+            (">1.0", None, False, "2.0.dev1", True, False),
+            (">1.0", True, False, "2.0.dev1", True, False),
+            # Setting prereleases to None falls back to default behavior
+            (">1.0", True, None, "2.0.dev1", True, True),
+            (">1.0", False, None, "2.0.dev1", False, True),
+            # Different specifiers with prerelease versions
+            (">=2.0.dev1", None, True, "2.0a1", True, True),
+            (">=2.0.dev1", None, False, "2.0a1", True, False),
+            # Alpha/beta/rc/dev variations
+            (">1.0", None, True, "2.0a1", True, True),
+            (">1.0", None, True, "2.0b1", True, True),
+            (">1.0", None, True, "2.0rc1", True, True),
+            # Edge cases
+            ("==2.0.*", None, True, "2.0.dev1", True, True),
+            ("==2.0.*", None, False, "2.0.dev1", True, False),
+            # Specifiers that already include prereleases implicitly
+            ("<1.0.dev1", None, False, "0.9.dev1", True, False),
+            (">1.0.dev1", None, None, "1.1.dev1", True, True),
+            # Multiple changes to the prereleases setting
+            # (initial -> True -> False)
+            (">1.0", True, False, "2.0.dev1", True, False),
+            # (initial -> False -> None)
+            (">1.0", False, None, "2.0.dev1", False, True),
+        ],
+    )
+    def test_specifier_prereleases_set(
+        self,
+        specifier,
+        initial_prereleases,
+        set_prereleases,
+        version,
+        initial_contains,
+        final_contains,
+    ):
+        """Test setting prereleases property."""
+        # Create the specifier with initial prereleases setting
+        spec = Specifier(specifier, prereleases=initial_prereleases)
+
+        # Check the initial behavior matches expectations
+        assert (version in spec) == initial_contains
+        assert spec.contains(version) == initial_contains
+
+        # Change the prereleases setting
+        spec.prereleases = set_prereleases
+
+        # Check the final behavior matches expectations
+        assert (version in spec) == final_contains
+        assert spec.contains(version) == final_contains
+
+    @pytest.mark.parametrize(
         ("version", "spec", "expected"),
         [
             ("1.0.0", "===1.0", False),


### PR DESCRIPTION
Fixes https://github.com/pypa/packaging/issues/854
Fixes https://github.com/pypa/packaging/issues/895
Fixes https://github.com/pypa/packaging/issues/856
Fixes https://github.com/pypa/packaging/issues/917

Builds on top of and, if accepted, supersedes https://github.com/pypa/packaging/pull/872

The goal of this is to have packaging specifier methods consistently follow the recommendation of PEP 440 and the specification:

> * accept already installed pre-releases for all version specifiers
> * accept remotely available pre-releases for version specifiers where there is no final or post release that satisfies the version specifier
> * exclude all other pre-releases from consideration

Specifically this PR fixes `Specifier.contains`, `SpecifierSet.contains`, and `SepcifierSet.filter`, but does not change the behavior of `Sepcifier.filter` which already correctly complies with the above points.

This PR moves all the logic of implementing this into the `filter` methods and then makes the `contains` methods fairly simple wrappers around the `filter` methods.

This PR adds many tests, but could probably do with thousands more.