### PR TITLE
chore: enable ruff ALL

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,9 +26,9 @@ repos:
     rev: v1.18.1
     hooks:
       - id: mypy
-        exclude: '^(docs|tasks)'
+        exclude: '^(docs)'
         args: []
-        additional_dependencies: [pyparsing, nox, orjson, 'pytest<9', tomli, tomli_w]
+        additional_dependencies: [pyparsing, nox, orjson, 'pytest<9', tomli, tomli_w, types-invoke, httpx]
 
   - repo: https://github.com/codespell-project/codespell
     rev: "v2.4.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ python_version = "3.8"
 files = ["src", "tests", "noxfile.py"]
 
 [[tool.mypy.overrides]]
-module = ["_manylinux", "pretend"]
+module = ["_manylinux", "pretend", "progress.*", "pkg_resources"]
 ignore_missing_imports = true
 
 [tool.ruff]
@@ -93,63 +93,41 @@ extend-exclude = [
 show-fixes = true
 
 [tool.ruff.lint]
-extend-select = [
-    "ARG",   # flake8-unused-argument
-    "B",     # flake8-bugbear
-    "BLE",   # flake8-blind-except
-    "C4",    # flake8-comprehensions
-    "DTZ",   # flake8-datetimez
-    "E",
-    "EXE",   # flake8-executable
-    "F",
-    "FA",    # flake8-future-annotations
-    "FLY",   # flynt
-    "FURB",  # refurb
-    "G",     # flake8-logging-format
-    "I",     # isort
-    "ICN",   # flake8-import-conventions
-    "ISC",   # flake8-implicit-str-concat
-    "LOG",   # flake8-logging
-    "N",     # pep8-naming
-    "PERF",  # perflint
-    "PGH",   # pygrep-hooks
-    "PIE",   # flake8-pie
-    "PL",    # pylint
-    "PT",    # flake8-pytest-style
-    "PYI",   # flake8-pyi
-    "Q",     # flake8-quotes
-    "RET",   # flake8-return
-    "RSE",   # flake8-raise
-    "RUF",   # Ruff-specific rules
-    "SIM",   # flake8-simplify
-    "SLOT",  # flake8-slots
-    "T10",   # flake8-debugger
-    "T20",   # flake8-print
-    "TC",    # flake8-type-checking
-    "TRY",   # tryceratops
-    "UP",    # pyupgrade
-    "W",
-    "YTT",   # flake8-2020
-]
+select = ["ALL"]
 ignore = [
+    "A002",    # function args shadowing builtins is fine
+    "C9",      # complexity
+    "COM812",  # trailing commas teach the formatter
+    "D",       # doc formatting
+    "EM",      # flake8-errmsg
+    "ERA",     # commented out code
+    "FBT",     # boolean positional args (existing API)
+    "FIX",     # has todos
     "N818",    # exceptions must end in "*Error"
     "PLR09",   # too many ...
     "PLR2004", # magic value in comparison
     "PLW0127", # duplicate of F821
-    "SIM103",  # returning negated value directly not ideal for long chain
-    "SIM105",  # try/except is faster than contextlib.suppress
-    "TRY003",  # long messages outside exception class
+    "PTH",     # pathlib
     "RET505",  # unused else/elif after return
     "RET506",  # unused else/elif after raise
     "RET507",  # unused else/elif after continue
     "RET508",  # unused else/elif after break
+    "S101",    # assert is used by mypy and pytest
+    "S105",    # the name token doesn't mean it's a password
+    "S603",    # check for untrusted input
+    "SIM103",  # returning negated value directly not ideal for long chain
+    "SIM105",  # try/except is faster than contextlib.suppress
+    "SLF001",  # private member access
+    "TD",      # todo format
+    "TRY003",  # long messages outside exception class
 ]
 flake8-comprehensions.allow-dict-calls-with-keyword-arguments = true
 flake8-unused-arguments.ignore-variadic-names = true
 
 [tool.ruff.lint.per-file-ignores]
-"tests/test_*.py" = ["PYI024", "PLR", "SIM201", "T20"]
+"tests/test_*.py" = ["PYI024", "PLR", "SIM201", "T20", "S301"]
 "tasks/check.py" = ["UP032", "T20"]
 "tests/test_requirements.py" = ["UP032"]
 "src/packaging/_musllinux.py" = ["T20"]
-"noxfile.py" = ["T20"]
+"docs/conf.py" = ["INP001", "S", "A001"]
+"noxfile.py" = ["T20", "S"]

--- a/src/packaging/_parser.py
+++ b/src/packaging/_parser.py
@@ -7,7 +7,7 @@ the implementation.
 from __future__ import annotations
 
 import ast
-from typing import NamedTuple, Sequence, Tuple, Union
+from typing import List, NamedTuple, Sequence, Tuple, Union
 
 from ._tokenizer import DEFAULT_RULES, Tokenizer
 
@@ -44,7 +44,7 @@ class Op(Node):
 MarkerVar = Union[Variable, Value]
 MarkerItem = Tuple[MarkerVar, Op, MarkerVar]
 MarkerAtom = Union[MarkerItem, Sequence["MarkerAtom"]]
-MarkerList = Sequence[Union["MarkerList", MarkerAtom, str]]
+MarkerList = List[Union["MarkerList", MarkerAtom, str]]
 
 
 class ParsedRequirement(NamedTuple):

--- a/src/packaging/markers.py
+++ b/src/packaging/markers.py
@@ -8,7 +8,7 @@ import operator
 import os
 import platform
 import sys
-from typing import AbstractSet, Any, Callable, Literal, Mapping, TypedDict, Union, cast
+from typing import AbstractSet, Callable, Literal, Mapping, TypedDict, Union, cast
 
 from ._parser import MarkerAtom, MarkerList, Op, Value, Variable
 from ._parser import parse_marker as _parse_marker
@@ -121,7 +121,7 @@ class Environment(TypedDict):
     """
 
 
-def _normalize_extra_values(results: Any) -> Any:
+def _normalize_extra_values(results: MarkerList) -> MarkerList:
     """
     Normalize extra values.
     """

--- a/src/packaging/metadata.py
+++ b/src/packaging/metadata.py
@@ -401,16 +401,16 @@ def parse_email(data: bytes | str) -> tuple[RawMetadata, dict[str, list[str]]]:
                 # can be independently encoded, so we'll need to check each
                 # of them.
                 chunks: list[tuple[bytes, str | None]] = []
-                for bin, _encoding in email.header.decode_header(h):
+                for binary, _encoding in email.header.decode_header(h):
                     try:
-                        bin.decode("utf8", "strict")
+                        binary.decode("utf8", "strict")
                     except UnicodeDecodeError:
                         # Enable mojibake.
                         encoding = "latin1"
                         valid_encoding = False
                     else:
                         encoding = "utf8"
-                    chunks.append((bin, encoding))
+                    chunks.append((binary, encoding))
 
                 # Turn our chunks back into a Header object, then let that
                 # Header object do the right thing to turn them into a

--- a/src/packaging/pylock.py
+++ b/src/packaging/pylock.py
@@ -63,7 +63,7 @@ def _toml_key(key: str) -> str:
     return key.replace("_", "-")
 
 
-def _toml_value(key: str, value: Any) -> Any:
+def _toml_value(key: str, value: Any) -> Any:  # noqa: ANN401
     if isinstance(value, (Version, Marker, SpecifierSet)):
         return str(value)
     if isinstance(value, Sequence) and key == "environments":
@@ -225,7 +225,7 @@ def _validate_path_url(path: str | None, url: str | None) -> None:
 def _validate_hashes(hashes: Mapping[str, Any]) -> Mapping[str, Any]:
     if not hashes:
         raise PylockValidationError("At least one hash must be provided")
-    if not all(isinstance(hash, str) for hash in hashes.values()):
+    if not all(isinstance(hash_val, str) for hash_val in hashes.values()):
         raise PylockValidationError("Hash values must be strings")
     return hashes
 

--- a/tasks/check.py
+++ b/tasks/check.py
@@ -2,6 +2,8 @@
 # 2.0, and the BSD License. See the LICENSE file in the root of this repository
 # for complete details.
 
+from __future__ import annotations
+
 import contextlib
 import itertools
 import json
@@ -17,7 +19,7 @@ from packaging.version import Version
 from .paths import CACHE
 
 
-def _parse_version(value):
+def _parse_version(value: str) -> Version | None:
     try:
         return Version(value)
     except ValueError:
@@ -25,7 +27,7 @@ def _parse_version(value):
 
 
 @invoke.task
-def pep440(cached=False):
+def pep440(cached: bool = False) -> None:
     cache_path = os.path.join(CACHE, "pep440.json")
 
     # If we were given --cached, then we want to attempt to use cached data if

--- a/tasks/licenses.py
+++ b/tasks/licenses.py
@@ -1,7 +1,10 @@
+from __future__ import annotations
+
 import pathlib
 from contextlib import closing
 from io import StringIO
 from textwrap import dedent
+from typing import Any
 
 import httpx
 
@@ -16,7 +19,7 @@ EXCEPTIONS_URL = (
 )
 
 
-def download_data(url):
+def download_data(url: str) -> Any:  # noqa: ANN401
     transport = httpx.HTTPTransport(retries=3)
     client = httpx.Client(transport=transport)
 
@@ -25,7 +28,7 @@ def download_data(url):
     return response.json()
 
 
-def main():
+def main() -> None:
     latest_version = download_data(LATEST_SPDX_GITHUB_RELEASE_URL)["tag_name"][1:]
 
     licenses = {}


### PR DESCRIPTION
Switching to opt-out instead of opt-in, which is now shorter config. Includes a few changes:

* Type check tasks, and fully type noxfile (from the ANN code)
* Replace an `Any` with the actual type - and fix `MarkerList` to be a `List` (since it gets modified, it can't be a `Sequence`, and it's a concrete return type anyway)
* Rename a few variables that are builtins (nicer syntax highlighting, too)

