### PR TITLE
perf: use fullmatch for markers too

### DIFF
--- a/src/packaging/utils.py
+++ b/src/packaging/utils.py
@@ -33,17 +33,15 @@ class InvalidSdistFilename(ValueError):
 
 
 # Core metadata spec for `Name`
-_validate_regex = re.compile(
-    r"^([A-Z0-9]|[A-Z0-9][A-Z0-9._-]*[A-Z0-9])\Z", re.IGNORECASE
-)
+_validate_regex = re.compile(r"[A-Z0-9]|[A-Z0-9][A-Z0-9._-]*[A-Z0-9]", re.IGNORECASE)
 _canonicalize_regex = re.compile(r"[-_.]+")
-_normalized_regex = re.compile(r"^([a-z0-9]|[a-z0-9]([a-z0-9-](?!--))*[a-z0-9])$")
+_normalized_regex = re.compile(r"[a-z0-9]|[a-z0-9]([a-z0-9-](?!--))*[a-z0-9]")
 # PEP 427: The build number must start with a digit.
 _build_tag_regex = re.compile(r"(\d+)(.*)")
 
 
 def canonicalize_name(name: str, *, validate: bool = False) -> NormalizedName:
-    if validate and not _validate_regex.match(name):
+    if validate and not _validate_regex.fullmatch(name):
         raise InvalidName(f"name is invalid: {name!r}")
     # This is taken from PEP 503.
     value = _canonicalize_regex.sub("-", name).lower()
@@ -51,7 +49,7 @@ def canonicalize_name(name: str, *, validate: bool = False) -> NormalizedName:
 
 
 def is_normalized_name(name: str) -> bool:
-    return _normalized_regex.match(name) is not None
+    return _normalized_regex.fullmatch(name) is not None
 
 
 def canonicalize_version(


### PR DESCRIPTION
This provides a small speedup (a few percent), and is a little simpler.

(Now reading the benchmark `compare` correctly.)

All benchmarks:

| Change   | Before [18f41192] <main>   | After [9dd1b532] <henryiii/perf/fullmatch>   |   Ratio | Benchmark (Parameter)                             |
|----------|----------------------------|----------------------------------------------|---------|---------------------------------------------------|
|          | 2.39±0.03ms                | 2.36±0.03ms                                  |    0.98 | markers.TimeMarkerSuite.time_constructor          |
|          | 1.23±0.02ms                | 1.18±0.04ms                                  |    0.96 | markers.TimeMarkerSuite.time_evaluate             |
|          | 9.64±0.03ms                | 9.75±0.04ms                                  |    1.01 | requirement.TimeRequirementSuite.time_constructor |
|          | 601±7μs                    | 603±10μs                                     |    1    | resolver.TimeResolverSuite.time_resolver_loop     |
|          | 3.47±0.05ms                | 3.40±0.05ms                                  |    0.98 | specifiers.TimeSpecSuite.time_constructor         |
|          | 4.15±0.01ms                | 3.99±0.09ms                                  |    0.96 | specifiers.TimeSpecSuite.time_contains            |
|          | 61.7±0.2μs                 | 61.7±0.5μs                                   |    1    | specifiers.TimeSpecSuite.time_filter              |
|          | 8.62±0.07μs                | 8.66±0.05μs                                  |    1    | utils.TimeUtils.time_canonicalize_name            |
|          | 2.00±0.01ms                | 1.99±0.01ms                                  |    0.99 | version.TimeVersionSuite.time_constructor         |
|          | 1.88±0.01ms                | 1.87±0.01ms                                  |    0.99 | version.TimeVersionSuite.time_sort                |
|          | 814±7μs                    | 808±2μs                                      |    0.99 | version.TimeVersionSuite.time_str                 |
