### PR TITLE
fix: charset error message formatting

### DIFF
--- a/src/packaging/metadata.py
+++ b/src/packaging/metadata.py
@@ -632,7 +632,7 @@ class _Validator(Generic[T]):
         charset = parameters.get("charset", "UTF-8")
         if charset != "UTF-8":
             raise self._invalid_metadata(
-                f"{{field}} can only specify the UTF-8 charset, not {list(charset)}"
+                f"{{field}} can only specify the UTF-8 charset, not {charset!r}"
             )
 
         markdown_variants = {"GFM", "CommonMark"}

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -539,6 +539,15 @@ class TestMetadata:
         with pytest.raises(metadata.InvalidMetadata):
             meta.description_content_type  # noqa: B018
 
+    def test_invalid_charset_error_message(self) -> None:
+        meta = metadata.Metadata.from_raw(
+            {"description_content_type": "text/plain; charset=iso-8859-1"},
+            validate=False,
+        )
+
+        with pytest.raises(metadata.InvalidMetadata, match="iso-8859-1"):
+            meta.description_content_type  # noqa: B018
+
     def test_keywords(self) -> None:
         keywords = ["hello", "world"]
         meta = metadata.Metadata.from_raw({"keywords": keywords}, validate=False)


### PR DESCRIPTION
charset is a string, so calling list on it produces `["i", "s", "o", "-", "8", ...]`