### PR TITLE
chore: clean up ruff ignores

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,23 +84,6 @@ extend-select = [
     "W"
 ]
 ignore = [
-    "B027",
-    "F821",
-    "N818",
-    "RUF003",
-    "RUF012",
-    "UP032",
-    # https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules
-    "W191",
-    "E111",
-    "E114",
-    "E117",
-    "D206",
-    "D300",
-    "Q000",
-    "Q001",
-    "Q002",
-    "Q003",
-    "COM812",
-    "COM819",
+    "N818",  # exceptions must end in "*Error"
+    "UP032", # f-strings over % or .format
 ]

--- a/src/packaging/markers.py
+++ b/src/packaging/markers.py
@@ -196,7 +196,7 @@ def _eval_op(lhs: str, op: Op, rhs: str | AbstractSet[str]) -> bool:
 def _normalize(
     lhs: str, rhs: str | AbstractSet[str], key: str
 ) -> tuple[str, str | AbstractSet[str]]:
-    # PEP 685 – Comparison of extra names for optional distribution dependencies
+    # PEP 685 - Comparison of extra names for optional distribution dependencies
     # https://peps.python.org/pep-0685/
     # > When comparing extra names, tools MUST normalize the names being
     # > compared using the semantics outlined in PEP 503 for names

--- a/src/packaging/metadata.py
+++ b/src/packaging/metadata.py
@@ -25,7 +25,7 @@ T = typing.TypeVar("T")
 
 
 if sys.version_info >= (3, 11):  # pragma: no cover
-    ExceptionGroup = ExceptionGroup
+    ExceptionGroup = ExceptionGroup  # noqa: F821
 else:  # pragma: no cover
 
     class ExceptionGroup(Exception):

--- a/src/packaging/specifiers.py
+++ b/src/packaging/specifiers.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import abc
 import itertools
 import re
-from typing import Callable, Iterable, Iterator, TypeVar, Union
+from typing import Callable, Final, Iterable, Iterator, TypeVar, Union
 
 from .utils import canonicalize_version
 from .version import Version
@@ -73,7 +73,7 @@ class BaseSpecifier(metaclass=abc.ABCMeta):
         prereleases or it can be set to ``None`` (the default) to use default semantics.
         """
 
-    @prereleases.setter
+    @prereleases.setter  # noqa: B027
     def prereleases(self, value: bool) -> None:
         """Setter for :attr:`prereleases`.
 
@@ -208,7 +208,7 @@ class Specifier(BaseSpecifier):
         re.VERBOSE | re.IGNORECASE,
     )
 
-    _operators = {
+    _operators: Final = {
         "~=": "compatible",
         "==": "equal",
         "!=": "not_equal",


### PR DESCRIPTION
A lot of these ignores aren't needed anymore (Ruff fixed the conflicts), and some of them are better inline, where you can see that something is intentionally unusual.
