### PR TITLE
No need for `license-files`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,6 @@ name = "packaging"
 description = "Core utilities for Python packages"
 dynamic = ["version"]
 license = "Apache-2.0 OR BSD-2-Clause"
-license-files = ["LICENSE*"]
 readme = "README.rst"
 requires-python = ">=3.8"
 authors = [{name = "Donald Stufft", email = "donald@stufft.io"}]


### PR DESCRIPTION
The default value is `LICEN[CS]E*` and covers `LICENSE*`.

https://flit.pypa.io/en/stable/pyproject_toml.html#new-style-metadata
> **license-files**
> 
> A list of glob patterns for license files to include. Defaults to `['COPYING*', 'LICEN[CS]E*']`.
