### PR TITLE
perf: add __slots__ to Nodes

### DIFF
--- a/src/packaging/_parser.py
+++ b/src/packaging/_parser.py
@@ -13,6 +13,8 @@ from ._tokenizer import DEFAULT_RULES, Tokenizer
 
 
 class Node:
+    __slots__ = ("value",)
+
     def __init__(self, value: str) -> None:
         self.value = value
 
@@ -20,23 +22,29 @@ class Node:
         return self.value
 
     def __repr__(self) -> str:
-        return f"<{self.__class__.__name__}('{self}')>"
+        return f"<{self.__class__.__name__}({self.value!r})>"
 
     def serialize(self) -> str:
         raise NotImplementedError
 
 
 class Variable(Node):
+    __slots__ = ()
+
     def serialize(self) -> str:
         return str(self)
 
 
 class Value(Node):
+    __slots__ = ()
+
     def serialize(self) -> str:
         return f'"{self}"'
 
 
 class Op(Node):
+    __slots__ = ()
+
     def serialize(self) -> str:
         return str(self)
 


### PR DESCRIPTION
Looking at these being created, noticed they didn't have `__slots__`. Seems like a perfect candidate, as lots get created.
