### PR TITLE
ci: auto-skip the dependabot PRs in the release changelog generation

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,4 @@
+changelog:
+  exclude:
+    authors:
+      - dependabot[bot]


### PR DESCRIPTION
When you generate the changelog in the GitHub release, this will keep the dependabot PRs out of the list.
