### PR TITLE
fix: standardize inner parts of reprs

### DIFF
--- a/src/packaging/markers.py
+++ b/src/packaging/markers.py
@@ -329,7 +329,7 @@ class Marker:
         return _format_marker(self._markers)
 
     def __repr__(self) -> str:
-        return f"<{self.__class__.__name__}('{self}')>"
+        return f"<{self.__class__.__name__}({str(self)!r})>"
 
     def __hash__(self) -> int:
         return hash(str(self))

--- a/src/packaging/requirements.py
+++ b/src/packaging/requirements.py
@@ -77,7 +77,7 @@ class Requirement:
         return "".join(self._iter_parts(self.name))
 
     def __repr__(self) -> str:
-        return f"<{self.__class__.__name__}('{self}')>"
+        return f"<{self.__class__.__name__}({str(self)!r})>"
 
     def __hash__(self) -> int:
         return hash(tuple(self._iter_parts(canonicalize_name(self.name))))

--- a/src/packaging/specifiers.py
+++ b/src/packaging/specifiers.py
@@ -934,7 +934,7 @@ class SpecifierSet(BaseSpecifier):
             else ""
         )
 
-        return f"<SpecifierSet({str(self)!r}{pre})>"
+        return f"<{self.__class__.__name__}({str(self)!r}{pre})>"
 
     def __str__(self) -> str:
         """A string representation of the specifier set that can be round-tripped.

--- a/src/packaging/version.py
+++ b/src/packaging/version.py
@@ -510,7 +510,7 @@ class Version(_BaseVersion):
         >>> Version('1.0.0')
         <Version('1.0.0')>
         """
-        return f"<Version('{self}')>"
+        return f"<{self.__class__.__name__}({str(self)!r})>"
 
     def __str__(self) -> str:
         """A string representation of the version that can be round-tripped.


### PR DESCRIPTION
This is a very small change to the workings of reprs to make them more consistent. It does not change the rerps themselves (yet).

* Always use the class name so subclasses show their names instead
* Consistently use `str()!r` vs. putting in quotes manually.
