### PR TITLE
perf: use map instead of generator

### DIFF
--- a/src/packaging/version.py
+++ b/src/packaging/version.py
@@ -259,7 +259,7 @@ class Version(_BaseVersion):
 
         # Pre-release
         if self.pre is not None:
-            parts.append("".join(str(x) for x in self.pre))
+            parts.append("".join(map(str, self.pre)))
 
         # Post-release
         if self.post is not None:


### PR DESCRIPTION
Another slow line in the profile. This one is the only case in the codebase that I see using a simple generator like this on `.split(".")`, all the rest use `map`. Using `map` saves about 8% when creating `Version`'s. Using `tuple([...])` also saves around 8%, but I think the map is nicer than using a list comprehension inside a function call (and also consistent with the other cases, like in `tags.py`).

Edit: also found one more place, inside the `__str__` method, which is used in SpecifierSet, for example.
