### PR TITLE
ci: fix pub job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -73,7 +73,7 @@ jobs:
       url: https://pypi.org/project/packaging/${{ needs.build.outputs.tag }}
     permissions:
       id-token: write
-    # Only run if there's a matching tag, and if this is not a fork
+    # Only publish if there's a matching tag, and if this is not a fork
     if: needs.build.outputs.tag != '' && !github.event.repository.fork
 
     runs-on: ubuntu-latest


### PR DESCRIPTION
This job has `""` which isn't valid in GHA. Trying to fix it.

Fighting against `!` which has YAML meaning and GHA's strange quoting rules.