### PR TITLE
perf: simply Specifier regex

### DIFF
--- a/src/packaging/_tokenizer.py
+++ b/src/packaging/_tokenizer.py
@@ -75,7 +75,7 @@ DEFAULT_RULES: dict[str, re.Pattern[str]] = {
         re.VERBOSE,
     ),
     "SPECIFIER": re.compile(
-        Specifier._operator_regex_str + Specifier._version_regex_str,
+        Specifier._specifier_regex_str,
         re.VERBOSE | re.IGNORECASE,
     ),
     "AT": re.compile(r"\@"),

--- a/src/packaging/specifiers.py
+++ b/src/packaging/specifiers.py
@@ -169,18 +169,15 @@ class Specifier(BaseSpecifier):
 
     __slots__ = ("_prereleases", "_spec", "_spec_version", "_wildcard_split")
 
-    _operator_regex_str = r"""
-        (?P<operator>(~=|==|!=|<=|>=|<|>|===))
-        """
-    _version_regex_str = r"""
-        (?P<version>
+    _specifier_regex_str = r"""
+        (?:
             (?:
                 # The identity operators allow for an escape hatch that will
                 # do an exact string match of the version you wish to install.
                 # This will not be parsed by PEP 440 and we cannot determine
                 # any semantic meaning from it. This operator is discouraged
                 # but included entirely as an escape hatch.
-                (?<====)  # Only match for the identity operator
+                ===  # Only match for the identity operator
                 \s*
                 [^\s;)]*  # The arbitrary version can be just about anything,
                           # we match everything except for whitespace, a
@@ -192,7 +189,7 @@ class Specifier(BaseSpecifier):
                 # The (non)equality operators allow for wild card and local
                 # versions to be specified so we have to define these two
                 # operators separately to enable that.
-                (?<===|!=)            # Only match for equals and not equals
+                (?:==|!=)            # Only match for equals and not equals
 
                 \s*
                 v?
@@ -221,7 +218,7 @@ class Specifier(BaseSpecifier):
             (?:
                 # The compatible operator requires at least two digits in the
                 # release segment.
-                (?<=~=)               # Only match for the compatible operator
+                (?:~=)               # Only match for the compatible operator
 
                 \s*
                 v?
@@ -244,9 +241,7 @@ class Specifier(BaseSpecifier):
                 # (non)equality operators do. Specifically they do not allow
                 # local versions to be specified nor do they allow the prefix
                 # matching wild cards.
-                (?<!==|!=|~=)         # We have special cases for these
-                                      # operators so we want to make sure they
-                                      # don't match here.
+                (?:<=|>=|<|>)
 
                 \s*
                 v?
@@ -267,8 +262,7 @@ class Specifier(BaseSpecifier):
         """
 
     _regex = re.compile(
-        r"\s*" + _operator_regex_str + _version_regex_str + r"\s*",
-        re.VERBOSE | re.IGNORECASE,
+        r"\s*" + _specifier_regex_str + r"\s*", re.VERBOSE | re.IGNORECASE
     )
 
     _operators: Final = {
@@ -295,14 +289,18 @@ class Specifier(BaseSpecifier):
         :raises InvalidSpecifier:
             If the given specifier is invalid (i.e. bad syntax).
         """
-        match = self._regex.fullmatch(spec)
-        if not match:
+        if not self._regex.fullmatch(spec):
             raise InvalidSpecifier(f"Invalid specifier: {spec!r}")
 
-        self._spec: tuple[str, str] = (
-            match.group("operator").strip(),
-            match.group("version").strip(),
-        )
+        spec = spec.strip()
+        if spec.startswith("==="):
+            operator, version = spec[:3], spec[3:].strip()
+        elif spec.startswith(("~=", "==", "!=", "<=", ">=")):
+            operator, version = spec[:2], spec[2:].strip()
+        else:
+            operator, version = spec[:1], spec[1:].strip()
+
+        self._spec: tuple[str, str] = (operator, version)
 
         # Store whether or not this Specifier should accept prereleases
         self._prereleases = prereleases


### PR DESCRIPTION
I'm not totally sure I trust the results I'm getting from benchmarking.
These results seem *too good* for the modest changes included here, so I'm concerned that I've somehow run the benchmarks incorrectly.

However, it's showing a consistent improvement, so I think this is worth submitting for further evaluation.

------

Examining the specifier regex, two potential optimizations seem
worthwhile:

1. Negative lookbehinds can be eliminated if we combine the operator
   regex with the version regex -- this avoids crawling the same
   characters of a string forwards and backwards.

2. Do more string operations, like `strip()` rather than having the
   regex engine do this work.

These ideas are somewhat combined, in that getting rid of the lookbehinds
only really works by eliminating the group selectors in use. And removing
the group selectors in the regex requires that we do more string
operations.

This also interestingly results in a regex stored in the `Specifier`
which matches its secondary usage in `_tokenizer`, which was previously
very slightly misaligned (in that the group captures in the regex were
unused).

-----

Running the benchmarks from #1059 on this, I get some surprisingly good results.

We expect this to be mostly noticeable with the `Specifier` constructor benchmark, and that does show results:
```
| Change   | Before [b2986d4b] <main>   | After [8feee4e6] <micro-optimize-specifiers>   | Ratio   | Benchmark (Parameter)                                                     |
|----------|----------------------------|------------------------------------------------|---------|---------------------------------------------------------------------------|
| -        | 4.87±0.6ms                 | 4.17±0.04ms                                    | 0.86    | specifiers.TimeSpecSuite.time_constructor [zug/virtualenv-py3.10]         |
| -        | 4.16±0.04ms                | 3.24±0.04ms                                    | 0.78    | specifiers.TimeSpecSuite.time_constructor [zug/virtualenv-py3.11]         |
| -        | 4.21±0.1ms                 | 3.37±0.04ms                                    | 0.80    | specifiers.TimeSpecSuite.time_constructor [zug/virtualenv-py3.12]         |
| -        | 4.16±0.08ms                | 3.29±0.07ms                                    | 0.79    | specifiers.TimeSpecSuite.time_constructor [zug/virtualenv-py3.13]         |
| -        | 3.47±0.01ms                | 2.86±0.05ms                                    | 0.82    | specifiers.TimeSpecSuite.time_constructor [zug/virtualenv-py3.14]         |
|          | 4.69±0.2ms                 | 4.57±0.1ms                                     | 0.97    | specifiers.TimeSpecSuite.time_constructor [zug/virtualenv-py3.8]          |
|          | 4.87±0.07ms                | 4.65±0.04ms                                    | 0.96    | specifiers.TimeSpecSuite.time_constructor [zug/virtualenv-py3.9]          |
```

So this makes this branch look *much* better, especially on newer Pythons, and no regression (but no real improvement) in 3.8 and 3.9.

Many of the higher level tests show similar/related improvement. I think the largest ratio in my runs is this one:
```
| Change   | Before [b2986d4b] <main>   | After [8feee4e6] <micro-optimize-specifiers>   | Ratio   | Benchmark (Parameter)                                                     |
|----------|----------------------------|------------------------------------------------|---------|---------------------------------------------------------------------------|
| -        | 800±9μs                    | 611±9μs                                        | 0.76    | resolver.TimeResolverSuite.time_resolver_loop [zug/virtualenv-py3.11]     |
```

<details><summary>full asv results</summary>

```
$ asv compare 'main' 'micro-optimize-specifiers'
<frozen importlib._bootstrap>:491: RuntimeWarning: The global interpreter lock (GIL) has been enabled to load module 'asv._rangemedian', which has not declared that it can run safely without the GIL. To override this behavior and keep the GIL disabled (at your own risk), run with PYTHON_GIL=0 or -Xgil=0.

All benchmarks:

| Change   | Before [b2986d4b] <main>   | After [8feee4e6] <micro-optimize-specifiers>   | Ratio   | Benchmark (Parameter)                                                     |
|----------|----------------------------|------------------------------------------------|---------|---------------------------------------------------------------------------|
| -        | 3.92±0.1ms                 | 3.47±0.03ms                                    | 0.88    | markers.TimeMarkerSuite.time_constructor [zug/virtualenv-py3.10]          |
| -        | 3.08±0.03ms                | 2.65±0.02ms                                    | 0.86    | markers.TimeMarkerSuite.time_constructor [zug/virtualenv-py3.11]          |
| -        | 3.47±0.1ms                 | 2.88±0.07ms                                    | 0.83    | markers.TimeMarkerSuite.time_constructor [zug/virtualenv-py3.12]          |
| -        | 3.41±0.05ms                | 2.97±0.05ms                                    | 0.87    | markers.TimeMarkerSuite.time_constructor [zug/virtualenv-py3.13]          |
| -        | 2.94±0.05ms                | 2.55±0.05ms                                    | 0.87    | markers.TimeMarkerSuite.time_constructor [zug/virtualenv-py3.14]          |
|          | 3.83±0.04ms                | 3.63±0.1ms                                     | 0.95    | markers.TimeMarkerSuite.time_constructor [zug/virtualenv-py3.8]           |
|          | 4.00±0.03ms                | 3.78±0.03ms                                    | 0.94    | markers.TimeMarkerSuite.time_constructor [zug/virtualenv-py3.9]           |
|          | 1.36±0.1ms                 | 1.16±0.02ms                                    | ~0.86   | markers.TimeMarkerSuite.time_evaluate [zug/virtualenv-py3.10]             |
| -        | 1.01±0ms                   | 833±30μs                                       | 0.83    | markers.TimeMarkerSuite.time_evaluate [zug/virtualenv-py3.11]             |
| -        | 1.15±0.05ms                | 965±30μs                                       | 0.84    | markers.TimeMarkerSuite.time_evaluate [zug/virtualenv-py3.12]             |
| -        | 1.10±0.03ms                | 919±20μs                                       | 0.83    | markers.TimeMarkerSuite.time_evaluate [zug/virtualenv-py3.13]             |
| -        | 894±20μs                   | 747±3μs                                        | 0.84    | markers.TimeMarkerSuite.time_evaluate [zug/virtualenv-py3.14]             |
|          | 1.23±0.01ms                | 1.15±0.03ms                                    | 0.93    | markers.TimeMarkerSuite.time_evaluate [zug/virtualenv-py3.8]              |
|          | 1.24±0.01ms                | 1.19±0.01ms                                    | 0.96    | markers.TimeMarkerSuite.time_evaluate [zug/virtualenv-py3.9]              |
|          | 17.2±2ms                   | 14.8±0.09ms                                    | ~0.86   | requirement.TimeRequirementSuite.time_constructor [zug/virtualenv-py3.10] |
| -        | 14.7±0.2ms                 | 11.5±0.2ms                                     | 0.78    | requirement.TimeRequirementSuite.time_constructor [zug/virtualenv-py3.11] |
| -        | 16.2±0.07ms                | 12.5±0.07ms                                    | 0.77    | requirement.TimeRequirementSuite.time_constructor [zug/virtualenv-py3.12] |
| -        | 15.4±0.1ms                 | 12.6±0.1ms                                     | 0.82    | requirement.TimeRequirementSuite.time_constructor [zug/virtualenv-py3.13] |
| -        | 12.7±0.2ms                 | 10.4±0.03ms                                    | 0.82    | requirement.TimeRequirementSuite.time_constructor [zug/virtualenv-py3.14] |
|          | 17.3±0.1ms                 | 16.0±0.2ms                                     | 0.92    | requirement.TimeRequirementSuite.time_constructor [zug/virtualenv-py3.8]  |
|          | 17.4±0.1ms                 | 16.2±0.2ms                                     | 0.93    | requirement.TimeRequirementSuite.time_constructor [zug/virtualenv-py3.9]  |
| -        | 991±90μs                   | 817±4μs                                        | 0.82    | resolver.TimeResolverSuite.time_resolver_loop [zug/virtualenv-py3.10]     |
| -        | 800±9μs                    | 611±9μs                                        | 0.76    | resolver.TimeResolverSuite.time_resolver_loop [zug/virtualenv-py3.11]     |
| -        | 791±3μs                    | 622±8μs                                        | 0.79    | resolver.TimeResolverSuite.time_resolver_loop [zug/virtualenv-py3.12]     |
| -        | 775±20μs                   | 646±10μs                                       | 0.83    | resolver.TimeResolverSuite.time_resolver_loop [zug/virtualenv-py3.13]     |
| -        | 624±8μs                    | 515±2μs                                        | 0.82    | resolver.TimeResolverSuite.time_resolver_loop [zug/virtualenv-py3.14]     |
|          | 906±10μs                   | 844±9μs                                        | 0.93    | resolver.TimeResolverSuite.time_resolver_loop [zug/virtualenv-py3.8]      |
|          | 921±20μs                   | 908±10μs                                       | 0.99    | resolver.TimeResolverSuite.time_resolver_loop [zug/virtualenv-py3.9]      |
| -        | 4.87±0.6ms                 | 4.17±0.04ms                                    | 0.86    | specifiers.TimeSpecSuite.time_constructor [zug/virtualenv-py3.10]         |
| -        | 4.16±0.04ms                | 3.24±0.04ms                                    | 0.78    | specifiers.TimeSpecSuite.time_constructor [zug/virtualenv-py3.11]         |
| -        | 4.21±0.1ms                 | 3.37±0.04ms                                    | 0.80    | specifiers.TimeSpecSuite.time_constructor [zug/virtualenv-py3.12]         |
| -        | 4.16±0.08ms                | 3.29±0.07ms                                    | 0.79    | specifiers.TimeSpecSuite.time_constructor [zug/virtualenv-py3.13]         |
| -        | 3.47±0.01ms                | 2.86±0.05ms                                    | 0.82    | specifiers.TimeSpecSuite.time_constructor [zug/virtualenv-py3.14]         |
|          | 4.69±0.2ms                 | 4.57±0.1ms                                     | 0.97    | specifiers.TimeSpecSuite.time_constructor [zug/virtualenv-py3.8]          |
|          | 4.87±0.07ms                | 4.65±0.04ms                                    | 0.96    | specifiers.TimeSpecSuite.time_constructor [zug/virtualenv-py3.9]          |
| -        | 6.17±0.6ms                 | 5.32±0.02ms                                    | 0.86    | specifiers.TimeSpecSuite.time_contains_cold [zug/virtualenv-py3.10]       |
| -        | 5.09±0.03ms                | 4.21±0.04ms                                    | 0.83    | specifiers.TimeSpecSuite.time_contains_cold [zug/virtualenv-py3.11]       |
| -        | 5.71±0.2ms                 | 4.44±0.1ms                                     | 0.78    | specifiers.TimeSpecSuite.time_contains_cold [zug/virtualenv-py3.12]       |
| -        | 5.42±0.05ms                | 4.64±0.08ms                                    | 0.86    | specifiers.TimeSpecSuite.time_contains_cold [zug/virtualenv-py3.13]       |
| -        | 4.24±0.09ms                | 3.46±0.03ms                                    | 0.82    | specifiers.TimeSpecSuite.time_contains_cold [zug/virtualenv-py3.14]       |
|          | 6.44±0.08ms                | 6.04±0.04ms                                    | 0.94    | specifiers.TimeSpecSuite.time_contains_cold [zug/virtualenv-py3.8]        |
|          | 6.38±0.06ms                | 6.04±0.1ms                                     | 0.95    | specifiers.TimeSpecSuite.time_contains_cold [zug/virtualenv-py3.9]        |
|          | 4.71±0.6ms                 | 4.10±0.04ms                                    | ~0.87   | specifiers.TimeSpecSuite.time_contains_warm [zug/virtualenv-py3.10]       |
| -        | 3.86±0.02ms                | 3.16±0.03ms                                    | 0.82    | specifiers.TimeSpecSuite.time_contains_warm [zug/virtualenv-py3.11]       |
| -        | 4.29±0.07ms                | 3.43±0.05ms                                    | 0.80    | specifiers.TimeSpecSuite.time_contains_warm [zug/virtualenv-py3.12]       |
| -        | 4.01±0.04ms                | 3.44±0.02ms                                    | 0.86    | specifiers.TimeSpecSuite.time_contains_warm [zug/virtualenv-py3.13]       |
| -        | 3.14±0.02ms                | 2.56±0.01ms                                    | 0.82    | specifiers.TimeSpecSuite.time_contains_warm [zug/virtualenv-py3.14]       |
|          | 4.77±0.07ms                | 4.37±0.07ms                                    | 0.92    | specifiers.TimeSpecSuite.time_contains_warm [zug/virtualenv-py3.8]        |
|          | 4.54±0.09ms                | 4.48±0.02ms                                    | 0.99    | specifiers.TimeSpecSuite.time_contains_warm [zug/virtualenv-py3.9]        |
|          | 14.2±2μs                   | 12.2±0.09μs                                    | ~0.86   | specifiers.TimeSpecSuite.time_filter_simple_cold [zug/virtualenv-py3.10]  |
| -        | 10.7±0.2μs                 | 8.09±0.03μs                                    | 0.75    | specifiers.TimeSpecSuite.time_filter_simple_cold [zug/virtualenv-py3.11]  |
| -        | 9.78±0.2μs                 | 7.93±0.1μs                                     | 0.81    | specifiers.TimeSpecSuite.time_filter_simple_cold [zug/virtualenv-py3.12]  |
| -        | 9.99±0.1μs                 | 8.44±0.1μs                                     | 0.85    | specifiers.TimeSpecSuite.time_filter_simple_cold [zug/virtualenv-py3.13]  |
| -        | 7.89±0.02μs                | 6.33±0.2μs                                     | 0.80    | specifiers.TimeSpecSuite.time_filter_simple_cold [zug/virtualenv-py3.14]  |
|          | 13.7±0.2μs                 | 13.0±0.2μs                                     | 0.95    | specifiers.TimeSpecSuite.time_filter_simple_cold [zug/virtualenv-py3.8]   |
|          | 13.6±0.09μs                | 13.2±0.04μs                                    | 0.97    | specifiers.TimeSpecSuite.time_filter_simple_cold [zug/virtualenv-py3.9]   |
|          | 12.3±1μs                   | 10.6±0.09μs                                    | ~0.86   | specifiers.TimeSpecSuite.time_filter_simple_warm [zug/virtualenv-py3.10]  |
| -        | 9.12±0.06μs                | 7.06±0.04μs                                    | 0.77    | specifiers.TimeSpecSuite.time_filter_simple_warm [zug/virtualenv-py3.11]  |
| -        | 8.22±0.07μs                | 6.80±0.1μs                                     | 0.83    | specifiers.TimeSpecSuite.time_filter_simple_warm [zug/virtualenv-py3.12]  |
| -        | 8.67±0.1μs                 | 7.17±0.1μs                                     | 0.83    | specifiers.TimeSpecSuite.time_filter_simple_warm [zug/virtualenv-py3.13]  |
| -        | 6.68±0.04μs                | 5.54±0.07μs                                    | 0.83    | specifiers.TimeSpecSuite.time_filter_simple_warm [zug/virtualenv-py3.14]  |
|          | 11.7±0.3μs                 | 11.2±0.2μs                                     | 0.96    | specifiers.TimeSpecSuite.time_filter_simple_warm [zug/virtualenv-py3.8]   |
|          | 11.7±0.1μs                 | 11.6±0.4μs                                     | 0.99    | specifiers.TimeSpecSuite.time_filter_simple_warm [zug/virtualenv-py3.9]   |
| -        | 3.81±0.3μs                 | 3.22±0.02μs                                    | 0.85    | utils.TimeUtils.time_canonicalize_name [zug/virtualenv-py3.10]            |
| -        | 3.23±0.01μs                | 2.56±0.01μs                                    | 0.79    | utils.TimeUtils.time_canonicalize_name [zug/virtualenv-py3.11]            |
| -        | 3.39±0.02μs                | 2.74±0.02μs                                    | 0.81    | utils.TimeUtils.time_canonicalize_name [zug/virtualenv-py3.12]            |
| -        | 3.56±0.06μs                | 3.04±0.06μs                                    | 0.85    | utils.TimeUtils.time_canonicalize_name [zug/virtualenv-py3.13]            |
|          | 3.06±0.05μs                | 2.55±0.06μs                                    | ~0.83   | utils.TimeUtils.time_canonicalize_name [zug/virtualenv-py3.14]            |
|          | 3.99±0.05μs                | 3.80±0.02μs                                    | 0.95    | utils.TimeUtils.time_canonicalize_name [zug/virtualenv-py3.8]             |
|          | 3.97±0.02μs                | 3.79±0.03μs                                    | 0.95    | utils.TimeUtils.time_canonicalize_name [zug/virtualenv-py3.9]             |
|          | 1.96±0.3ms                 | 1.73±0.02ms                                    | ~0.88   | version.TimeVersionSuite.time_constructor [zug/virtualenv-py3.10]         |
| -        | 1.40±0.02ms                | 1.15±0.01ms                                    | 0.82    | version.TimeVersionSuite.time_constructor [zug/virtualenv-py3.11]         |
| -        | 1.80±0.03ms                | 1.38±0.06ms                                    | 0.76    | version.TimeVersionSuite.time_constructor [zug/virtualenv-py3.12]         |
| -        | 1.56±0.01ms                | 1.30±0.03ms                                    | 0.83    | version.TimeVersionSuite.time_constructor [zug/virtualenv-py3.13]         |
| -        | 1.33±0ms                   | 1.10±0.03ms                                    | 0.83    | version.TimeVersionSuite.time_constructor [zug/virtualenv-py3.14]         |
|          | 2.07±0.07ms                | 1.96±0.01ms                                    | 0.95    | version.TimeVersionSuite.time_constructor [zug/virtualenv-py3.8]          |
|          | 2.04±0.01ms                | 1.95±0.04ms                                    | 0.96    | version.TimeVersionSuite.time_constructor [zug/virtualenv-py3.9]          |
|          | 3.37±0.3ms                 | 2.95±0.03ms                                    | ~0.88   | version.TimeVersionSuite.time_hash [zug/virtualenv-py3.10]                |
| -        | 2.51±0.05ms                | 2.02±0.02ms                                    | 0.80    | version.TimeVersionSuite.time_hash [zug/virtualenv-py3.11]                |
| -        | 3.06±0.01ms                | 2.45±0.03ms                                    | 0.80    | version.TimeVersionSuite.time_hash [zug/virtualenv-py3.12]                |
| -        | 2.92±0.06ms                | 2.42±0.01ms                                    | 0.83    | version.TimeVersionSuite.time_hash [zug/virtualenv-py3.13]                |
| -        | 2.33±0.01ms                | 1.95±0.01ms                                    | 0.83    | version.TimeVersionSuite.time_hash [zug/virtualenv-py3.14]                |
|          | 3.43±0.05ms                | 3.33±0.09ms                                    | 0.97    | version.TimeVersionSuite.time_hash [zug/virtualenv-py3.8]                 |
|          | 3.49±0.05ms                | 3.29±0.09ms                                    | 0.94    | version.TimeVersionSuite.time_hash [zug/virtualenv-py3.9]                 |
|          | 2.21±0.3ms                 | 1.88±0.01ms                                    | ~0.85   | version.TimeVersionSuite.time_sort_cold [zug/virtualenv-py3.10]           |
| -        | 1.64±0.03ms                | 1.28±0.01ms                                    | 0.78    | version.TimeVersionSuite.time_sort_cold [zug/virtualenv-py3.11]           |
| -        | 1.99±0ms                   | 1.61±0.02ms                                    | 0.81    | version.TimeVersionSuite.time_sort_cold [zug/virtualenv-py3.12]           |
| -        | 2.05±0.01ms                | 1.71±0.02ms                                    | 0.84    | version.TimeVersionSuite.time_sort_cold [zug/virtualenv-py3.13]           |
| -        | 1.70±0ms                   | 1.38±0.01ms                                    | 0.81    | version.TimeVersionSuite.time_sort_cold [zug/virtualenv-py3.14]           |
|          | 2.57±0.05ms                | 2.43±0.04ms                                    | 0.94    | version.TimeVersionSuite.time_sort_cold [zug/virtualenv-py3.8]            |
|          | 2.54±0.02ms                | 2.50±0.03ms                                    | 0.99    | version.TimeVersionSuite.time_sort_cold [zug/virtualenv-py3.9]            |
| -        | 1.59±0.2ms                 | 1.35±0.02ms                                    | 0.85    | version.TimeVersionSuite.time_sort_warm [zug/virtualenv-py3.10]           |
| -        | 1.34±0.02ms                | 1.05±0.01ms                                    | 0.79    | version.TimeVersionSuite.time_sort_warm [zug/virtualenv-py3.11]           |
| -        | 1.63±0ms                   | 1.33±0.02ms                                    | 0.81    | version.TimeVersionSuite.time_sort_warm [zug/virtualenv-py3.12]           |
| -        | 1.69±0.03ms                | 1.38±0.02ms                                    | 0.82    | version.TimeVersionSuite.time_sort_warm [zug/virtualenv-py3.13]           |
| -        | 1.37±0ms                   | 1.13±0.01ms                                    | 0.82    | version.TimeVersionSuite.time_sort_warm [zug/virtualenv-py3.14]           |
|          | 2.03±0.01ms                | 1.91±0.04ms                                    | 0.94    | version.TimeVersionSuite.time_sort_warm [zug/virtualenv-py3.8]            |
|          | 2.00±0.02ms                | 1.93±0.01ms                                    | 0.96    | version.TimeVersionSuite.time_sort_warm [zug/virtualenv-py3.9]            |
| -        | 3.31±0.3ms                 | 2.76±0.02ms                                    | 0.83    | version.TimeVersionSuite.time_str [zug/virtualenv-py3.10]                 |
| -        | 2.47±0.04ms                | 1.96±0.01ms                                    | 0.79    | version.TimeVersionSuite.time_str [zug/virtualenv-py3.11]                 |
| -        | 2.83±0.04ms                | 2.27±0.02ms                                    | 0.80    | version.TimeVersionSuite.time_str [zug/virtualenv-py3.12]                 |
| -        | 2.60±0.02ms                | 2.09±0.01ms                                    | 0.80    | version.TimeVersionSuite.time_str [zug/virtualenv-py3.13]                 |
| -        | 2.15±0.02ms                | 1.79±0.02ms                                    | 0.83    | version.TimeVersionSuite.time_str [zug/virtualenv-py3.14]                 |
|          | 3.45±0.03ms                | 3.40±0.08ms                                    | 0.99    | version.TimeVersionSuite.time_str [zug/virtualenv-py3.8]                  |
|          | 3.50±0.02ms                | 3.32±0.03ms                                    | 0.95    | version.TimeVersionSuite.time_str [zug/virtualenv-py3.9]                  |
```

</details>
