### PR TITLE
ci: add a tests pass job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,3 +40,18 @@ jobs:
 
       - name: Run nox
         run: pipx run nox --error-on-missing-interpreters -s tests-${{ matrix.python_version }}
+
+  pass:
+    name: All pass
+    if: always()
+
+    needs:
+      - test
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Decide whether the needed jobs succeeded or failed
+        uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
This job will pass only if all the other test jobs pass. It can be used for branch protection, for example; since it doesn't change like the test matrix does. Currently we only require the docs pass, with this we could require the test pass too.

I've occasionally had people request longer names; I've got with my default (`tests (workflow) -> pass (job)`), but can change it if anyone wants something different.
