### PR TITLE
docs: backfill API version directives

### DIFF
--- a/docs/licenses.rst
+++ b/docs/licenses.rst
@@ -8,6 +8,8 @@ Helper for canonicalizing SPDX
 `License-Expression metadata <https://peps.python.org/pep-0639/#term-license-expression>`__
 as `defined in PEP 639 <https://peps.python.org/pep-0639/#spdx>`__.
 
+.. versionadded:: 24.2
+
 
 Reference
 ---------

--- a/docs/metadata.rst
+++ b/docs/metadata.rst
@@ -42,13 +42,19 @@ High Level Interface
 .. autoclass:: packaging.metadata.Metadata
     :members:
 
+    .. versionadded:: 23.2
+
 Low Level Interface
 '''''''''''''''''''
 
 .. autoclass:: packaging.metadata.RawMetadata
     :members:
 
+    .. versionadded:: 23.1
+
 .. autofunction:: packaging.metadata.parse_email
+
+    .. versionadded:: 23.1
 
 
 Exceptions
@@ -57,8 +63,12 @@ Exceptions
 .. autoclass:: packaging.metadata.InvalidMetadata
     :members:
 
+    .. versionadded:: 23.2
+
 .. autoclass:: packaging.metadata.ExceptionGroup
     :members:
+
+    .. versionadded:: 23.2
 
 
 .. _source distributions: https://packaging.python.org/en/latest/specifications/source-distribution-format/

--- a/docs/pylock.rst
+++ b/docs/pylock.rst
@@ -5,6 +5,8 @@ Lock Files
 
 Parse and validate `pylock.toml files <https://packaging.python.org/en/latest/specifications/pylock-toml/>`_.
 
+.. versionadded:: 25.0
+
 Usage
 -----
 

--- a/docs/tags.rst
+++ b/docs/tags.rst
@@ -157,6 +157,8 @@ to the implementation to provide.
 
     Yields the :attr:`~Tag.platform` tags for iOS.
 
+    .. versionadded:: 24.1
+
     :param tuple version: A two-item tuple representing the version of iOS.
                           Defaults to the current system's version.
     :param str multiarch: The CPU architecture+ABI to be used. This should be in
@@ -173,6 +175,8 @@ to the implementation to provide.
 
     Yields the :attr:`~Tag.platform` tags for Android. If this function is invoked on
     non-Android platforms, the ``api_level`` and ``abi`` arguments are required.
+
+    .. versionadded:: 24.2
 
     :param int api_level: The maximum `API level
         <https://developer.android.com/tools/releases/platforms>`__ to return. Defaults


### PR DESCRIPTION
## Summary
- backfill missing version directives in the metadata API reference
- document when the iOS and Android tag helpers were added
- mark the licenses and pylock API reference pages with their introduction versions

## Validation
- d:/project_contribution/.venv/Scripts/python.exe -m nox -s tests-3.11 docs
- d:/project_contribution/.venv/Scripts/python.exe -m nox -s lint *(hits an existing all-files mypy failure in src/packaging/_manylinux.py under the current toolchain)*
- .nox/lint/Scripts/prek.exe run --files docs/metadata.rst docs/tags.rst docs/licenses.rst docs/pylock.rst

Refs #597