### PR TITLE
ci: test on first public release of CPythons

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,12 +27,6 @@ jobs:
           ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "pypy3.8", "pypy3.9", "pypy3.10", "pypy3.11"]
         include:
           - os: Ubuntu
-            python_version: "3.8.0"
-          - os: Ubuntu
-            python_version: "3.9.0"
-          - os: Ubuntu
-            python_version: "3.10.0"
-          - os: Ubuntu
             python_version: "3.11.0"
           - os: Ubuntu
             python_version: "3.12.0"


### PR DESCRIPTION
Adds jobs testing x.0 releases. Had to be rebased after #1055.