### PR TITLE
perf: translate for canonicalize_name

### DIFF
--- a/src/packaging/utils.py
+++ b/src/packaging/utils.py
@@ -45,6 +45,8 @@ def canonicalize_name(name: str, *, validate: bool = False) -> NormalizedName:
     if validate and not _validate_regex.fullmatch(name):
         raise InvalidName(f"name is invalid: {name!r}")
     # Ensure all ``.`` and ``_`` are ``-``
+    # Emulates ``re.sub(r"[-_.]+", "-", name).lower()`` from PEP 503
+    # About 2x faster, safe since packages only support alphanumeric characters
     value = name.translate(_canonicalize_table)
     # Condense repeats (faster than regex)
     while "--" in value:


### PR DESCRIPTION
This roughly doubles the performance of `canonicalize_name`, by avoiding a regex. 5% improvement or so in marker evaluation. (Edit: swapped the `.lower()` for a single translate call for another 5% - extras are required to be ascii elsewhere, like the the validation regex)

All benchmarks:

| Change   | Before [e49f0fb5] <main>   | After [cc07639f] <henryiii/perf/translate>   |   Ratio | Benchmark (Parameter)                             |
|----------|----------------------------|----------------------------------------------|---------|---------------------------------------------------|
|          | 2.33±0.01ms                | 2.29±0ms                                     |    0.98 | markers.TimeMarkerSuite.time_constructor          |
|          | 1.14±0.01ms                | 1.08±0ms                                     |    0.95 | markers.TimeMarkerSuite.time_evaluate             |
|          | 9.71±0.2ms                 | 9.45±0.03ms                                  |    0.97 | requirement.TimeRequirementSuite.time_constructor |
|          | 592±3μs                    | 603±8μs                                      |    1.02 | resolver.TimeResolverSuite.time_resolver_loop     |
|          | 3.41±0.05ms                | 3.39±0.02ms                                  |    1    | specifiers.TimeSpecSuite.time_constructor         |
|          | 4.04±0.09ms                | 4.12±0.03ms                                  |    1.02 | specifiers.TimeSpecSuite.time_contains            |
|          | 61.4±0.3μs                 | 61.3±0.3μs                                   |    1    | specifiers.TimeSpecSuite.time_filter              |
| -        | 8.51±0.04μs                | 4.00±0.05μs                                  |    0.47 | utils.TimeUtils.time_canonicalize_name            |
|          | 1.97±0ms                   | 1.97±0.01ms                                  |    1    | version.TimeVersionSuite.time_constructor         |
|          | 1.86±0.01ms                | 1.87±0.01ms                                  |    1    | version.TimeVersionSuite.time_sort                |
|          | 811±8μs                    | 806±1μs                                      |    0.99 | version.TimeVersionSuite.time_str                 |