### PR TITLE
chore: use prek for faster pre-commit lint step

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -71,12 +71,12 @@ def tests(session: nox.Session) -> None:
 
 @nox.session(python="3.9")
 def lint(session: nox.Session) -> None:
-    # Run the linters (via pre-commit)
-    session.install("pre-commit")
-    session.run("pre-commit", "run", "--all-files", *session.posargs)
+    session.install("prek", "build", "twine")
+
+    # Run the linters (via prek, a Rust pre-commit runner)
+    session.run("prek", "run", "--all-files", *session.posargs)
 
     # Check the distribution
-    session.install("build", "twine")
     session.run("pyproject-build")
     session.run("twine", "check", *glob.glob("dist/*"))
 


### PR DESCRIPTION
Prek is a Rust pre-commit runner that is quite a bit faster to setup, nice for running inside a task runner.
