### PR TITLE
perf: avoid duplicate Version creation in canonicalize_version

### DIFF
--- a/src/packaging/utils.py
+++ b/src/packaging/utils.py
@@ -76,10 +76,11 @@ def canonicalize_version(
     >>> canonicalize_version('foo bar baz')
     'foo bar baz'
     """
-    try:
-        version = Version(version)
-    except InvalidVersion:
-        return str(version)
+    if isinstance(version, str):
+        try:
+            version = Version(version)
+        except InvalidVersion:
+            return str(version)
     return str(_TrimmedRelease(version) if strip_trailing_zero else version)
 
 

--- a/src/packaging/version.py
+++ b/src/packaging/version.py
@@ -197,7 +197,7 @@ class Version(_BaseVersion):
 
     _regex = re.compile(r"\s*" + VERSION_PATTERN + r"\s*", re.VERBOSE | re.IGNORECASE)
 
-    def __init__(self, version: str | Version) -> None:
+    def __init__(self, version: str) -> None:
         """Initialize a Version object.
 
         :param version:
@@ -207,16 +207,6 @@ class Version(_BaseVersion):
             If the ``version`` does not conform to PEP 440 in any way then this
             exception will be raised.
         """
-        if isinstance(version, Version):
-            self._epoch = version._epoch
-            self._release = version._release
-            self._dev = version._dev
-            self._pre = version._pre
-            self._post = version._post
-            self._local = version._local
-            self._key_cache = version._key_cache
-            return
-
         # Validate the version and parse it into pieces
         match = self._regex.fullmatch(version)
         if not match:
@@ -460,6 +450,18 @@ class Version(_BaseVersion):
 
 
 class _TrimmedRelease(Version):
+    def __init__(self, version: str | Version) -> None:
+        if isinstance(version, Version):
+            self._epoch = version._epoch
+            self._release = version._release
+            self._dev = version._dev
+            self._pre = version._pre
+            self._post = version._post
+            self._local = version._local
+            self._key_cache = version._key_cache
+            return
+        super().__init__(version)  # pragma: no cover
+
     @property
     def release(self) -> tuple[int, ...]:
         """


### PR DESCRIPTION
Builds on #993.

This makes `SpecifierSet` creation take 37% less time (on top of the previous 7%) by avoiding extra `Version` creation. It does it by adding a new signature to `_TrimmedRelease` with a `Version` argument instead of only a `str`, which does a low-cost cast.

~~There are probably other ways to do this if we don't want to add a `Version(version: Version)` signature, starting with this as it's simple to open discussion. We could only support this in the subclass for example.~~ Actually, I like not changing API at all when working on performance, so I moved this to the subclass.
