### PR TITLE
fix: support CPython 3.11.0-3.11.4 and older PyPy3.11

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,9 @@ Changelog
 *unreleased*
 ~~~~~~~~~~~~
 
-No unreleased changes.
+Fixes:
+
+* Support CPython 3.11.0-3.11.4 and older PyPy3.11 (:pull:`1055`)
 
 26.0rc2 - 2026-01-12
 ~~~~~~~~~~~~~~~~~~~~

--- a/src/packaging/version.py
+++ b/src/packaging/version.py
@@ -176,8 +176,15 @@ _VERSION_PATTERN = r"""
 
 _VERSION_PATTERN_OLD = _VERSION_PATTERN.replace("*+", "*").replace("?+", "?")
 
+# Possessive qualifiers were added in Python 3.11.
+# CPython 3.11.0-3.11.4 had a bug: https://github.com/python/cpython/pull/107795
+# Older PyPy also had a bug.
 VERSION_PATTERN = (
-    _VERSION_PATTERN_OLD if sys.version_info < (3, 11) else _VERSION_PATTERN
+    _VERSION_PATTERN_OLD
+    if (sys.implementation.name == "cpython" and sys.version_info < (3, 11, 5))
+    or (sys.implementation.name == "pypy" and sys.version_info < (3, 11, 13))
+    or sys.version_info < (3, 11)
+    else _VERSION_PATTERN
 )
 """
 A string containing the regular expression used to match a valid version.


### PR DESCRIPTION
Fix #1054. Tested with:

```python
#!/usr/bin/env -S uv run --script

# /// script
# dependencies = ["plumbum"]
# ///

from plumbum import FG
from plumbum.cmd import uv
from plumbum.colors import red, bold

versions = uv("python", "list", "--all-versions")
cpython_versions = ["-".join(line.split()[0].strip().split("-")[:2]) for line in versions.splitlines() if line.startswith("cpython")]
for version in cpython_versions:
    print(red & bold | f"Running {version}")
    uv["run", f"--python={version}", "pytest"] & FG
```

On versions:

```
cpython-3.15.0a3
cpython-3.15.0a3+freethreaded
cpython-3.14.2
cpython-3.14.2
cpython-3.14.2
cpython-3.14.2
cpython-3.14.2+freethreaded
cpython-3.14.1
cpython-3.14.1+freethreaded
cpython-3.14.0
cpython-3.14.0+freethreaded
cpython-3.13.11
cpython-3.13.11
cpython-3.13.11+freethreaded
cpython-3.13.10
cpython-3.13.10+freethreaded
cpython-3.13.9
cpython-3.13.9+freethreaded
cpython-3.13.8
cpython-3.13.8+freethreaded
cpython-3.13.7
cpython-3.13.7+freethreaded
cpython-3.13.6
cpython-3.13.6+freethreaded
cpython-3.13.5
cpython-3.13.5+freethreaded
cpython-3.13.4
cpython-3.13.4+freethreaded
cpython-3.13.3
cpython-3.13.3+freethreaded
cpython-3.13.2
cpython-3.13.2+freethreaded
cpython-3.13.1
cpython-3.13.1+freethreaded
cpython-3.13.0
cpython-3.13.0+freethreaded
cpython-3.12.12
cpython-3.12.11
cpython-3.12.10
cpython-3.12.9
cpython-3.12.8
cpython-3.12.7
cpython-3.12.6
cpython-3.12.5
cpython-3.12.4
cpython-3.12.3
cpython-3.12.2
cpython-3.12.1
cpython-3.12.0
cpython-3.11.14
cpython-3.11.14
cpython-3.11.13
cpython-3.11.12
cpython-3.11.11
cpython-3.11.10
cpython-3.11.9
cpython-3.11.8
cpython-3.11.7
cpython-3.11.6
cpython-3.11.5
cpython-3.11.4
cpython-3.11.3
cpython-3.11.1
cpython-3.10.19
cpython-3.10.19
cpython-3.10.18
cpython-3.10.17
cpython-3.10.16
cpython-3.10.15
cpython-3.10.14
cpython-3.10.13
cpython-3.10.12
cpython-3.10.11
cpython-3.10.9
cpython-3.10.8
cpython-3.10.7
cpython-3.10.6
cpython-3.10.5
cpython-3.10.4
cpython-3.10.3
cpython-3.10.2
cpython-3.10.0
cpython-3.9.25
cpython-3.9.24
cpython-3.9.23
cpython-3.9.22
cpython-3.9.21
cpython-3.9.20
cpython-3.9.19
cpython-3.9.18
cpython-3.9.17
cpython-3.9.16
cpython-3.9.15
cpython-3.9.14
cpython-3.9.13
cpython-3.9.12
cpython-3.9.11
cpython-3.9.10
cpython-3.9.7
cpython-3.9.6
cpython-3.9.6
cpython-3.9.5
cpython-3.9.4
cpython-3.9.3
cpython-3.9.2
cpython-3.9.1
cpython-3.9.0
cpython-3.8.20
cpython-3.8.19
cpython-3.8.18
cpython-3.8.17
cpython-3.8.16
cpython-3.8.15
cpython-3.8.14
cpython-3.8.13
cpython-3.8.12
cpython-3.8.11
cpython-3.8.10
cpython-3.8.9
cpython-3.8.8
cpython-3.8.7
cpython-3.8.6
cpython-3.8.5
cpython-3.8.3
cpython-3.8.2
```
