### PR TITLE
ci: use slim runner for all check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,7 @@ jobs:
     needs:
       - test
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
 
     steps:
       - name: Decide whether the needed jobs succeeded or failed


### PR DESCRIPTION
I noticed this in GHA (in an unrelated announcement) and am trying it here to see if it works. This seems to be exactly what it's intended for. It uses a completely different runner technology (container instead of full VM) to start up much faster.

* https://docs.github.com/en/actions/reference/runners/github-hosted-runners#single-cpu-runners
* Packages: https://github.com/actions/runner-images/blob/main/images/ubuntu-slim/ubuntu-slim-Readme.md

Yes, seems to work. Also updating https://github.com/scientific-python/cookie/pull/729.