### PR TITLE
fix(markers): only parse versions on certain keys

### DIFF
--- a/src/packaging/markers.py
+++ b/src/packaging/markers.py
@@ -28,6 +28,11 @@ __all__ = [
 Operator = Callable[[str, Union[str, AbstractSet[str]]], bool]
 EvaluateContext = Literal["metadata", "lock_file", "requirement"]
 MARKERS_ALLOWING_SET = {"extras", "dependency_groups"}
+MARKERS_REQUIRING_VERSION = {
+    "python_version",
+    "python_full_version",
+    "implementation_version",
+}
 
 
 class InvalidMarker(ValueError):
@@ -177,16 +182,17 @@ _operators: dict[str, Operator] = {
 }
 
 
-def _eval_op(lhs: str, op: Op, rhs: str | AbstractSet[str]) -> bool:
-    if isinstance(rhs, str):
+def _eval_op(lhs: str, op: Op, rhs: str | AbstractSet[str], *, key: str) -> bool:
+    op_str = op.serialize()
+    if key in MARKERS_REQUIRING_VERSION:
         try:
-            spec = Specifier("".join([op.serialize(), rhs]))
+            spec = Specifier("".join([op_str, rhs]))
         except InvalidSpecifier:
             pass
         else:
             return spec.contains(lhs, prereleases=True)
 
-    oper: Operator | None = _operators.get(op.serialize())
+    oper: Operator | None = _operators.get(op_str)
     if oper is None:
         raise UndefinedComparison(f"Undefined {op!r} on {lhs!r} and {rhs!r}.")
 
@@ -234,9 +240,10 @@ def _evaluate_markers(
                 lhs_value = lhs.value
                 environment_key = rhs.value
                 rhs_value = environment[environment_key]
+
             assert isinstance(lhs_value, str), "lhs must be a string"
             lhs_value, rhs_value = _normalize(lhs_value, rhs_value, key=environment_key)
-            groups[-1].append(_eval_op(lhs_value, op, rhs_value))
+            groups[-1].append(_eval_op(lhs_value, op, rhs_value, key=environment_key))
         else:
             assert marker in ["and", "or"]
             if marker == "or":

--- a/tests/test_markers.py
+++ b/tests/test_markers.py
@@ -426,3 +426,22 @@ class TestMarker:
 
         with pytest.raises(KeyError):
             marker.evaluate(context="requirement")
+
+    @pytest.mark.parametrize(
+        ("marker_string", "environment", "expected"),
+        [
+            ('extra == "v2"', None, False),
+            ('extra == "v2"', {"extra": ""}, False),
+            ('extra == "v2"', {"extra": "v2"}, True),
+            ('extra == "v2"', {"extra": "v2a3"}, False),
+            ('extra == "v2a3"', {"extra": "v2"}, False),
+            ('extra == "v2a3"', {"extra": "v2a3"}, True),
+        ],
+    )
+    def test_version_like_equality(self, marker_string, environment, expected):
+        """
+        Test for issue #938: Extras are meant to be literal strings, even if
+        they look like versions, and therefore should not be parsed as version.
+        """
+        marker = Marker(marker_string)
+        assert marker.evaluate(environment) is expected


### PR DESCRIPTION
According to the [environment markers](https://packaging.python.org/en/latest/specifications/dependency-specifiers/#environment-markers), most markers are strings, with only a small subset being use to handle versions. As such, this PR changes the behaviour to use version comparison only on those keys which are dealing with versions.

Note that the choice of only doing version comparison on keys which are defined as being versions results in one failure for a custom key:

```text
    def test_prefers_pep440(self):
>       assert Marker('"2.7.9" < "foo"').evaluate(dict(foo="2.7.10"))
E       assert False
E        +  where False = evaluate({'foo': '2.7.10'})
E        +    where evaluate = <Marker('"2.7.9" < "foo"')>.evaluate
E        +      where <Marker('"2.7.9" < "foo"')> = Marker('"2.7.9" < "foo"')
E        +    and   {'foo': '2.7.10'} = dict(foo='2.7.10')
```

From my reading of the specification, it is unclear whether the use of version comparison in this case is meant to be supported or not.

I can see a few ways of moving forward

1. If version comparisons are only meant to be used with the defined set of keys, then this PR is ready to go, requiring only that the one test be changed to expect failure.

2. If version comparison should be the default, and only some keys are exempted from the version comparison, then we can invert the logic in `_eval_op` from an `if key in MARKERS_REQUIRING_VERSION:` to an `if key in MARKERS_REQUIRING_STRING_COMPARISON`. If this is the case, then we would need to define what those keys are.

3. An intermediate approach would be to inspect the operator and, for example, using version comparison for `<`, `<=`, `>=`, `>`, `~=` and `===`, and string comparison for `==` and `!=`. I don't like this approach as it muddies the logic, and I think it would be better to be explicit about which keys are to be treated as versions.

Resolves: #938