### PR TITLE
Support nested parens in license expressions

### DIFF
--- a/src/packaging/licenses/__init__.py
+++ b/src/packaging/licenses/__init__.py
@@ -90,7 +90,7 @@ def canonicalize_license_expression(
             python_tokens.append("False")
         elif token == "with":
             python_tokens.append("or")
-        elif token == "(" and python_tokens and python_tokens[-1] not in {"or", "and"}:
+        elif token == "(" and python_tokens and python_tokens[-1] not in {"or", "and", "("}:
             message = f"Invalid license expression: {raw_license_expression!r}"
             raise InvalidLicenseExpression(message)
         elif token == ")" and python_tokens and python_tokens[-1] == "(":

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -684,6 +684,12 @@ class TestMetadata:
                 "(LicenseRef-Special-License OR licenseref-OtherLicense) OR unlicense",
                 "(LicenseRef-Special-License OR LicenseRef-OtherLicense) OR Unlicense",
             ),
+            # we don't canonicalize redundant parens, instead leaving them as-is
+            # in the license expression.
+            ("(MIT)", "(MIT)"),
+            ("((MIT))", "((MIT))"),
+            ("(( MIT ))", "((MIT))"),
+            ("((MIT AND (MIT)))", "((MIT AND (MIT)))"),
         ],
     )
     def test_valid_license_expression(self, license_expression, expected):


### PR DESCRIPTION
Closes https://github.com/pypa/packaging/issues/928.

I've tested this with the following hypothesis test:

<details><summary>Details</summary>

```python
import lark
from hypothesis import given, settings
from hypothesis.extra.lark import from_lark
from packaging.metadata import licenses

# naming and order follows
# https://spdx.github.io/spdx-spec/v2.2.2/SPDX-license-expressions/
grammar = """
start: license_expression

idstring: (ALPHA | DIGIT | "-" | ".")+
# a few hardcoded test licenses and exceptions
license_id: "MIT"
          | "Apache-2.0"
          | "GPL-3.0"
          | "BSD-3-Clause"
          | "ISC"
license_exception_id: "LLVM-exception"
                    | "Classpath-exception-2.0"
                    | "GCC-exception-3.1"

# DocumentRef is a valid prefix according to
# https://spdx.github.io/spdx-spec/v2.2.2/SPDX-license-expressions/, but
# we don't implement it.
# license_ref: ("DocumentRef-" idstring ":")? "LicenseRef-" idstring
license_ref: "LicenseRef-" idstring

simple_expression: license_id
                 | license_id "+"
                 | license_ref
compound_expression: simple_expression
                   | simple_expression " WITH " license_exception_id
                   | compound_expression " AND " compound_expression
                   | compound_expression " OR " compound_expression
                   | "(" compound_expression ")"
license_expression: simple_expression | compound_expression

%import common.LETTER -> ALPHA
%import common.DIGIT
"""

parser = lark.Lark(grammar)

@given(from_lark(parser))
@settings(deadline=None)
def test_canonicalize_license_expression(expression):
    licenses.canonicalize_license_expression(expression)
```

</details> 



I'm very happy to add this test to the suite if you think it's worth the hypothesis dependency.