### PR TITLE
Run twine-check on push in CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -51,6 +51,9 @@ jobs:
       - name: Build
         run: pipx run build
 
+      - name: Build
+        run: pipx run twine check --strict
+
       - name: Archive files
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:


### PR DESCRIPTION
Run `twine check` in linting CI workflow's 'build' job, which runs on each push and pull request update (when relevant files are updated). This checks the validity of the built distribution. This is a result of [a comment](https://github.com/pypa/packaging/pull/893/files#r2232663778) on #893.