### PR TITLE
chore: pytest log_level is better than log_cli_level

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ minversion = "6.2"
 addopts = ["-ra", "--showlocals", "--strict-markers", "--strict-config"]
 xfail_strict = true
 filterwarnings = ["error"]
-log_cli_level = "INFO"
+log_level = "INFO"
 testpaths = ["tests"]
 
 


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos

See https://github.com/scientific-python/cookie/issues/679

Note that there's not a practical difference, since `log_cli_level` doesn't trigger live logging if it's in a config file, but this is more conceptually correct (and maps to the CLI better, as `--log-cli-level` does trigger live logging).