### PR TITLE
ci: use nox's uv integration

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,5 +27,8 @@ jobs:
           python-version: "3.9"
           cache: "pip"
 
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        name: Setup uv
+
       - name: Build documentation
-        run: pipx run nox --error-on-missing-interpreters -s docs
+        run: pipx run nox -s docs

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,8 +37,11 @@ jobs:
           python-version: "3.10"
           cache: "pip"
 
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        name: Setup uv
+
       - name: Run `nox -s lint`
-        run: pipx run nox --error-on-missing-interpreters -s lint -- --show-diff-on-failure
+        run: pipx run nox -s lint -- --show-diff-on-failure
 
   build:
     name: Build sdist and wheel
@@ -54,11 +57,14 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Build
-        run: pipx run build
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        name: Setup uv
 
       - name: Build
-        run: pipx run twine check --strict ./dist/*
+        run: uv build
+
+      - name: Build
+        run: uvx twine check --strict ./dist/*
 
       - name: Archive files
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -33,7 +33,7 @@ jobs:
             3.14
 
       - name: Install uv
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
       - name: Setup ASV
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,6 +38,9 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        name: Setup uv
+
       - name: Check ref is the commit SHA
         # require SHA as tags and branches are mutable
         run: test "${INPUTS_REF}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
           python-version: ${{ matrix.python_version }}
           allow-prereleases: true
 
-      - uses: astral-sh/setup-uv@61cb8a9741eeb8a550a1b8544337180c0fc8476b # v7.2.0
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         name: Setup uv
 
       - name: Run nox
@@ -68,6 +68,9 @@ jobs:
         with:
           python-version: "3.14"
           cache: "pip"
+
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        name: Setup uv
 
       - name: Run nox
         run: pipx run nox -s property_tests
@@ -91,6 +94,9 @@ jobs:
           python-version: "3.14"
           cache: "pip"
 
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        name: Setup uv
+
       - name: Run nox
         env:
           MATRIX_PROJECT: ${{ matrix.project }}
@@ -109,6 +115,9 @@ jobs:
         with:
           python-version: "3.14"
           cache: "pip"
+
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        name: Setup uv
 
       - name: Run nox
         run: pipx run nox -s test_pickle

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,8 +44,10 @@ jobs:
         name: Install Python ${{ matrix.python_version }}
         with:
           python-version: ${{ matrix.python_version }}
-          cache: "pip"
           allow-prereleases: true
+
+      - uses: astral-sh/setup-uv@61cb8a9741eeb8a550a1b8544337180c0fc8476b # v7.2.0
+        name: Setup uv
 
       - name: Run nox
         run: pipx run nox -s tests


### PR DESCRIPTION
Trying nox's uv integration in CI. uv doesn't support PyPy 3.8 on Windows, maybe best to just wait until 3.8 is dropped?