### PR TITLE
Use relative import in `packaging.licenses`

### DIFF
--- a/src/packaging/licenses/__init__.py
+++ b/src/packaging/licenses/__init__.py
@@ -34,7 +34,7 @@ from __future__ import annotations
 import re
 from typing import NewType, cast
 
-from packaging.licenses._spdx import EXCEPTIONS, LICENSES
+from ._spdx import EXCEPTIONS, LICENSES
 
 __all__ = [
     "InvalidLicenseExpression",


### PR DESCRIPTION
This matches all other modules.