### PR TITLE
Fix RHS marker-variable version comparisons

### DIFF
--- a/src/packaging/markers.py
+++ b/src/packaging/markers.py
@@ -230,6 +230,21 @@ def _eval_op(lhs: str, op: Op, rhs: str | AbstractSet[str], *, key: str) -> bool
     return oper(lhs, rhs)
 
 
+def _swap_op(op: Op) -> Op:
+    swapped = {
+        "<": ">",
+        "<=": ">=",
+        ">": "<",
+        ">=": "<=",
+        "==": "==",
+        "!=": "!=",
+        "~=": "~=",
+    }.get(op.serialize())
+    if swapped is None:
+        return op
+    return Op(swapped)
+
+
 def _normalize(
     lhs: str, rhs: str | AbstractSet[str], key: str
 ) -> tuple[str, str | AbstractSet[str]]:
@@ -270,6 +285,13 @@ def _evaluate_markers(
                 lhs_value = lhs.value
                 environment_key = rhs.value
                 rhs_value = environment[environment_key]
+
+                if (
+                    environment_key in MARKERS_REQUIRING_VERSION
+                    and op.serialize() in {"<", "<=", "==", "!=", ">=", ">", "~="}
+                ):
+                    lhs_value, rhs_value = rhs_value, lhs_value
+                    op = _swap_op(op)
 
             assert isinstance(lhs_value, str), "lhs must be a string"
             lhs_value, rhs_value = _normalize(lhs_value, rhs_value, key=environment_key)

--- a/src/packaging/markers.py
+++ b/src/packaging/markers.py
@@ -286,10 +286,15 @@ def _evaluate_markers(
                 environment_key = rhs.value
                 rhs_value = environment[environment_key]
 
-                if (
-                    environment_key in MARKERS_REQUIRING_VERSION
-                    and op.serialize() in {"<", "<=", "==", "!=", ">=", ">", "~="}
-                ):
+                if environment_key in MARKERS_REQUIRING_VERSION and op.serialize() in {
+                    "<",
+                    "<=",
+                    "==",
+                    "!=",
+                    ">=",
+                    ">",
+                    "~=",
+                }:
                     lhs_value, rhs_value = rhs_value, lhs_value
                     op = _swap_op(op)
 

--- a/tests/test_markers.py
+++ b/tests/test_markers.py
@@ -17,7 +17,9 @@ from packaging._parser import Node
 from packaging.markers import (
     InvalidMarker,
     Marker,
+    Op,
     UndefinedComparison,
+    _swap_op,
     default_environment,
     format_full_version,
 )
@@ -113,6 +115,11 @@ class TestOperatorEvaluation:
         assert Marker('python_full_version > "3.6.2"').evaluate(
             {"python_full_version": "3.11.0a5"}
         )
+
+
+def test_swap_op_unknown_operator_passthrough() -> None:
+    op = Op("===")
+    assert _swap_op(op) is op
 
 
 class FakeVersionInfo(NamedTuple):

--- a/tests/test_markers.py
+++ b/tests/test_markers.py
@@ -86,6 +86,12 @@ class TestOperatorEvaluation:
             dict(python_full_version="2.7.8")
         )
 
+    def test_rhs_version_variable_uses_equivalent_pep440_comparison(self) -> None:
+        env = {"python_full_version": "3.13.7"}
+
+        assert Marker('python_full_version == "3.13.*"').evaluate(env)
+        assert Marker('"3.13.*" == python_full_version').evaluate(env)
+
     def test_new_string_rules(self) -> None:
         assert not Marker('"b" < python_full_version').evaluate(
             dict(python_full_version="c")

--- a/tests/test_markers.py
+++ b/tests/test_markers.py
@@ -13,11 +13,10 @@ from unittest import mock
 
 import pytest
 
-from packaging._parser import Node
+from packaging._parser import Node, Op
 from packaging.markers import (
     InvalidMarker,
     Marker,
-    Op,
     UndefinedComparison,
     _swap_op,
     default_environment,


### PR DESCRIPTION
## Summary
- fix marker evaluation when a version marker variable appears on the right-hand side (for example, `'3.13.*' == python_full_version`)
- for version-comparison operators, normalize that form by swapping operands and the corresponding operator, so it evaluates equivalently to the canonical `python_full_version == '3.13.*'`
- add regression coverage to confirm wildcard equality works in both operand orders

## Testing
- `uv run pytest tests/test_markers.py`

## Related
- Fixes #934