### PR TITLE
chore: fix release script

### DIFF
--- a/docs/development/release-process.rst
+++ b/docs/development/release-process.rst
@@ -2,16 +2,20 @@ Release Process
 ===============
 
 #. Checkout the current ``main`` branch.
+
 #. Install the latest ``nox``::
 
     $ pip install nox
 
 #. Manually update the changelog to list all unreleased changes. Also verify that no new changes were added to a previous release in an earlier PR due to merge/rebase issues.
+
 #. Run the release automation with the required version number (YY.N)::
 
     $ nox -s release -- YY.N
 
-   This creates and pushes a new tag for the release.
+   This creates a new tag for the release. It will tell you how to push the tag.
+
+#. Push the tag (command will be printed out in the last step).
 
 #. Add a `release on GitHub <https://github.com/pypa/packaging/releases>`__.
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -167,7 +167,8 @@ def release(session: nox.Session) -> None:
     # NOTE: The following fails if pushing to the branch is not allowed. This can
     #       happen on GitHub, if the main branch is protected, there are required
     #       CI checks and "Include administrators" is enabled on the protection.
-    session.run("git", "push", "upstream", "main", release_version, external=True)
+    session.log("Run the following to push changes and tag (assuming 'upstream')")
+    print("git", "push", "upstream", "main", release_version)
 
 
 @nox.session


### PR DESCRIPTION
Followup fixes to #893, when trying to make a release.


- **chore: allow RCs and betas** This was failing for anything other than `YY.X`, now allowing any valid version, but requiring one `.` and fully normalized form instead.

- **chore: make push a printout** I'd prefer it to print out the command to run, rather than pushing to a (name assumed) remote.
