### PR TITLE
tests: modernize and speed up on Python 3.14

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -37,23 +37,24 @@ nox.options.reuse_existing_virtualenvs = True
     ]
 )
 def tests(session):
-    def coverage(*args):
-        session.run("python", "-m", "coverage", *args)
+    coverage = ["python", "-m", "coverage"]
 
     session.install("-r", "tests/requirements.txt")
     session.install(".")
+    env = {} if session.python != "3.14" else {"COVERAGE_CORE": "sysmon"}
 
     if "pypy" not in session.python:
-        coverage(
+        session.run(
+            *coverage,
             "run",
             "--source",
             "packaging",
             "-m",
             "pytest",
-            "--strict-markers",
             *session.posargs,
+            env=env,
         )
-        coverage("report", "-m", "--fail-under", "100")
+        session.run(*coverage, "report", "-m", "--fail-under", "100")
     else:
         # Don't do coverage tracking for PyPy, since it's SLOW.
         session.run(
@@ -61,7 +62,6 @@ def tests(session):
             "-m",
             "pytest",
             "--capture=no",
-            "--strict-markers",
             *session.posargs,
         )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,14 @@ branch = true
 [tool.coverage.report]
 exclude_lines = ["pragma: no cover", "@abc.abstractmethod", "@abc.abstractproperty"]
 
+[tool.pytest.ini_options]
+minversion = "6.2"
+addopts = ["-ra", "--showlocals", "--strict-markers", "--strict-config"]
+xfail_strict = true
+filterwarnings = ["error"]
+log_cli_level = "INFO"
+testpaths = ["tests"]
+
 
 [tool.mypy]
 strict = true

--- a/tests/test_manylinux.py
+++ b/tests/test_manylinux.py
@@ -7,7 +7,6 @@ import pathlib
 import platform
 import sys
 import types
-import warnings
 
 import pretend
 import pytest
@@ -72,10 +71,8 @@ def test_is_manylinux_compatible_glibc_support(version, compatible, monkeypatch)
 
 @pytest.mark.parametrize("version_str", ["glibc-2.4.5", "2"])
 def test_check_glibc_version_warning(version_str):
-    with warnings.catch_warnings(record=True) as w:
+    with pytest.warns(RuntimeWarning):
         _parse_glibc_version(version_str)
-        assert len(w) == 1
-        assert issubclass(w[0].category, RuntimeWarning)
 
 
 @pytest.mark.skipif(not ctypes, reason="requires ctypes")

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -7,7 +7,7 @@ from packaging.metadata import ExceptionGroup
 
 
 class TestRawMetadata:
-    @pytest.mark.parametrize("raw_field", metadata._STRING_FIELDS)
+    @pytest.mark.parametrize("raw_field", sorted(metadata._STRING_FIELDS))
     def test_non_repeating_fields_only_once(self, raw_field):
         data = "VaLuE"
         header_field = metadata._RAW_TO_EMAIL_MAPPING[raw_field]
@@ -18,7 +18,7 @@ class TestRawMetadata:
         assert raw_field in raw
         assert raw[raw_field] == data
 
-    @pytest.mark.parametrize("raw_field", metadata._STRING_FIELDS)
+    @pytest.mark.parametrize("raw_field", sorted(metadata._STRING_FIELDS))
     def test_non_repeating_fields_repeated(self, raw_field):
         header_field = metadata._RAW_TO_EMAIL_MAPPING[raw_field]
         data = "VaLuE"
@@ -30,7 +30,7 @@ class TestRawMetadata:
         assert header_field in unparsed
         assert unparsed[header_field] == [data] * 2
 
-    @pytest.mark.parametrize("raw_field", metadata._LIST_FIELDS)
+    @pytest.mark.parametrize("raw_field", sorted(metadata._LIST_FIELDS))
     def test_repeating_fields_only_once(self, raw_field):
         data = "VaLuE"
         header_field = metadata._RAW_TO_EMAIL_MAPPING[raw_field]
@@ -41,7 +41,7 @@ class TestRawMetadata:
         assert raw_field in raw
         assert raw[raw_field] == [data]
 
-    @pytest.mark.parametrize("raw_field", metadata._LIST_FIELDS)
+    @pytest.mark.parametrize("raw_field", sorted(metadata._LIST_FIELDS))
     def test_repeating_fields_repeated(self, raw_field):
         header_field = metadata._RAW_TO_EMAIL_MAPPING[raw_field]
         data = "VaLuE"


### PR DESCRIPTION
I was adding some pytest config, and I noticed we could speed up coverage on Python 3.14. For me it dropped from 55 seconds to 35 seconds.
