### PR TITLE
chore: use typos instead of codespell

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,9 +30,8 @@ repos:
         args: []
         additional_dependencies: [pyparsing, nox, orjson, 'pytest<9', tomli, tomli_w, types-invoke, httpx]
 
-  - repo: https://github.com/codespell-project/codespell
-    rev: "v2.4.1"
+  - repo: https://github.com/crate-ci/typos
+    rev: v1.40.0
     hooks:
-      - id: codespell
-        additional_dependencies:
-          - tomli; python_version<'3.11'
+      - id: typos
+        args: []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,11 +51,16 @@ dev = [{ include-group = "test" }]
 include = ["tests/", "docs/", "CHANGELOG.rst"]
 exclude = ["docs/_build", "tests/manylinux/build-hello-world.sh", "tests/musllinux/build.sh", "tests/hello-world.c", "tests/__pycache__", "build/__pycache__"]
 
-[tool.codespell]
-ignore-words-list = [
-    "dynamc",
-    "notin"
-]
+[tool.typos.default.extend-identifiers]
+iMatix = "iMatix"
+ANDed = "ANDed"
+ORed = "ORed"
+
+[tool.typos.default.extend-words]
+dynamc = "dynamc"
+notin = "notin"
+nd = "nd"
+tou = "tou"
 
 [tool.coverage.run]
 branch = true

--- a/src/packaging/metadata.py
+++ b/src/packaging/metadata.py
@@ -129,7 +129,7 @@ class RawMetadata(TypedDict, total=False):
 
     # Metadata 2.3 - PEP 685
     # No new fields were added in PEP 685, just some edge case were
-    # tightened up to provide better interoptability.
+    # tightened up to provide better interoperability.
 
     # Metadata 2.4 - PEP 639
     license_expression: str


### PR DESCRIPTION
This is a Rust spell checker with the same basic idea as codespell, but it supports CamelCase / snake_case, and has a more flexible configuraiton (not perfect). I've found it catches some things codespell doesn't, and it's fast (though codespell is pretty fast too). It's got more stars on github than codespell, and has been around for a while, and seems well maintained. I haven't been actively trying it out that long, though (since the Python Bytes mention).

See https://github.com/scientific-python/cookie/pull/724 and https://github.com/scikit-build/scikit-build-core/pull/1192 for a couple of other conversions, both found a little more than codespell. Can't really tell if it's missing stuff codespell would have caught, though. If you want, I could keep both. :)
