### PR TITLE
ci: always run tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,13 +2,9 @@ name: Test
 
 on:
   pull_request:
-    paths:
-      - ".github/workflows/test.yml"
-      - "**.py"
   push:
-    paths:
-      - ".github/workflows/test.yml"
-      - "**.py"
+    branches:
+      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}


### PR DESCRIPTION
Currently, the tests don't run if python files don't change, which is a problem since we require the `pass` job to pass. The tests are fast, so let's just always run them. There are also more involved solution that let you do this, but I think for us this is fine.
