### PR TITLE
chore: enable ruff EM

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -203,18 +203,21 @@ def _get_version_from_arguments(arguments: list[str]) -> str:
     Otherwise, raise a ValueError describing what's wrong.
     """
     if len(arguments) != 1:
-        raise ValueError("Expected exactly 1 argument")
+        msg = "Expected exactly 1 argument"
+        raise ValueError(msg)
 
     version = arguments[0]
     parts = version.split(".")
 
     if len(parts) != 2:
         # Not of the form: YY.N
-        raise ValueError("not of the form: YY.N")
+        msg = "not of the form: YY.N"
+        raise ValueError(msg)
 
     if not all(part.isdigit() for part in parts):
         # Not all segments are integers.
-        raise ValueError("non-integer segments")
+        msg = "non-integer segments"
+        raise ValueError(msg)
 
     # All is good.
     return version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,13 +93,11 @@ extend-exclude = [
 show-fixes = true
 
 [tool.ruff.lint]
-select = ["ALL"]
 ignore = [
     "A002",    # function args shadowing builtins is fine
     "C9",      # complexity
     "COM812",  # trailing commas teach the formatter
     "D",       # doc formatting
-    "EM",      # flake8-errmsg
     "ERA",     # commented out code
     "FBT",     # boolean positional args (existing API)
     "FIX",     # has todos

--- a/src/packaging/_elffile.py
+++ b/src/packaging/_elffile.py
@@ -48,10 +48,12 @@ class ELFFile:
         try:
             ident = self._read("16B")
         except struct.error as e:
-            raise ELFInvalid("unable to parse identification") from e
+            msg = "unable to parse identification"
+            raise ELFInvalid(msg) from e
         magic = bytes(ident[:4])
         if magic != b"\x7fELF":
-            raise ELFInvalid(f"invalid magic: {magic!r}")
+            msg = f"invalid magic: {magic!r}"
+            raise ELFInvalid(msg)
 
         self.capacity = ident[4]  # Format for program header (bitness).
         self.encoding = ident[5]  # Data structure encoding (endianness).
@@ -67,9 +69,10 @@ class ELFFile:
                 (2, 2): (">HHIQQQIHHH", ">IIQQQQQQ", (0, 2, 5)),  # 64-bit MSB.
             }[(self.capacity, self.encoding)]
         except KeyError as e:
-            raise ELFInvalid(
+            msg = (
                 f"unrecognized capacity ({self.capacity}) or encoding ({self.encoding})"
-            ) from e
+            )
+            raise ELFInvalid(msg) from e
 
         try:
             (
@@ -85,7 +88,8 @@ class ELFFile:
                 self._e_phnum,  # Number of sections.
             ) = self._read(e_fmt)
         except struct.error as e:
-            raise ELFInvalid("unable to parse machine and section information") from e
+            msg = "unable to parse machine and section information"
+            raise ELFInvalid(msg) from e
 
     def _read(self, fmt: str) -> tuple[int, ...]:
         return struct.unpack(fmt, self._f.read(struct.calcsize(fmt)))

--- a/src/packaging/_tokenizer.py
+++ b/src/packaging/_tokenizer.py
@@ -140,7 +140,8 @@ class Tokenizer:
         The token is *not* read.
         """
         if not self.check(name):
-            raise self.raise_syntax_error(f"Expected {expected}")
+            msg = f"Expected {expected}"
+            raise self.raise_syntax_error(msg)
         return self.read()
 
     def read(self) -> Token:

--- a/src/packaging/markers.py
+++ b/src/packaging/markers.py
@@ -188,7 +188,8 @@ def _eval_op(lhs: str, op: Op, rhs: str | AbstractSet[str]) -> bool:
 
     oper: Operator | None = _operators.get(op.serialize())
     if oper is None:
-        raise UndefinedComparison(f"Undefined {op!r} on {lhs!r} and {rhs!r}.")
+        msg = f"Undefined {op!r} on {lhs!r} and {rhs!r}."
+        raise UndefinedComparison(msg)
 
     return oper(lhs, rhs)
 

--- a/src/packaging/specifiers.py
+++ b/src/packaging/specifiers.py
@@ -256,7 +256,8 @@ class Specifier(BaseSpecifier):
         """
         match = self._regex.search(spec)
         if not match:
-            raise InvalidSpecifier(f"Invalid specifier: {spec!r}")
+            msg = f"Invalid specifier: {spec!r}"
+            raise InvalidSpecifier(msg)
 
         self._spec: tuple[str, str] = (
             match.group("operator").strip(),
@@ -843,9 +844,10 @@ class SpecifierSet(BaseSpecifier):
         ) or self._prereleases == other._prereleases:
             specifier._prereleases = self._prereleases
         else:
-            raise ValueError(
+            msg = (
                 "Cannot combine SpecifierSets with True and False prerelease overrides."
             )
+            raise ValueError(msg)
 
         return specifier
 

--- a/src/packaging/tags.py
+++ b/src/packaging/tags.py
@@ -262,7 +262,8 @@ def _generic_abi() -> list[str]:
 
     ext_suffix = _get_config_var("EXT_SUFFIX", warn=True)
     if not isinstance(ext_suffix, str) or ext_suffix[0] != ".":
-        raise SystemError("invalid sysconfig.get_config_var('EXT_SUFFIX')")
+        msg = "invalid sysconfig.get_config_var('EXT_SUFFIX')"
+        raise SystemError(msg)
     parts = ext_suffix.split(".")
     if len(parts) < 3:
         # CPython3.7 and earlier uses ".pyd" on Windows.
@@ -545,9 +546,8 @@ def android_platforms(
         underscores.
     """
     if platform.system() != "Android" and (api_level is None or abi is None):
-        raise TypeError(
-            "on non-Android platforms, the api_level and abi arguments are required"
-        )
+        msg = "on non-Android platforms, the api_level and abi arguments are required"
+        raise TypeError(msg)
 
     if api_level is None:
         # Python 3.13 was the first version to return platform.system() == "Android",

--- a/src/packaging/version.py
+++ b/src/packaging/version.py
@@ -204,7 +204,8 @@ class Version(_BaseVersion):
         # Validate the version and parse it into pieces
         match = self._regex.fullmatch(version)
         if not match:
-            raise InvalidVersion(f"Invalid version: {version!r}")
+            msg = f"Invalid version: {version!r}"
+            raise InvalidVersion(msg)
 
         # Store the parsed out pieces of the version
         self._version = _Version(

--- a/tests/test_manylinux.py
+++ b/tests/test_manylinux.py
@@ -169,7 +169,8 @@ def test_glibc_version_string_ctypes_raise_oserror(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     def patched_cdll(_name: str) -> None:
-        raise OSError("Dynamic loading not supported")
+        msg = "Dynamic loading not supported"
+        raise OSError(msg)
 
     monkeypatch.setattr(ctypes, "CDLL", patched_cdll)
     assert _glibc_version_string_ctypes() is None


### PR DESCRIPTION
This is the ruff EM check, based on flake8-errmsg (my package). It changes tracebacks from this:

```pytb
Traceback (most recent call last):
  File "tmp.py", line 2, in <module>
    raise RuntimeError(f"{sub!r} is incorrect")
RuntimeError: 'Some value' is incorrect
```

to this:

```pytb
Traceback (most recent call last):
  File "tmp.py", line 3, in <module>
    raise RuntimeError(msg)
RuntimeError: 'Some value' is incorrect
```

This avoids printing the error message twice, sometimes with placeholders. It also tends to format a little nicer.

It's a ruff autofix, so was easy to apply. We don't have to if people don't like it.
