### PR TITLE
chore: better local runs for codespell

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,10 +41,6 @@ include = ["tests/", "docs/", "CHANGELOG.rst"]
 exclude = ["docs/_build", "tests/manylinux/build-hello-world.sh", "tests/musllinux/build.sh", "tests/hello-world.c", "tests/__pycache__", "build/__pycache__"]
 
 [tool.codespell]
-# Ref: https://github.com/codespell-project/codespell#using-a-config-file
-skip = '.git'
-check-hidden = true
-# ignore-regex = ''
 ignore-words-list = [
     "dynamc",
     "notin"


### PR DESCRIPTION
Quick followup to #910. Don't run on hidden folders and files automatically when run by hand.


CC @yarikoptic.