### PR TITLE
perf: canonicalize_name

### DIFF
--- a/src/packaging/utils.py
+++ b/src/packaging/utils.py
@@ -33,9 +33,7 @@ class InvalidSdistFilename(ValueError):
 
 
 # Core metadata spec for `Name`
-_validate_regex = re.compile(
-    r"[A-Z0-9]|[A-Z0-9][A-Z0-9._-]*[A-Z0-9]", re.IGNORECASE
-)
+_validate_regex = re.compile(r"[A-Z0-9]|[A-Z0-9][A-Z0-9._-]*[A-Z0-9]", re.IGNORECASE)
 _canonicalize_regex = re.compile(r"[-_.]+")
 _normalized_regex = re.compile(r"[a-z0-9]|[a-z0-9]([a-z0-9-](?!--))*[a-z0-9]")
 # PEP 427: The build number must start with a digit.
@@ -46,12 +44,15 @@ def canonicalize_name(name: str, *, validate: bool = False) -> NormalizedName:
     if validate and not _validate_regex.fullmatch(name):
         raise InvalidName(f"name is invalid: {name!r}")
 
+    if not name.islower():
+        name = name.lower()
+
     # Just return if already normalized
-    if name.islower() and _normalized_regex.fullmatch(name):
+    if _normalized_regex.fullmatch(name):
         return cast("NormalizedName", name)
 
     # This is taken from PEP 503.
-    value = _canonicalize_regex.sub("-", name).lower()
+    value = _canonicalize_regex.sub("-", name)
     return cast("NormalizedName", value)
 
 


### PR DESCRIPTION
I notice that marker evaluation hasn't changed in performance, so I thought I'd look at optimizing it. It relies (too) heavily on `normalize_name`, so I looked at ways to optimize that. I did a couple of easy ones:

* Use `fullmatch` instead of anchors
* Early return if the name is normalized
* Early return if lowering is normalized

Here's the benchmark results:

All benchmarks:

| Change   | Before [353fd7b3] <henryiii/chore/bench>   | After [3eab1f90] <henryiii/perf/canonicalize>   |   Ratio | Benchmark (Parameter)                             |
|----------|--------------------------------------------|-------------------------------------------------|---------|---------------------------------------------------|
|          | 2.32±0.01ms                                | 2.43±0.05ms                                     |    1.05 | markers.TimeMarkerSuite.time_constructor          |
| +        | 1.18±0.02ms                                | 1.32±0.04ms                                     |    1.12 | markers.TimeMarkerSuite.time_evaluate             |
|          | 9.57±0.03ms                                | 9.68±0.05ms                                     |    1.01 | requirement.TimeRequirementSuite.time_constructor |
|          | 600±5μs                                    | 597±10μs                                        |    0.99 | resolver.TimeResolverSuite.time_resolver_loop     |
|          | 3.42±0.03ms                                | 3.49±0.05ms                                     |    1.02 | specifiers.TimeSpecSuite.time_constructor         |
|          | 3.98±0.04ms                                | 4.08±0.02ms                                     |    1.02 | specifiers.TimeSpecSuite.time_contains            |
|          | 60.9±0.1μs                                 | 61.8±0.2μs                                      |    1.01 | specifiers.TimeSpecSuite.time_filter              |
| +        | 8.44±0.1μs                                 | 12.1±0.09μs                                     |    1.44 | utils.TimeUtils.time_canonicalize_name            |
|          | 2.00±0.01ms                                | 1.98±0ms                                        |    0.99 | version.TimeVersionSuite.time_constructor         |
|          | 1.88±0.02ms                                | 1.87±0.01ms                                     |    0.99 | version.TimeVersionSuite.time_sort                |
|          | 810±8μs                                    | 812±4μs                                         |    1    | version.TimeVersionSuite.time_str                 |

This results in a 44% speedup to `normalize_name`, with a 12% overall speedup to marker evaluation and 5% to marker construction.
