### PR TITLE
perf: SpecifierSet use tuple instead of frozenset for `_specs`

### DIFF
--- a/benchmarks/specifiers.py
+++ b/benchmarks/specifiers.py
@@ -37,6 +37,12 @@ class TimeSpecSuite:
         for sp in self._single_warm_spec._specs:
             sp.contains(self.single_version)
 
+    def _make_cold(self, spec: SpecifierSet) -> None:
+        if hasattr(spec, "_sorted"):
+            spec._sorted = False
+        for sp in spec._specs:
+            sp._spec_version = None
+
     @add_attributes(pretty_name="SpecifierSet constructor")
     def time_constructor(self) -> None:
         for s in self.spec_strs:
@@ -45,9 +51,7 @@ class TimeSpecSuite:
     @add_attributes(pretty_name="SpecifierSet contains (cold)")
     def time_contains_cold(self) -> None:
         for spec in self._cold_specs:
-            for sp in spec._specs:
-                sp._spec_version = None
-
+            self._make_cold(spec)
         for spec in self._cold_specs:
             spec.contains(self.single_version)
 
@@ -58,8 +62,7 @@ class TimeSpecSuite:
 
     @add_attributes(pretty_name="SpecifierSet filter (simple, cold)")
     def time_filter_simple_cold(self) -> None:
-        for sp in self._single_cold_spec._specs:
-            sp._spec_version = None
+        self._make_cold(self._single_cold_spec)
         list(self._single_cold_spec.filter(self.sample_versions))
 
     @add_attributes(pretty_name="SpecifierSet filter (simple, warm)")

--- a/src/packaging/specifiers.py
+++ b/src/packaging/specifiers.py
@@ -851,7 +851,7 @@ class SpecifierSet(BaseSpecifier):
     specifiers (``>=3.0,!=3.1``), or no specifier at all.
     """
 
-    __slots__ = ("_prereleases", "_specs")
+    __slots__ = ("_prereleases", "_sorted", "_specs")
 
     def __init__(
         self,
@@ -880,16 +880,25 @@ class SpecifierSet(BaseSpecifier):
             # strip each item to remove leading/trailing whitespace.
             split_specifiers = [s.strip() for s in specifiers.split(",") if s.strip()]
 
-            # Make each individual specifier a Specifier and save in a frozen set
-            # for later.
-            self._specs = frozenset(map(Specifier, split_specifiers))
+            # Deduplicate strings first.
+            self._specs: tuple[Specifier, ...] = tuple(
+                map(Specifier, dict.fromkeys(split_specifiers))
+            )
         else:
-            # Save the supplied specifiers in a frozen set.
-            self._specs = frozenset(specifiers)
+            self._specs = tuple(dict.fromkeys(specifiers))
+
+        self._sorted = len(self._specs) <= 1
 
         # Store our prereleases value so we can use it later to determine if
         # we accept prereleases or not.
         self._prereleases = prereleases
+
+    def _sort_specs(self) -> tuple[Specifier, ...]:
+        """Sort and cache the specs tuple for order-sensitive operations."""
+        if not self._sorted:
+            self._specs = tuple(sorted(self._specs, key=str))
+            self._sorted = True
+        return self._specs
 
     @property
     def prereleases(self) -> bool | None:
@@ -947,10 +956,10 @@ class SpecifierSet(BaseSpecifier):
         >>> str(SpecifierSet(">=1.0.0,!=1.0.1", prereleases=False))
         '!=1.0.1,>=1.0.0'
         """
-        return ",".join(sorted(str(s) for s in self._specs))
+        return ",".join(str(s) for s in self._sort_specs())
 
     def __hash__(self) -> int:
-        return hash(self._specs)
+        return hash(self._sort_specs())
 
     def __and__(self, other: SpecifierSet | str) -> SpecifierSet:
         """Return a SpecifierSet which is a combination of the two sets.
@@ -968,7 +977,8 @@ class SpecifierSet(BaseSpecifier):
             return NotImplemented
 
         specifier = SpecifierSet()
-        specifier._specs = frozenset(self._specs | other._specs)
+        specifier._specs = tuple(dict.fromkeys(self._specs + other._specs))
+        specifier._sorted = len(specifier._specs) <= 1
 
         # Combine prerelease settings: use common or non-None value
         if self._prereleases is None or self._prereleases == other._prereleases:
@@ -1006,7 +1016,10 @@ class SpecifierSet(BaseSpecifier):
         elif not isinstance(other, SpecifierSet):
             return NotImplemented
 
-        return self._specs == other._specs
+        if len(self._specs) != len(other._specs):
+            return False
+
+        return self._sort_specs() == other._sort_specs()
 
     def __len__(self) -> int:
         """Returns the number of specifiers in this specifier set."""


### PR DESCRIPTION
Change `SpecifierSet._specs` from `frozenset` to `tuple` as it is only ever iterated, never looked up, so tuple is a better fit, more performant, and doesn't cause hash seed based ordering. Strings are deduplicated before constructing `Specifier` objects to reduce the number of `Specifiers` constructed and hashing strings is much faster than hashing `Specifier`s.

Since tuples are order-sensitive unlike frozensets, `__hash__`, `__eq__`, and `__str__` now lazily sort and cache `_specs` to ensure a canonical order.