### PR TITLE
Fix docs and docs ci after #897 landed

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,10 +5,12 @@ on:
     paths:
       - ".github/workflows/docs.yml"
       - "docs/**"
+      - "src/**"
   push:
     paths:
       - ".github/workflows/docs.yml"
       - "docs/**"
+      - "src/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}

--- a/src/packaging/specifiers.py
+++ b/src/packaging/specifiers.py
@@ -510,7 +510,7 @@ class Specifier(BaseSpecifier):
         >>> "1.0.0" in Specifier(">=1.2.3")
         False
         >>> "1.3.0a1" in Specifier(">=1.2.3")
-        False
+        True
         >>> "1.3.0a1" in Specifier(">=1.2.3", prereleases=True)
         True
         """
@@ -534,7 +534,7 @@ class Specifier(BaseSpecifier):
         >>> Specifier(">=1.2.3").contains("1.0.0")
         False
         >>> Specifier(">=1.2.3").contains("1.3.0a1")
-        False
+        True
         >>> Specifier(">=1.2.3", prereleases=False).contains("1.3.0a1")
         False
         >>> Specifier(">=1.2.3").contains("1.3.0a1")
@@ -856,7 +856,7 @@ class SpecifierSet(BaseSpecifier):
         >>> "1.0.1" in SpecifierSet(">=1.0.0,!=1.0.1")
         False
         >>> "1.3.0a1" in SpecifierSet(">=1.0.0,!=1.0.1")
-        False
+        True
         >>> "1.3.0a1" in SpecifierSet(">=1.0.0,!=1.0.1", prereleases=True)
         True
         """
@@ -921,7 +921,7 @@ class SpecifierSet(BaseSpecifier):
         >>> list(SpecifierSet(">=1.2.3").filter(["1.2", "1.3", Version("1.4")]))
         ['1.3', <Version('1.4')>]
         >>> list(SpecifierSet(">=1.2.3").filter(["1.2", "1.5a1"]))
-        ["1.5a1"]
+        ['1.5a1']
         >>> list(SpecifierSet(">=1.2.3").filter(["1.3", "1.5a1"], prereleases=True))
         ['1.3', '1.5a1']
         >>> list(SpecifierSet(">=1.2.3", prereleases=True).filter(["1.3", "1.5a1"]))


### PR DESCRIPTION
https://github.com/pypa/packaging/pull/897 changed the behavior of Specifier and SpecifierSet handling of prereleases, but some doc strings were not correctly updated

This was missed because the docs workflow does not run if nothing in docs is updated, but the docs workflow includes running tests against doc strings in `src`, so it should also run if anything in `src` has been updated.

Apologies, I was unaware of this docs test workflow.