### PR TITLE
chore: minor cleanup to regex code

### DIFF
--- a/src/packaging/version.py
+++ b/src/packaging/version.py
@@ -114,34 +114,39 @@ class _BaseVersion:
 # Deliberately not anchored to the start and end of the string, to make it
 # easier for 3rd party code to reuse
 _VERSION_PATTERN = r"""
-    v?
+    v?                                                    # optional leading v
     (?:
         (?:(?P<epoch>[0-9]+)!)?                           # epoch
         (?P<release>[0-9]+(?:\.[0-9]+)*)                  # release segment
         (?P<pre>                                          # pre-release
-            [-_\.]?
+            [._-]?
             (?P<pre_l>alpha|a|beta|b|preview|pre|c|rc)
-            [-_\.]?
+            [._-]?
             (?P<pre_n>[0-9]+)?
         )?
         (?P<post>                                         # post release
             (?:-(?P<post_n1>[0-9]+))
             |
             (?:
-                [-_\.]?
+                [._-]?
                 (?P<post_l>post|rev|r)
-                [-_\.]?
+                [._-]?
                 (?P<post_n2>[0-9]+)?
             )
         )?
         (?P<dev>                                          # dev release
-            [-_\.]?
+            [._-]?
             (?P<dev_l>dev)
-            [-_\.]?
+            [._-]?
             (?P<dev_n>[0-9]+)?
         )?
     )
-    (?:\+(?P<local>[a-z0-9]+(?:[-_\.][a-z0-9]+)*))?       # local version
+    (?:\+
+        (?P<local>                                        # local version
+            [a-z0-9]+
+            (?:[._-][a-z0-9]+)*
+        )
+    )?
 """
 
 VERSION_PATTERN = _VERSION_PATTERN
@@ -181,7 +186,7 @@ class Version(_BaseVersion):
     True
     """
 
-    _regex = re.compile(r"^\s*" + VERSION_PATTERN + r"\s*$", re.VERBOSE | re.IGNORECASE)
+    _regex = re.compile(r"\s*" + VERSION_PATTERN + r"\s*", re.VERBOSE | re.IGNORECASE)
     _version: _Version
     _key: CmpKey
 
@@ -197,7 +202,7 @@ class Version(_BaseVersion):
         """
 
         # Validate the version and parse it into pieces
-        match = self._regex.search(version)
+        match = self._regex.fullmatch(version)
         if not match:
             raise InvalidVersion(f"Invalid version: {version!r}")
 


### PR DESCRIPTION
Some minor cleanup before #988 (commit also present there).

* A few more comments, broke up the local version line into several lines like the others
* Inside `[]`, no need to escape `.`
* Used `fullmatch` (3.4+) instead of `search` + anchors
