### PR TITLE
Use direct operator methods in `_compare_compatible`

### DIFF
--- a/src/packaging/specifiers.py
+++ b/src/packaging/specifiers.py
@@ -478,8 +478,8 @@ class Specifier(BaseSpecifier):
         # Add the prefix notation to the end of our string
         prefix += ".*"
 
-        return self._get_operator(">=")(prospective, spec) and self._get_operator("==")(
-            prospective, prefix
+        return (self._compare_greater_than_equal(prospective, spec)) and (
+            self._compare_equal(prospective, prefix)
         )
 
     def _compare_equal(self, prospective: Version, spec: str) -> bool:


### PR DESCRIPTION
We already use direct operator method calls in other places now, this makes it easier to navigate the code using coding tools as you can jump directly to the intended method.

And in theory should be slight faster, as you don't have to go via another function to get the correct method, but I have not benchmarked it and I imagine it would be marginal.

I have added additional parenthesis to preserve the method calls on a single line, otherwise formatting breaks them up.