### PR TITLE
ci: benchmark variance reduction

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -41,7 +41,7 @@ jobs:
           asv machine --yes
 
       - name: Run ASV continuous benchmark
-        run: asv continuous origin/main HEAD --sort default --no-only-changed | tee -a asv_output.txt || true
+        run: asv continuous origin/main HEAD --interleave-rounds --sort default --no-only-changed | tee -a asv_output.txt || true
 
       - name: Write out to GitHub Summary
         run: sed -n '/All benchmarks/,$p' asv_output.txt >> "$GITHUB_STEP_SUMMARY"

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -8,7 +8,12 @@
     "build_command": ["python -m pip wheel -w {build_cache_dir} {build_dir}"],
     "default_benchmark_timeout": 180,
     "regressions_thresholds": {
-        ".*": 0.01
+        ".*": 0.05
+    },
+    "matrix": {
+        "env_nobuild": {
+            "PYTHONHASHSEED": ["0"]
+        }
     },
     "pythons": ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 }

--- a/benchmarks/markers.py
+++ b/benchmarks/markers.py
@@ -10,6 +10,8 @@ DIR = Path(__file__).parent.resolve()
 
 
 class TimeMarkerSuite:
+    rounds = 4
+
     def setup(self) -> None:
         with (DIR / "dist_sample.txt").open() as f:
             self.marker_strs = [m.split(";")[1].strip() for m in f if ";" in m]

--- a/benchmarks/requirement.py
+++ b/benchmarks/requirement.py
@@ -10,6 +10,8 @@ DIR = Path(__file__).parent.resolve()
 
 
 class TimeRequirementSuite:
+    rounds = 4
+
     def setup(self) -> None:
         with (DIR / "dist_sample.txt").open() as f:
             self.req_strs = [r.strip() for r in f]

--- a/benchmarks/resolver.py
+++ b/benchmarks/resolver.py
@@ -7,6 +7,8 @@ from . import add_attributes
 
 
 class TimeResolverSuite:
+    rounds = 4
+
     def setup(self) -> None:
         self.valid_versions = [
             "1.0.0",

--- a/benchmarks/specifiers.py
+++ b/benchmarks/specifiers.py
@@ -11,6 +11,8 @@ DIR = Path(__file__).parent.resolve()
 
 
 class TimeSpecSuite:
+    rounds = 4
+
     def setup(self) -> None:
         with (DIR / "specs_sample.txt").open() as f:
             self.spec_strs = [s.strip() for s in f.readlines()]

--- a/benchmarks/utils.py
+++ b/benchmarks/utils.py
@@ -25,6 +25,8 @@ NAMES = [
 
 
 class TimeUtils:
+    rounds = 4
+
     @add_attributes(pretty_name="canonicalize_name")
     def time_canonicalize_name(self) -> None:
         for v in NAMES:

--- a/benchmarks/version.py
+++ b/benchmarks/version.py
@@ -17,6 +17,8 @@ def valid_version(v: str) -> Version | None:
 
 
 class TimeVersionSuite:
+    rounds = 4
+
     def setup(self) -> None:
         with (DIR / "version_sample.txt").open() as f:
             self.versions = [v.strip() for v in f.readlines()]


### PR DESCRIPTION
This PR does 4 things to reduce benchmark variance:

### 1. PYTHONHASHSEED=0

Set `PYTHONHASHSEED=0` via `env_nobuild` in `asv.conf.json` to eliminate `frozenset` iteration order variance across process spawns.

This happens because `self._specs` in a `SpecifierSet` is a frozenset and iterating over it can have very different performance characteristics per run, we may be able to tackle this and improve performance in a separate PR, but either way we don't want hash seed differences causing benchmark differences anywhere.

> Variables in 'no_build' will be passed to every environment during the test phase, but will not trigger a new build.
>
> [asv.conf.json reference](https://asv.readthedocs.io/en/latest/asv.conf.json.html)

### 2. Interleave rounds

Added `--interleave-rounds` to `asv continuous` in CI to avoid commit-ordering bias.

> Interleave benchmarks with multiple rounds across commits. This can avoid measurement biases from commit ordering, can take longer.
>
> [`asv continuous` reference](https://asv.readthedocs.io/en/latest/commands.html)

### 3. More rounds and repeats

Set `rounds=4` on all benchmark classes to sample across longer time periods, I found that the default 2 rounds is simply not enough for untuned machines.

> **rounds**: How many rounds to run the benchmark in (default: 2). The rounds run different timing benchmarks in an interleaved order, allowing to sample over longer periods of background performance variations (e.g. CPU power levels).
>
> [Benchmark attributes reference](https://asv.readthedocs.io/en/latest/benchmarks.html)

### 4. Regression threshold

Reset `regressions_thresholds` from `0.01` (1%) to the default `0.05` (5%). Noise on micro-benchmarks easily exceeds 1%, we should only consider performance wins or gains on micro-benchmarks of >5%, we could set tighter or looser results for specific benchmarks if we wanted.

> If no entry matches, the default threshold is `0.05` (iow. 5%).
>
> [asv.conf.json reference](https://asv.readthedocs.io/en/latest/asv.conf.json.html)
