### PR TITLE
feat: support positional pattern matching on Version/Specifier

### DIFF
--- a/src/packaging/specifiers.py
+++ b/src/packaging/specifiers.py
@@ -65,6 +65,12 @@ class InvalidSpecifier(ValueError):
 
 class BaseSpecifier(metaclass=abc.ABCMeta):
     __slots__ = ()
+    __match_args__ = ("_str",)
+
+    @property
+    def _str(self) -> str:
+        """Internal property for match_args"""
+        return str(self)
 
     @abc.abstractmethod
     def __str__(self) -> str:

--- a/src/packaging/version.py
+++ b/src/packaging/version.py
@@ -268,6 +268,9 @@ class Version(_BaseVersion):
     """
 
     __slots__ = ("_dev", "_epoch", "_key_cache", "_local", "_post", "_pre", "_release")
+    __match_args__ = ("_str",)
+
+    _regex = re.compile(r"\s*" + VERSION_PATTERN + r"\s*", re.VERBOSE | re.IGNORECASE)
 
     _epoch: int
     _release: tuple[int, ...]
@@ -277,8 +280,6 @@ class Version(_BaseVersion):
     _local: LocalType | None
 
     _key_cache: CmpKey | None
-
-    _regex = re.compile(r"\s*" + VERSION_PATTERN + r"\s*", re.VERBOSE | re.IGNORECASE)
 
     def __init__(self, version: str) -> None:
         """Initialize a Version object.
@@ -385,6 +386,11 @@ class Version(_BaseVersion):
             parts.append(f"+{self.local}")
 
         return "".join(parts)
+
+    @property
+    def _str(self) -> str:
+        """Internal property for match_args"""
+        return str(self)
 
     @property
     def epoch(self) -> int:

--- a/tests/test_specifiers.py
+++ b/tests/test_specifiers.py
@@ -46,6 +46,10 @@ class TestSpecifier:
     def test_specifiers_valid(self, specifier: str) -> None:
         Specifier(specifier)
 
+    def test_match_args(self) -> None:
+        assert Specifier.__match_args__ == ("_str",)
+        assert Specifier(">=1.0")._str == ">=1.0"
+
     @pytest.mark.parametrize(
         "specifier",
         [
@@ -828,6 +832,10 @@ class TestSpecifierSet:
         specs = [Specifier(s) for s in spec_strs]
         spec = SpecifierSet(iter(specs))
         assert set(spec) == set(specs)
+
+    def test_match_args(self) -> None:
+        assert SpecifierSet.__match_args__ == ("_str",)
+        assert SpecifierSet(">=1.0,<2")._str == str(SpecifierSet(">=1.0,<2"))
 
     @pytest.mark.parametrize(
         (

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -108,6 +108,10 @@ class TestVersion:
     def test_valid_versions(self, version: str) -> None:
         Version(version)
 
+    def test_match_args(self) -> None:
+        assert Version.__match_args__ == ("_str",)
+        assert Version("1.2")._str == "1.2"
+
     @pytest.mark.parametrize(
         "version",
         [


### PR DESCRIPTION
This adds pattern matching support to Version/Specifier/SpecifierSet. You've always been able to get the components, but now you can get the string that creates one, too. For example:

```python
item = Version("1.2")

match item:
    case Version(version):
        assert version == "1.2"
```
