### PR TITLE
fix: add space before at symbol in Requirements string

### DIFF
--- a/src/packaging/requirements.py
+++ b/src/packaging/requirements.py
@@ -57,7 +57,7 @@ class Requirement:
             yield str(self.specifier)
 
         if self.url:
-            yield f"@ {self.url}"
+            yield f" @ {self.url}"
             if self.marker:
                 yield " "
 

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -633,7 +633,7 @@ class TestRequirementBehaviour:
 
     @pytest.mark.parametrize(
         "url_or_specifier",
-        ["", "@ https://url ", "!=2.0", "==2.*"],
+        ["", " @ https://url ", "!=2.0", "==2.*"],
     )
     @pytest.mark.parametrize("extras", ["", "[a]", "[a,b]", "[a1,b1,b2]"])
     @pytest.mark.parametrize(


### PR DESCRIPTION
Fix for https://github.com/pypa/packaging/issues/935.
