### PR TITLE
chore: adding ruff PERF

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,7 @@ extend-select = [
     "ISC",   # flake8-implicit-str-concat
     "LOG",   # flake8-logging
     "N",     # pep8-naming
+    "PERF",  # perflint
     "PGH",   # pygrep-hooks
     "PIE",   # flake8-pie
     "PL",    # pylint

--- a/src/packaging/tags.py
+++ b/src/packaging/tags.py
@@ -223,7 +223,7 @@ def cpython_tags(
     for explicit_abi in ("abi3", "none"):
         try:
             abis.remove(explicit_abi)
-        except ValueError:
+        except ValueError:  # noqa: PERF203
             pass
 
     platforms = list(platforms or platform_tags())


### PR DESCRIPTION
This is adding the PERF rule. The main change I made to make the rule happy was to move the try/excepts outside loops, which reduces overhead. I just ignored the rule in one case where the loop was always two elements.

I also fixed the return types in a few cases where there was a clear concrete return type. Return types should be as specific as possible, while input types should be as general as possible.
