### PR TITLE
perf: dual replace

### DIFF
--- a/src/packaging/utils.py
+++ b/src/packaging/utils.py
@@ -34,10 +34,6 @@ class InvalidSdistFilename(ValueError):
 
 # Core metadata spec for `Name`
 _validate_regex = re.compile(r"[A-Z0-9]|[A-Z0-9][A-Z0-9._-]*[A-Z0-9]", re.IGNORECASE)
-_canonicalize_table = str.maketrans(
-    "ABCDEFGHIJKLMNOPQRSTUVWXYZ_.",
-    "abcdefghijklmnopqrstuvwxyz--",
-)
 _normalized_regex = re.compile(r"[a-z0-9]|[a-z0-9]([a-z0-9-](?!--))*[a-z0-9]")
 # PEP 427: The build number must start with a digit.
 _build_tag_regex = re.compile(r"(\d+)(.*)")
@@ -48,8 +44,8 @@ def canonicalize_name(name: str, *, validate: bool = False) -> NormalizedName:
         raise InvalidName(f"name is invalid: {name!r}")
     # Ensure all ``.`` and ``_`` are ``-``
     # Emulates ``re.sub(r"[-_.]+", "-", name).lower()`` from PEP 503
-    # About 2x faster, safe since packages only support alphanumeric characters
-    value = name.translate(_canonicalize_table)
+    # Much faster than re, and even faster than str.translate
+    value = name.lower().replace("_", "-").replace(".", "-")
     # Condense repeats (faster than regex)
     while "--" in value:
         value = value.replace("--", "-")


### PR DESCRIPTION
On Python 3.12 and 3.13, `str.translate` is really slow. This is less elegant, but much faster on those two Python versions, and a bit faster on the other Python versions.


| Change   | Before [d5398b8b] <main>   | After [712338f5] <henryiii/perf/doublerepl>   |   Ratio | Benchmark (Parameter)                                                                 |
|----------|----------------------------|-----------------------------------------------|---------|---------------------------------------------------------------------------------------|
| -        | 5.91±0.01μs                | 3.11±0μs                                      |    0.53 | utils.TimeUtils.time_canonicalize_name [PU-H2WF61JRQ6NY/virtualenv-py3.8]             |
| -        | 5.88±0.02μs                | 3.16±0.03μs                                   |    0.54 | utils.TimeUtils.time_canonicalize_name [PU-H2WF61JRQ6NY/virtualenv-py3.9]             |
| -        | 5.98±0.02μs                | 3.09±0.01μs                                   |    0.52 | utils.TimeUtils.time_canonicalize_name [PU-H2WF61JRQ6NY/virtualenv-py3.10]            |
| -        | 5.06±0.01μs                | 2.36±0.02μs                                   |    0.47 | utils.TimeUtils.time_canonicalize_name [PU-H2WF61JRQ6NY/virtualenv-py3.11]            |
| -        | 9.51±0.04μs                | 2.42±0.04μs                                   |    0.25 | utils.TimeUtils.time_canonicalize_name [PU-H2WF61JRQ6NY/virtualenv-py3.12]            |
| -        | 9.64±0.01μs                | 2.37±0.01μs                                   |    0.25 | utils.TimeUtils.time_canonicalize_name [PU-H2WF61JRQ6NY/virtualenv-py3.13]            |
| -        | 3.96±0.04μs                | 3.09±0.05μs                                   |    0.78 | utils.TimeUtils.time_canonicalize_name [PU-H2WF61JRQ6NY/virtualenv-py3.14]            |


This fixes a performance regression for Python 3.12 and 3.13 (#1030 is faster for all other Python versions), and is faster on all current Python versions.

<img width="1260" height="704" alt="Screenshot 2026-01-19 at 12 16 34 PM" src="https://github.com/user-attachments/assets/275c30cf-e07c-4245-99ae-85965f6eaaea" />


(I suspect that `.translate` could be made faster in the future, as logically it could be faster, I think a lot more work went into optimizing `.replace`, there's a specialized fast path for one char replace) Edit: actually, not so sure. Translate is processing every char, while replace can do a vectorized copy, then scan looking for a single character replacement (there's [a fast path for one char replacements](https://github.com/python/cpython/blob/main/Objects/stringlib/replace.h)). For a small number of chars, this is going to be faster than a hash table lookup and one byte builder. Optimizing translate to complete might be tricky.


CC @hugovk, not as important for CPython, where this is only marginally faster, but very nice for libraries that run on 3.12 and 3.13. `str.translate` is really slow in those versions.

Credit to @sirosen for coming up with this alternative, I was thinking about falling back to the old method on CPython 3.12 and 3.13. :)