### PR TITLE
perf:  10% faster stripping zeros

### DIFF
--- a/src/packaging/version.py
+++ b/src/packaging/version.py
@@ -624,10 +624,11 @@ class _TrimmedRelease(Version):
         """
         # This leaves one 0.
         rel = super().release
-        i = len(rel)
+        len_release = len(rel)
+        i = len_release
         while i > 1 and rel[i - 1] == 0:
             i -= 1
-        return rel[:i]
+        return rel if i == len_release else rel[:i]
 
 
 def _parse_letter_version(
@@ -679,10 +680,11 @@ def _cmpkey(
 ) -> CmpKey:
     # When we compare a release version, we want to compare it with all of the
     # trailing zeros removed. We will use this for our sorting key.
-    i = len(release)
-    while i > 0 and release[i - 1] == 0:
+    len_release = len(release)
+    i = len_release
+    while i and release[i - 1] == 0:
         i -= 1
-    _release = release[:i]
+    _release = release if i == len_release else release[:i]
 
     # We need to "trick" the sorting algorithm to put 1.0.dev0 before 1.0a0.
     # We'll do this by abusing the pre segment, but we _only_ want to do this


### PR DESCRIPTION
This is faster than the current version, and a bit simpler. Suggested by ℤahlman on discord a while back; I thought it would be slower so I didn't try it till now. I found a way to improve it to be faster, actually, and more like the previous version but inline. I had the function primarily for the early return, but this avoids that, making it faster I think in the common case where a zero does not need to be stripped, due to the removed function call.

It also removes the function added in 26.0 `_strip_trailing_zeros`, which is why it might be worth putting in now, to keep people from depending on that (private) function? I'm perfectly fine to leave it till after 26.0 final, though, since we are in RC phase. [Not that anyone would depend on something with a leading underscore](https://github.com/pypa/packaging/pull/1048). What do other people think? It's about 10% faster hashing and 5% faster sorting.

Edit: found a problem in the asv benchmarks; `.setup` is not rerun between samples, so caching needs to be cleared. Fixing this shows this is a bit faster.

All benchmarks:

| Change   | Before [350a2306] <main>   | After [b699ea06] <henryiii/pref/simplerzeros>   |   Ratio | Benchmark (Parameter)                             |
|----------|----------------------------|-------------------------------------------------|---------|---------------------------------------------------|
|          | 2.29±0.01ms                | 2.30±0.02ms                                     |    1    | markers.TimeMarkerSuite.time_constructor          |
|          | 816±60μs                   | 801±3μs                                         |    0.98 | markers.TimeMarkerSuite.time_evaluate             |
|          | 9.44±0.06ms                | 9.37±0.03ms                                     |    0.99 | requirement.TimeRequirementSuite.time_constructor |
|          | 588±6μs                    | 588±5μs                                         |    1    | resolver.TimeResolverSuite.time_resolver_loop     |
|          | 3.31±0.02ms                | 3.30±0.01ms                                     |    1    | specifiers.TimeSpecSuite.time_constructor         |
|          | 4.08±0.2ms                 | 3.91±0.04ms                                     |    0.96 | specifiers.TimeSpecSuite.time_contains            |
|          | 61.5±2μs                   | 60.4±0.04μs                                     |    0.98 | specifiers.TimeSpecSuite.time_filter              |
|          | 4.07±0.03μs                | 4.03±0.08μs                                     |    0.99 | utils.TimeUtils.time_canonicalize_name            |
|          | 1.99±0.06ms                | 1.96±0ms                                        |    0.99 | version.TimeVersionSuite.time_constructor         |
| -        | 1.04±0ms                   | 935±5μs                                         |    0.9  | version.TimeVersionSuite.time_hash                |
|          | 2.21±0.01ms                | 2.11±0ms                                        |    0.95 | version.TimeVersionSuite.time_sort                |
|          | 723±10μs                   | 704±7μs                                         |    0.97 | version.TimeVersionSuite.time_str                 |