### PR TITLE
Changed static type annotations in prereleases setter method in specifier.py

### DIFF
--- a/src/packaging/specifiers.py
+++ b/src/packaging/specifiers.py
@@ -268,7 +268,7 @@ class Specifier(BaseSpecifier):
         return False
 
     @prereleases.setter
-    def prereleases(self, value: bool) -> None:
+    def prereleases(self, value: bool | None) -> None:
         self._prereleases = value
 
     @property
@@ -730,7 +730,7 @@ class SpecifierSet(BaseSpecifier):
         return None
 
     @prereleases.setter
-    def prereleases(self, value: bool) -> None:
+    def prereleases(self, value: bool | None) -> None:
         self._prereleases = value
 
     def __repr__(self) -> str:


### PR DESCRIPTION
There are two changes made to the value parameters of the `prereleases` setter methods of the `Specifier` and `SpecifierSet` class, since both of them are accepting `None` values at runtime from the unit tests. The links to the unit tests are as follows where they are accepting None values as arguments to the value parameter even though it is statically annotated as `bool`.

https://github.com/pypa/packaging/blob/e5470c1854e352f68fa3f83df9cbb0af59558c49/tests/test_specifiers.py#L497
https://github.com/pypa/packaging/blob/e5470c1854e352f68fa3f83df9cbb0af59558c49/tests/test_specifiers.py#L746