### PR TITLE
chore: add more __all__/__dir__

### DIFF
--- a/src/packaging/licenses/__init__.py
+++ b/src/packaging/licenses/__init__.py
@@ -42,6 +42,12 @@ __all__ = [
     "canonicalize_license_expression",
 ]
 
+
+# Simple __dir__ implementation since there are no public submodules
+def __dir__() -> list[str]:
+    return __all__
+
+
 license_ref_allowed = re.compile("^[A-Za-z0-9.-]*$")
 
 NormalizedLicenseExpression = NewType("NormalizedLicenseExpression", str)

--- a/src/packaging/markers.py
+++ b/src/packaging/markers.py
@@ -26,6 +26,11 @@ __all__ = [
     "default_environment",
 ]
 
+
+def __dir__() -> list[str]:
+    return __all__
+
+
 Operator = Callable[[str, Union[str, AbstractSet[str]]], bool]
 EvaluateContext = Literal["metadata", "lock_file", "requirement"]
 MARKERS_ALLOWING_SET = {"extras", "dependency_groups"}

--- a/src/packaging/metadata.py
+++ b/src/packaging/metadata.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import email.feedparser
 import email.header
 import email.message
 import email.parser
@@ -47,6 +46,20 @@ else:  # pragma: no cover
 
         def __repr__(self) -> str:
             return f"{self.__class__.__name__}({self.message!r}, {self.exceptions!r})"
+
+
+__all__ = [
+    "InvalidMetadata",
+    "Metadata",
+    "RFC822Message",
+    "RFC822Policy",
+    "RawMetadata",
+    "parse_email",
+]
+
+
+def __dir__() -> list[str]:
+    return __all__
 
 
 class InvalidMetadata(ValueError):

--- a/src/packaging/pylock.py
+++ b/src/packaging/pylock.py
@@ -39,6 +39,11 @@ __all__ = [
     "is_valid_pylock_path",
 ]
 
+
+def __dir__() -> list[str]:
+    return __all__
+
+
 _T = TypeVar("_T")
 _T2 = TypeVar("_T2")
 

--- a/src/packaging/requirements.py
+++ b/src/packaging/requirements.py
@@ -11,6 +11,15 @@ from .markers import Marker, _normalize_extra_values
 from .specifiers import SpecifierSet
 from .utils import canonicalize_name
 
+__all__ = [
+    "InvalidRequirement",
+    "Requirement",
+]
+
+
+def __dir__() -> list[str]:
+    return __all__
+
 
 class InvalidRequirement(ValueError):
     """

--- a/src/packaging/specifiers.py
+++ b/src/packaging/specifiers.py
@@ -19,6 +19,18 @@ from typing import Any, Callable, Final, Iterable, Iterator, TypeVar, Union
 from .utils import canonicalize_version
 from .version import InvalidVersion, Version
 
+__all__ = [
+    "BaseSpecifier",
+    "InvalidSpecifier",
+    "Specifier",
+    "SpecifierSet",
+]
+
+
+def __dir__() -> list[str]:
+    return __all__
+
+
 T = TypeVar("T")
 UnparsedVersion = Union[Version, str]
 UnparsedVersionVar = TypeVar("UnparsedVersionVar", bound=UnparsedVersion)

--- a/src/packaging/utils.py
+++ b/src/packaging/utils.py
@@ -13,6 +13,23 @@ from .version import InvalidVersion, Version, _TrimmedRelease
 BuildTag = Union[Tuple[()], Tuple[int, str]]
 NormalizedName = NewType("NormalizedName", str)
 
+__all__ = [
+    "BuildTag",
+    "InvalidName",
+    "InvalidSdistFilename",
+    "InvalidWheelFilename",
+    "NormalizedName",
+    "canonicalize_name",
+    "canonicalize_version",
+    "is_normalized_name",
+    "parse_sdist_filename",
+    "parse_wheel_filename",
+]
+
+
+def __dir__() -> list[str]:
+    return __all__
+
 
 class InvalidName(ValueError):
     """

--- a/src/packaging/version.py
+++ b/src/packaging/version.py
@@ -64,6 +64,11 @@ _LETTER_NORMALIZATION = {
 
 __all__ = ["VERSION_PATTERN", "InvalidVersion", "Version", "parse"]
 
+
+def __dir__() -> list[str]:
+    return __all__
+
+
 LocalType = Tuple[Union[int, str], ...]
 
 CmpPrePostDevType = Union[InfinityType, NegativeInfinityType, Tuple[str, int]]


### PR DESCRIPTION
Followup to #1011, filling out more all/dir.

I was going to do this one at a time, but quite a few already had `__all__`, so I did it all at once. Here's the script I used to help:


```python
import argparse
import ast
from pathlib import Path


def generate_all_from_ast(path: Path) -> list[str]:
    tree = ast.parse(path.read_text())
    names: set[str] = set()

    for node in tree.body:
        match node:
            # def foo(...) or class Foo:
            case (
                ast.FunctionDef(name=name)
                | ast.AsyncFunctionDef(name=name)
                | ast.ClassDef(name=name)
            ) if not name.startswith("_"):
                names.add(name)

            # x = ...
            case ast.Assign(targets=targets) | ast.AnnAssign(targets=targets):
                for target in targets:
                    match target:
                        case ast.Name(id=name) if not name.startswith("_"):
                            names.add(name)
            case (
                ast.Assign(target=ast.Name(id=name))
                | ast.AnnAssign(target=ast.Name(id=name))
            ) if not name.startswith("_"):
                names.add(name)

            # from module import a, b as c
            case ast.ImportFrom(module=_, level=0, names=imported):
                for entry in imported:
                    match entry:
                        case ast.alias(name=name, asname=asname) if (
                            asname is not None and not asname.startswith("_")
                        ):
                            names.add(asname)

            # Ignore everything else
            case _:
                pass

    return sorted(names)


def main() -> None:
    parser = argparse.ArgumentParser(
        description="Generate a __all__ list for a Python source file"
    )
    parser.add_argument(
        "file",
        type=Path,
        help="Python source file to analyze",
    )
    args = parser.parse_args()

    names = generate_all_from_ast(args.file)

    print("__all__ = [")
    for name in names:
        print(f'    "{name}",')
    print("]")


if __name__ == "__main__":
    main()
```