### PR TITLE
chore: ruff was renamed ruff-check in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-toml
       - id: check-yaml
@@ -9,7 +9,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.15.0
+    rev: v1.18.1
     hooks:
       - id: mypy
         exclude: '^(docs|tasks|tests)|setup\.py'
@@ -17,9 +17,9 @@ repos:
         additional_dependencies: [pyparsing, nox, orjson]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.8
+    rev: v0.13.0
     hooks:
-      - id: ruff
+      - id: ruff-check
         args: [ --fix, --show-fixes ]
       - id: ruff-format
 


### PR DESCRIPTION
This was renamed, avoids a warning about an old alias. Also bumped pre-commit versions.
