### PR TITLE
chore: add more checks that don't affect anything

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,16 +89,21 @@ extend-exclude = [
 
 [tool.ruff.lint]
 extend-select = [
-    "B",
+    "B",     # flake8-bugbear
     "E",
+    "EXE",   # flake8-executable
     "F",
-    "FA",
+    "FA",    # flake8-future-annotations
     "I",
-    "N",
-    "PYI",
-    "RUF",
-    "UP",
-    "W"
+    "N",     # pep8-naming
+    "PGH",   # pygrep-hooks
+    "PYI",   # flake8-pyi
+    "RUF",   # Ruff-specific rules
+    "SLOT",  # flake8-slots
+    "T10",   # flake8-debugger
+    "UP",    # pyupgrade
+    "W",
+    "YTT",   # flake8-2020
 ]
 ignore = [
     "N818",  # exceptions must end in "*Error"


### PR DESCRIPTION
Adding a few checks that currently pass. Also noting the names of the checks.

Remaining for future PRs (may not apply all, but will at least look at them):

```
  "BLE",   # flake8-blind-except
  "DTZ",   # flake8-datetimez
  "EM",    # flake8-errmsg
  "PERF",  # Perflint
  "PTH",   # flake8-use-pathlib
  "RET",   # flake8-return
  "SIM",   # flake8-simplify
  "T20",   # flake8-print
  "TC",    # flake8-type-checking
```