### PR TITLE
chore: use docs group, faster readthedocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,16 +1,18 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
 version: 2
 
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
-    python: "3.9"
-
-formats: [pdf]
-sphinx:
-  configuration: docs/conf.py
-
-python:
-  install:
-    - requirements: docs/requirements.txt
-    - method: pip
-      path: .
+    python: "3.13"
+  commands:
+    - asdf plugin add uv
+    - asdf install uv latest
+    - asdf global uv latest
+    - uv sync --group docs
+    - uv run python -m sphinx -T -b html -d docs/_build/doctrees -D language=en
+      docs $READTHEDOCS_OUTPUT/html

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,0 @@
-furo
-sphinx-toolbox
-typing-extensions>=4.1.0; python_version < "3.9"

--- a/noxfile.py
+++ b/noxfile.py
@@ -89,14 +89,14 @@ def lint(session: nox.Session) -> None:
     session.run("twine", "check", *glob.glob("dist/*"))
 
 
-@nox.session(python="3.9", default=False)
+@nox.session(default=False)
 def docs(session: nox.Session) -> None:
     """
     Build the docs.
     """
     shutil.rmtree("docs/_build", ignore_errors=True)
-    session.install("-r", "docs/requirements.txt")
-    session.install("-e", ".")
+    session.install(*nox.project.dependency_groups(PYPROJECT, "docs"))
+    session.install("-e.")
 
     variants = [
         # (builder, dest)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,11 @@ test = [
   "tomli_w",
 ]
 dev = [{ include-group = "test" }]
+docs = [
+    "furo",
+    "sphinx-toolbox",
+    "typing-extensions>=4.1.0; python_version < '3.9'",
+]
 
 
 [tool.flit.sdist]


### PR DESCRIPTION
Modernizing the docs job a bit. Roughly cuts the time in half.

(Can wait till after 26.0, just infrastructure stuff)