### PR TITLE
docs: fill out and clean up Version page a little

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -75,6 +75,12 @@ html_show_sourcelink = False
 
 autodoc_member_order = "bysource"
 autodoc_preserve_defaults = True
+autodoc_default_options = {
+    "exclude-members": "__weakref__",
+}
+
+# Allow the signature to be overridden
+autodoc_docstring_signature = True
 
 # Automatically extract typehints when specified and place them in
 # descriptions of the relevant function/method.


### PR DESCRIPTION
Working on the Version page a little:

* Drop the `__weakref__` display on `packaging.version.InvalidVersion`
* Document `from_parts`, `__replace__`, `__match_args__`
* Override the `__replace__` signature to be more useful
* Display the `__replace__` parameters
* Add `versionchanged` and `versionadded`
* Trick sphinx into putting `versionadded` in the right place (at the end) of `from_parts` by including at least one `:param ...`
* Mention fast path replacements for `.public` and `.base_version`
* Mention that `parse(...)` is identical to `Version(...)`
