### PR TITLE
Fix incorrectly implicitly concatenated string in specifiers test

### DIFF
--- a/tests/test_specifiers.py
+++ b/tests/test_specifiers.py
@@ -179,7 +179,7 @@ class TestSpecifier:
             "1.0-POST1",
             "1.0-5",
             # Local version case insensitivity
-            "1.0+AbC"
+            "1.0+AbC",
             # Integer Normalization
             "1.01",
             "1.0a05",


### PR DESCRIPTION
Missing comma causes test to incorrectly parse `1.0+AbC1.01` instead of `1.0+AbC` and `1.01`.

Found this while writing extensive tests for https://github.com/pypa/packaging/issues/940.

I investigated if enabling the `ISC` rules in ruff would have caught this, but actually it appears not: https://github.com/astral-sh/ruff/issues/20854