### PR TITLE
fix: better support for subclassing

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,6 +31,7 @@ Fixes:
 * Support nested parens in license expressions (:pull:`931`)
 * Add space before at symbol in ``Requirements`` string (:pull:`953`)
 * A root logger use found, use a ``packaging`` logger instead (:pull:`965`)
+* Better support for subclassing ``Marker`` and ``Requirement`` (:pull:`1022`)
 
 Performance:
 

--- a/src/packaging/_structures.py
+++ b/src/packaging/_structures.py
@@ -2,8 +2,13 @@
 # 2.0, and the BSD License. See the LICENSE file in the root of this repository
 # for complete details.
 
+import typing
 
+
+@typing.final
 class InfinityType:
+    __slots__ = ()
+
     def __repr__(self) -> str:
         return "Infinity"
 
@@ -32,7 +37,10 @@ class InfinityType:
 Infinity = InfinityType()
 
 
+@typing.final
 class NegativeInfinityType:
+    __slots__ = ()
+
     def __repr__(self) -> str:
         return "-Infinity"
 

--- a/src/packaging/markers.py
+++ b/src/packaging/markers.py
@@ -310,10 +310,10 @@ class Marker:
         return _format_marker(self._markers)
 
     def __repr__(self) -> str:
-        return f"<Marker('{self}')>"
+        return f"<{self.__class__.__name__}('{self}')>"
 
     def __hash__(self) -> int:
-        return hash((self.__class__.__name__, str(self)))
+        return hash(str(self))
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, Marker):

--- a/src/packaging/requirements.py
+++ b/src/packaging/requirements.py
@@ -68,15 +68,10 @@ class Requirement:
         return "".join(self._iter_parts(self.name))
 
     def __repr__(self) -> str:
-        return f"<Requirement('{self}')>"
+        return f"<{self.__class__.__name__}('{self}')>"
 
     def __hash__(self) -> int:
-        return hash(
-            (
-                self.__class__.__name__,
-                *self._iter_parts(canonicalize_name(self.name)),
-            )
-        )
+        return hash(tuple(self._iter_parts(canonicalize_name(self.name))))
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, Requirement):


### PR DESCRIPTION
This improves the subclassing support of a couple of classes (`Marker` and `Requirement`), and explicitly marks the infinity types as non-subclassable (only affects type checkers, or someone explicitly looking for `__final__` at runtime in 3.11+). You don't need to add the class name into the hash, Python already handles types, and that can cause strange behavior if you don't also include the class name in `__eq__` (they should match!).


Fix #1018.

