### PR TITLE
docs: add versionchanged for platform_tags

### DIFF
--- a/docs/markers.rst
+++ b/docs/markers.rst
@@ -96,14 +96,6 @@ Reference
 
     :rtype: Environment
 
- .. function:: format_full_version(info)
-
-    Formats a Python version from a ``sys.version_info``-like object.
-
-    :param info: An object with ``major``, ``minor``, ``micro``,
-                 ``releaselevel`` and ``serial`` attributes.
-    :rtype: str
-
 .. exception:: InvalidMarker
 
     Raised when attempting to create a :class:`Marker` with a string that

--- a/docs/tags.rst
+++ b/docs/tags.rst
@@ -185,11 +185,10 @@ to the implementation to provide.
 
 .. function:: platform_tags(version=None, arch=None)
 
-
     Yields the :attr:`~Tag.platform` tags for the running interpreter.
 
         .. versionchanged:: 21.3
-        Added the `pp3-none-any` tag (:issue:`311`).
+            Added the `pp3-none-any` tag (:issue:`311`).
 
 
 


### PR DESCRIPTION
Adds missing versionchanged directive for platform_tags based on changelog (issue #597).
