### PR TITLE
chore: move some config into coverage config

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -43,21 +43,19 @@ def tests(session):
     coverage = ["python", "-m", "coverage"]
 
     session.install(*nox.project.dependency_groups(PYPROJECT, "test"))
-    session.install(".")
+    session.install("-e.")
     env = {} if session.python != "3.14" else {"COVERAGE_CORE": "sysmon"}
 
     if "pypy" not in session.python:
         session.run(
             *coverage,
             "run",
-            "--source",
-            "packaging",
             "-m",
             "pytest",
             *session.posargs,
             env=env,
         )
-        session.run(*coverage, "report", "-m", "--fail-under", "100")
+        session.run(*coverage, "report")
     else:
         # Don't do coverage tracking for PyPy, since it's SLOW.
         session.run(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ Source = "https://github.com/pypa/packaging"
 
 [dependency-groups]
 test = [
-  "coverage[toml]>=5.0.0",
+  "coverage[toml]>=7.2.0",
   "pip>=21.1",
   "pretend",
   "pytest>=6.2.0",
@@ -59,9 +59,12 @@ ignore-words-list = [
 
 [tool.coverage.run]
 branch = true
+source_pkgs = ["packaging"]
 
 [tool.coverage.report]
-exclude_lines = ["pragma: no cover", "@abc.abstractmethod", "@abc.abstractproperty"]
+show_missing = true
+fail_under = 100
+exclude_also = ["@abc.abstractmethod", "@abc.abstractproperty"]
 
 [tool.pytest.ini_options]
 minversion = "6.2"


### PR DESCRIPTION
Moving some config into coverage config instead of command line arguments passed in the noxfile. Bumps the min version of coverage a bit, to 7.2, a couple of years old, for `exclude_also`. Also using an editable install, which makes nox's  `-R` flag work better.