### PR TITLE
Return `False` instead of raising for `.contains` with invalid version

### DIFF
--- a/tests/test_specifiers.py
+++ b/tests/test_specifiers.py
@@ -495,6 +495,17 @@ class TestSpecifier:
             assert not spec.contains(Version(version))
 
     @pytest.mark.parametrize(
+        ("spec", "version"),
+        [
+            ("==1.0", "not a valid version"),
+            ("===invalid", "invalid"),
+        ],
+    )
+    def test_invalid_spec(self, spec, version):
+        spec = Specifier(spec, prereleases=True)
+        assert not spec.contains(version)
+
+    @pytest.mark.parametrize(
         (
             "specifier",
             "initial_prereleases",
@@ -960,6 +971,9 @@ class TestSpecifierSet:
             (">=1.0,<=2.0", False, True, ["1.0", "1.5a1"], ["1.0", "1.5a1"]),
             (">=1.0,<=2.0dev", True, False, ["1.0", "1.5a1"], ["1.0"]),
             (">=1.0,<=2.0dev", False, True, ["1.0", "1.5a1"], ["1.0", "1.5a1"]),
+            # Test that invalid versions are discarded
+            ("", None, None, ["not a valid version"], []),
+            ("", None, None, ["1.0", "not a valid version"], ["1.0"]),
         ],
     )
     def test_specifier_filter(
@@ -973,6 +987,16 @@ class TestSpecifierSet:
         kwargs = {"prereleases": prereleases} if prereleases is not None else {}
 
         assert list(spec.filter(input, **kwargs)) == expected
+
+    @pytest.mark.parametrize(
+        ("specifier", "input"),
+        [
+            (">=1.0", "not a valid version"),
+        ],
+    )
+    def test_contains_rejects_invalid_specifier(self, specifier, input):
+        spec = SpecifierSet(specifier, prereleases=True)
+        assert not spec.contains(input)
 
     @pytest.mark.parametrize(
         ("specifier", "expected"),


### PR DESCRIPTION
Closes https://github.com/pypa/packaging/issues/767.