### PR TITLE
Perf: Skip redundant creation of Versions in specifier comparison

### DIFF
--- a/tests/test_specifiers.py
+++ b/tests/test_specifiers.py
@@ -461,6 +461,7 @@ class TestSpecifier:
                 ("2.0.post1", ">2"),
                 ("2.0.post1.dev1", ">2"),
                 ("2.0+local.version", ">2"),
+                ("1.0+local", ">1.0.dev1"),
                 # Test the less than operation
                 ("2.0.dev1", "<2"),
                 ("2.0a1", "<2"),


### PR DESCRIPTION
When doing a lot of comparisons with the `Specifier` class, a lot of redundant temporary `Version` objects are created for comparison.

This is particularly problematic for pip, which has to call comparisons many times, on one of my resolver benchmark, with https://github.com/pypa/packaging/pull/985 already applied, adding the `_public_version` function reduces the number of times `Version` is instantiated from ~1.3 million times to ~580k times, and the `_base_version` function reduces that to ~574k times (`_base_version` is called in significantly more edge case situations).