### PR TITLE
Correct regex for metadata 'name' format

### DIFF
--- a/src/packaging/utils.py
+++ b/src/packaging/utils.py
@@ -35,7 +35,7 @@ class InvalidSdistFilename(ValueError):
 
 # Core metadata spec for `Name`
 _validate_regex = re.compile(
-    r"^([A-Z0-9]|[A-Z0-9][A-Z0-9._-]*[A-Z0-9])$", re.IGNORECASE
+    r"^([A-Z0-9]|[A-Z0-9][A-Z0-9._-]*[A-Z0-9])\Z", re.IGNORECASE
 )
 _canonicalize_regex = re.compile(r"[-_.]+")
 _normalized_regex = re.compile(r"^([a-z0-9]|[a-z0-9]([a-z0-9-](?!--))*[a-z0-9])$")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -37,10 +37,22 @@ def test_canonicalize_name(name, expected):
     assert canonicalize_name(name) == expected
 
 
-def test_canonicalize_name_invalid():
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        ("_not_legal", "-not-legal"),
+        ("hi\n", "hi\n"),
+        ("\nhi", "\nhi"),
+        ("h\ni", "h\ni"),
+        ("hi\r", "hi\r"),
+        ("\rhi", "\rhi"),
+        ("h\ri", "h\ri"),
+    ],
+)
+def test_canonicalize_name_invalid(name, expected):
     with pytest.raises(InvalidName):
-        canonicalize_name("_not_legal", validate=True)
-    assert canonicalize_name("_not_legal") == "-not-legal"
+        canonicalize_name(name, validate=True)
+    assert canonicalize_name(name) == expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
The current regex permits strings that end in the newline character, which is counter to what the description for the field states ("ASCII letters and numbers, period, underscore and hyphen").

This updates the regex to use `\Z` instead of `$` to match at the end of the string and exclude newline characters.

Corresponding update to the spec is here: https://github.com/pypa/packaging.python.org/pull/1898.