### PR TITLE
fix: handle key parameter in SpecifierSet.filter for empty specifiers and prerelease is false

### DIFF
--- a/src/packaging/specifiers.py
+++ b/src/packaging/specifiers.py
@@ -1179,8 +1179,11 @@ class SpecifierSet(BaseSpecifier):
                 return (
                     item
                     for item in iterable
-                    if (version := _coerce_version(item)) is None
-                    or not version.is_prerelease
+                    if (
+                        (version := _coerce_version(item if key is None else key(item)))
+                        is None
+                        or not version.is_prerelease
+                    )
                 )
 
         # PEP 440: exclude prereleases unless no final releases matched

--- a/tests/test_specifiers.py
+++ b/tests/test_specifiers.py
@@ -1441,6 +1441,28 @@ class TestSpecifierSet:
         assert result == expected
 
     @pytest.mark.parametrize(
+        ("prereleases", "expected_indexes"),
+        [
+            (None, [1]),
+            (True, [0, 1]),
+            (False, [1]),
+        ],
+    )
+    def test_empty_specifierset_filter_with_key(
+        self, prereleases: bool | None, expected_indexes: list[int]
+    ) -> None:
+        items = [
+            {"version": "2.0a1"},
+            {"version": "2.1"},
+        ]
+
+        spec = SpecifierSet("", prereleases=prereleases)
+        result = list(spec.filter(items, key=lambda item: item["version"]))
+
+        expected = [items[index] for index in expected_indexes]
+        assert result == expected
+
+    @pytest.mark.parametrize(
         ("specifier", "prereleases", "input", "expected"),
         [
             # !=1.*, !=2.*, !=3.0 leaves gap at 3.0 prereleases


### PR DESCRIPTION
I manually vendored packaging main into pip main and ran pip's test and found this missing case from adding key filter in https://github.com/pypa/packaging/pull/1068.