### PR TITLE
perf: lazily calculate `_key` in `Version`

### DIFF
--- a/src/packaging/version.py
+++ b/src/packaging/version.py
@@ -197,7 +197,7 @@ class Version(_BaseVersion):
 
     _regex = re.compile(r"\s*" + VERSION_PATTERN + r"\s*", re.VERBOSE | re.IGNORECASE)
     _version: _Version
-    __key: CmpKey | None
+    _key_cache: CmpKey | None
 
     def __init__(self, version: str) -> None:
         """Initialize a Version object.
@@ -226,12 +226,12 @@ class Version(_BaseVersion):
         )
 
         # Key which will be used for sorting
-        self.__key = None
+        self._key_cache = None
 
     @property
     def _key(self) -> CmpKey:
-        if self.__key is None:
-            self.__key = _cmpkey(
+        if self._key_cache is None:
+            self._key_cache = _cmpkey(
                 self._version.epoch,
                 self._version.release,
                 self._version.pre,
@@ -239,7 +239,7 @@ class Version(_BaseVersion):
                 self._version.dev,
                 self._version.local,
             )
-        return self.__key
+        return self._key_cache
 
     def __repr__(self) -> str:
         """A representation of the Version that shows all internal state.


### PR DESCRIPTION
Inspired by https://github.com/pypa/packaging/pull/987 I investigated if calling `_cmpkey` to calculate `_key` on every `Version` initialization made sense.

At least for pip, `_key` is only accessed on less than 30% of `Version` objects ever created, with longer resolutions going down to below 20%, so precalculating `_key` with `_cmpkey` is doing work that's often not needed.

`_version` could also be made lazy, but at least for pip `_version` is accessed on 100% of all `Version` objects.