### PR TITLE
fix: only ASCII allowed in local version

### DIFF
--- a/src/packaging/specifiers.py
+++ b/src/packaging/specifiers.py
@@ -204,17 +204,17 @@ class Specifier(BaseSpecifier):
                 (?:
                     \.\*  # Wild card syntax of .*
                     |
-                    (?:                                  # pre release
+                    (?a:                                  # pre release
                         [-_\.]?
                         (alpha|beta|preview|pre|a|b|c|rc)
                         [-_\.]?
                         [0-9]*
                     )?
-                    (?:                                  # post release
+                    (?a:                                  # post release
                         (?:-[0-9]+)|(?:[-_\.]?(post|rev|r)[-_\.]?[0-9]*)
                     )?
-                    (?:[-_\.]?dev[-_\.]?[0-9]*)?         # dev release
-                    (?:\+[a-z0-9]+(?:[-_\.][a-z0-9]+)*)? # local
+                    (?a:[-_\.]?dev[-_\.]?[0-9]*)?         # dev release
+                    (?a:\+[a-z0-9]+(?:[-_\.][a-z0-9]+)*)? # local
                 )?
             )
             |
@@ -252,16 +252,16 @@ class Specifier(BaseSpecifier):
                 v?
                 (?:[0-9]+!)?          # epoch
                 [0-9]+(?:\.[0-9]+)*   # release
-                (?:                   # pre release
+                (?a:                   # pre release
                     [-_\.]?
                     (alpha|beta|preview|pre|a|b|c|rc)
                     [-_\.]?
                     [0-9]*
                 )?
-                (?:                                   # post release
+                (?a:                                   # post release
                     (?:-[0-9]+)|(?:[-_\.]?(post|rev|r)[-_\.]?[0-9]*)
                 )?
-                (?:[-_\.]?dev[-_\.]?[0-9]*)?          # dev release
+                (?a:[-_\.]?dev[-_\.]?[0-9]*)?          # dev release
             )
         )
         """

--- a/src/packaging/utils.py
+++ b/src/packaging/utils.py
@@ -55,10 +55,12 @@ class InvalidSdistFilename(ValueError):
 
 
 # Core metadata spec for `Name`
-_validate_regex = re.compile(r"[A-Z0-9]|[A-Z0-9][A-Z0-9._-]*[A-Z0-9]", re.IGNORECASE)
-_normalized_regex = re.compile(r"[a-z0-9]|[a-z0-9]([a-z0-9-](?!--))*[a-z0-9]")
+_validate_regex = re.compile(
+    r"[a-z0-9]|[a-z0-9][a-z0-9._-]*[a-z0-9]", re.IGNORECASE | re.ASCII
+)
+_normalized_regex = re.compile(r"[a-z0-9]|[a-z0-9]([a-z0-9-](?!--))*[a-z0-9]", re.ASCII)
 # PEP 427: The build number must start with a digit.
-_build_tag_regex = re.compile(r"(\d+)(.*)")
+_build_tag_regex = re.compile(r"(\d+)(.*)", re.ASCII)
 
 
 def canonicalize_name(name: str, *, validate: bool = False) -> NormalizedName:

--- a/src/packaging/version.py
+++ b/src/packaging/version.py
@@ -201,7 +201,7 @@ class _BaseVersion:
 # Note that ++ doesn't behave identically on CPython and PyPy, so not using it here
 _VERSION_PATTERN = r"""
     v?+                                                   # optional leading v
-    (?:
+    (?a:
         (?:(?P<epoch>[0-9]+)!)?+                          # epoch
         (?P<release>[0-9]+(?:\.[0-9]+)*+)                 # release segment
         (?P<pre>                                          # pre-release
@@ -227,7 +227,7 @@ _VERSION_PATTERN = r"""
             (?P<dev_n>[0-9]+)?
         )?+
     )
-    (?:\+
+    (?a:\+
         (?P<local>                                        # local version
             [a-z0-9]+
             (?:[._-][a-z0-9]+)*+
@@ -265,7 +265,7 @@ flags set.
 
 
 # Validation pattern for local version in replace()
-_LOCAL_PATTERN = re.compile(r"[a-z0-9]+(?:[._-][a-z0-9]+)*", re.IGNORECASE)
+_LOCAL_PATTERN = re.compile(r"[a-z0-9]+(?:[._-][a-z0-9]+)*", re.IGNORECASE | re.ASCII)
 
 # Fast path: If a version has only digits and dots then we
 # can skip the regex and parse it as a release segment

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -166,6 +166,9 @@ class TestVersion:
             "1.0.",
             ".1.0",
             "1..2.3",
+            # Local version which includes a non-ASCII letter that matches
+            # regex '[a-z]' when re.IGNORECASE is in force and re.ASCII is not
+            "1.0+\u0130",
         ],
     )
     def test_invalid_versions(self, version: str) -> None:
@@ -284,6 +287,8 @@ class TestVersion:
             # Various other normalizations
             ("v1.0", "1.0"),
             ("   v1.0\t\n", "1.0"),
+            # Non-ASCII whitespace
+            ("\N{NARROW NO-BREAK SPACE}1.0\t\N{PARAGRAPH SEPARATOR}\n ", "1.0"),
         ],
     )
     def test_normalized_versions(self, version: str, normalized: str) -> None:


### PR DESCRIPTION
This is an alternative to and closes #470. Tests come from that PR.

Starting in Python 3.6, you can add a flag to a subsection of a regex, so we can make the matches ASCII-only without changing the surrounding whitespace matching. I'm not sure why we support non-ASCII whitespace, but this keeps support. I've added it several places where only ASCII is supported.

I expect this might be a tiny bit faster, since it's a simpler regex match, but not measurably so.
