### PR TITLE
Move codespell configuration into pyproject.toml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,4 +33,7 @@ repos:
   - repo: https://github.com/codespell-project/codespell
     rev: "v2.4.1"
     hooks:
-    - id: codespell
+      - id: codespell
+        additional_dependencies:
+          - tomli  # for python_version < '3.11'
+

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,5 +35,4 @@ repos:
     hooks:
       - id: codespell
         additional_dependencies:
-          - "tomli; python_version<'3.11'"
-
+          - tomli; python_version<'3.11'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,5 +35,5 @@ repos:
     hooks:
       - id: codespell
         additional_dependencies:
-          - tomli  # for python_version < '3.11'
+          - "tomli; python_version<'3.11'"
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,4 +34,3 @@ repos:
     rev: "v2.4.1"
     hooks:
     - id: codespell
-      args: ["-Ldynamc,notin"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,10 @@ exclude = ["docs/_build", "tests/manylinux/build-hello-world.sh", "tests/musllin
 skip = '.git'
 check-hidden = true
 # ignore-regex = ''
-ignore-words-list = 'dynamc,notin'
+ignore-words-list = [
+    "dynamc",
+    "notin"
+]
 
 [tool.coverage.run]
 branch = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,12 @@ Source = "https://github.com/pypa/packaging"
 include = ["tests/", "docs/", "CHANGELOG.rst"]
 exclude = ["docs/_build", "tests/manylinux/build-hello-world.sh", "tests/musllinux/build.sh", "tests/hello-world.c", "tests/__pycache__", "build/__pycache__"]
 
+[tool.codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = '.git'
+check-hidden = true
+# ignore-regex = ''
+ignore-words-list = 'dynamc,notin'
 
 [tool.coverage.run]
 branch = true


### PR DESCRIPTION
So it is

- among other tools
- could be used/ran outside of pre-commit, e.g. just "codespell" or "codespell -w" to apply the fixes