### PR TITLE
chore: cleanup pre-commit a bit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,10 +9,10 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.13.0
+    rev: v0.15.0
     hooks:
       - id: ruff-check
-        args: [ --fix, --show-fixes ]
+        args: [ --fix ]
       - id: ruff-format
 
   - repo: https://github.com/pre-commit/pygrep-hooks
@@ -23,21 +23,21 @@ repos:
     - id: rst-inline-touching-normal
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.18.1
+    rev: v1.19.1
     hooks:
       - id: mypy
         exclude: '^(docs)'
         args: []
-        additional_dependencies: [pyparsing, nox, orjson, 'pytest<9', tomli, tomli_w, types-invoke, httpx]
+        additional_dependencies: [nox, orjson, 'pytest<9', tomli, tomli_w, types-invoke, httpx]
 
   - repo: https://github.com/crate-ci/typos
-    rev: v1.40.0
+    rev: v1.43.1
     hooks:
       - id: typos
         args: []
 
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
-    rev: v1.20.0
+    rev: v1.22.0
     hooks:
       - id: zizmor
         files: "^\\.github"

--- a/src/packaging/version.py
+++ b/src/packaging/version.py
@@ -37,7 +37,7 @@ else:  # pragma: no cover
     import warnings
 
     def _deprecated(message: str) -> object:
-        def decorator(func: object) -> object:
+        def decorator(func: Callable[[...], object]) -> object:
             @functools.wraps(func)
             def wrapper(*args: object, **kwargs: object) -> object:
                 warnings.warn(

--- a/tests/test_markers.py
+++ b/tests/test_markers.py
@@ -347,8 +347,10 @@ class TestMarker:
     def test_evaluates(
         self, marker_string: str, environment: dict[str, str] | None, expected: bool
     ) -> None:
-        args = () if environment is None else (environment,)
-        assert Marker(marker_string).evaluate(*args) == expected
+        if environment is None:
+            assert Marker(marker_string).evaluate() == expected
+        else:
+            assert Marker(marker_string).evaluate(environment) == expected
 
     @pytest.mark.parametrize(
         "marker_string",
@@ -386,8 +388,10 @@ class TestMarker:
     def test_evaluate_pep345_markers(
         self, marker_string: str, environment: dict[str, str] | None, expected: bool
     ) -> None:
-        args = () if environment is None else (environment,)
-        assert Marker(marker_string).evaluate(*args) == expected
+        if environment is None:
+            assert Marker(marker_string).evaluate() == expected
+        else:
+            assert Marker(marker_string).evaluate(environment) == expected
 
     @pytest.mark.parametrize(
         "marker_string",


### PR DESCRIPTION
Small things I found to clean up. I was trying out ty, and noticed this cleanup while testing it.

<details><summary>Diff to try out ty</summary>

```diff
diff --git a/noxfile.py b/noxfile.py
index 046ec14..7505b8e 100644
--- a/noxfile.py
+++ b/noxfile.py
@@ -118,6 +118,18 @@ def docs(session: nox.Session) -> None:
         )


+@nox.session(default=False)
+def mypy(session: nox.Session) -> None:
+    session.install("--group=typing", "mypy", "orjson")
+    session.run("mypy")
+
+
+@nox.session(default=False)
+def ty(session: nox.Session) -> None:
+    session.install("--group=typing", "ty")
+    session.run("ty", "check")
+
+
 @nox.session(default=False)
 def release(session: nox.Session) -> None:
     """
diff --git a/pyproject.toml b/pyproject.toml
index de92ac7..a5c4c8a 100644
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,14 @@ docs = [
     "sphinx-toolbox",
     "typing-extensions>=4.1.0; python_version < '3.9'",
 ]
+typing = [
+  "nox",
+  "pytest<9",
+  "tomli",
+  "tomli_w",
+  "types-invoke",
+  "httpx",
+]


 [tool.flit.sdist]
@@ -96,6 +104,13 @@ files = ["src", "tests", "noxfile.py"]
 module = ["_manylinux", "pretend", "progress.*", "pkg_resources"]
 ignore_missing_imports = true

+
+[tool.ty]
+rules.unused-ignore-comment = "ignore"
+analysis.allowed-unresolved-imports = ["_manylinux", "pretend", "progress.*", "pkg_resources"]
+src.exclude = ["tasks/check.py"]
+
+
 [tool.ruff]
 extend-exclude = [
     "src/packaging/licenses/_spdx.py"
```

</details> 
