### PR TITLE
chore: reorder mypy check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,14 +8,6 @@ repos:
       - id: mixed-line-ending
       - id: trailing-whitespace
 
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.18.1
-    hooks:
-      - id: mypy
-        exclude: '^(docs|tasks|tests)|setup\.py'
-        args: []
-        additional_dependencies: [pyparsing, nox, orjson]
-
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.13.0
     hooks:
@@ -29,6 +21,14 @@ repos:
     - id: rst-backticks
     - id: rst-directive-colons
     - id: rst-inline-touching-normal
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.18.1
+    hooks:
+      - id: mypy
+        exclude: '^(docs|tasks|tests)|setup\.py'
+        args: []
+        additional_dependencies: [pyparsing, nox, orjson]
 
   - repo: https://github.com/codespell-project/codespell
     rev: "v2.4.1"


### PR DESCRIPTION
When working on #982, I notice the mypy check was before ruff, which meant that line numbers reported by mypy would get changed by ruff, which meant I had to run pre-commit twice every time I wanted to get a new report after I changed things. In general, non-modifying checks should come after modifying ones.
