### PR TITLE
perf: don't renormalize extras

### DIFF
--- a/tests/test_markers.py
+++ b/tests/test_markers.py
@@ -280,6 +280,13 @@ class TestMarker:
         # THEN
         assert marker.evaluate(environment) is False
 
+    def test_environment_with_no_extras(self) -> None:
+        # Environment is set but no 'extra' key is present; branch only hit on
+        # non-metadata context.
+        marker = Marker("os_name == 'foo'")
+        assert marker.evaluate({"os_name": "foo"}, context="requirement")
+        assert not marker.evaluate({"os_name": "bar"}, context="requirement")
+
     @pytest.mark.parametrize(
         ("marker_string", "environment", "expected"),
         [


### PR DESCRIPTION
We don't need to normalize extras multiple times, once is enough.

Requires #1024 to go in first, as otherwise extras might not be normalized if not first, breaking the assumption this makes. This counteracts the extra time that fix takes.

Branch coverage required a test added for the empty side of this branch; before the `None` check caused the empty side to trigger, but now that's moved, so needed a new test.