### PR TITLE
fix: restore previous behavior on platform_release

### DIFF
--- a/src/packaging/specifiers.py
+++ b/src/packaging/specifiers.py
@@ -198,7 +198,7 @@ class Specifier(BaseSpecifier):
             )
             |
             (?:
-                # All other operators only allow a sub set of what the
+                # All other operators only allow a subset of what the
                 # (non)equality operators do. Specifically they do not allow
                 # local versions to be specified nor do they allow the prefix
                 # matching wild cards.


### PR DESCRIPTION
This walks back the behavior change for `platform_release`; in 25.0, it was basically unusable, as without short circuiting, it would throw a `InvalidVersion` error when it was not a version (which it is not on some platforms), and you can't stop it from happening. This was fixed in #954 by handling legacy versions as never being "contained", so now any comparisons always return False. So `platform_release >= '6'` will always return False if `platform_release` is not a valid Version; the spec states it should fall back to python string comparison. Since this changes to a non-spec compliant behavior, this PR reverts this so it remains unusable.

The only field where comparisons other than `==` and `!=` make sense is `platform_release`, so I think handling it there only is likely fine.

This is a proposal only; I'm also okay with always returning False (current behavior) or updating to match the spec (#889) or fixing the spec (https://discuss.python.org/t/100287).

I believe old versions of packing (with LegacyVersion) had this always False behavior, so that might be a vote in favor of the current version (not this PR). I think that's my current preference.