### PR TITLE
perf: Stream PEP440 filtering in `SpecifierSet.filter`

### DIFF
--- a/tests/test_specifiers.py
+++ b/tests/test_specifiers.py
@@ -1079,6 +1079,33 @@ class TestSpecifierSet:
         # check filter behavior (no override of prereleases passed to filter)
         assert list(spec.filter(versions)) == expected
 
+    @pytest.mark.parametrize(
+        ("versions", "expected"),
+        [
+            # Mixed prerelease, arbitrary, final - return arbitrary and final in order
+            (
+                ["1.0a1", "foobar", "1.0", "2.0a1", "bazqux", "2.0"],
+                ["foobar", "1.0", "bazqux", "2.0"],
+            ),
+            # Mixed arbitrary, final - return all in order
+            (
+                ["foobar", "1.0", "bazqux", "2.0", "hello"],
+                ["foobar", "1.0", "bazqux", "2.0", "hello"],
+            ),
+            # Mixed prerelease, arbitrary (no final) - return all in order
+            (
+                ["1.0a1", "foobar", "2.0a1", "bazqux", "3.0a1"],
+                ["1.0a1", "foobar", "2.0a1", "bazqux", "3.0a1"],
+            ),
+        ],
+    )
+    def test_empty_specifier_ordering_with_arbitrary(
+        self, versions: list[str], expected: list[str]
+    ) -> None:
+        spec = SpecifierSet("")
+        result = list(spec.filter(versions))
+        assert result == expected
+
     def test_create_from_specifiers(self) -> None:
         spec_strs = [">=1.0", "!=1.1", "!=1.2", "<2.0"]
         specs = [Specifier(s) for s in spec_strs]


### PR DESCRIPTION
This is a performance improvement when using  `SpecifierSet.filter` with the default `prereleases` to get the first version, e.g.

```python
versions = [Version(str(i)) for i in range(1000, 0, -1)]
spec = SpecifierSet(">=900")
best_version = next(iter(spec.filter(versions)))
```

On my machine the performance of line 3 goes from about 450 µs to 2 µs, the complete filtering performance is not improved (and may be ~2% slower on my machine, it was within the error range so hard to tell). Prerelease only performance is not affected, but this is not the common case.

I expect this streaming performance to be important now users of packaging can do one-pass using `SpecifierSet.filter` on candidates with `key` (https://github.com/pypa/packaging/pull/1068).

I've added some tests to make sure ordering is preserved, as naively implementing this would break order preservation in some edge cases,