### PR TITLE
chore: adding ruff T20

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,6 +122,7 @@ extend-select = [
     "SIM",   # flake8-simplify
     "SLOT",  # flake8-slots
     "T10",   # flake8-debugger
+    "T20",   # flake8-print
     "TRY",   # tryceratops
     "UP",    # pyupgrade
     "W",
@@ -140,6 +141,8 @@ flake8-comprehensions.allow-dict-calls-with-keyword-arguments = true
 flake8-unused-arguments.ignore-variadic-names = true
 
 [tool.ruff.lint.per-file-ignores]
-"tests/test_*.py" = ["PYI024", "PLR", "SIM201"]
-"tasks/check.py" = ["UP032"]
+"tests/test_*.py" = ["PYI024", "PLR", "SIM201", "T20"]
+"tasks/check.py" = ["UP032", "T20"]
 "tests/test_requirements.py" = ["UP032"]
+"src/packaging/_musllinux.py" = ["T20"]
+"noxfile.py" = ["T20"]


### PR DESCRIPTION
This ensures print statements don't sneak in when debugging. Like what happened to PyPy a few versions ago, breaking numpy. :)
