### PR TITLE
fix: support lazy imports in Python 3.15+

### DIFF
--- a/src/packaging/_elffile.py
+++ b/src/packaging/_elffile.py
@@ -9,6 +9,8 @@ ELF header: https://refspecs.linuxfoundation.org/elf/gabi4+/ch4.eheader.html
 
 from __future__ import annotations
 
+__lazy_modules__ = ["os", "struct", "typing"]
+
 import enum
 import os
 import struct

--- a/src/packaging/_manylinux.py
+++ b/src/packaging/_manylinux.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+__lazy_modules__ = [f"{__spec__.parent}._elffile", "os", "re", "sys", "warnings"]
+
 import collections
 import contextlib
 import functools

--- a/src/packaging/_musllinux.py
+++ b/src/packaging/_musllinux.py
@@ -6,6 +6,8 @@ linked against musl, and what musl version is used.
 
 from __future__ import annotations
 
+__lazy_modules__ = [f"{__spec__.parent}._elffile", "subprocess"]
+
 import functools
 import re
 import subprocess

--- a/src/packaging/_parser.py
+++ b/src/packaging/_parser.py
@@ -6,6 +6,8 @@ the implementation.
 
 from __future__ import annotations
 
+__lazy_modules__ = ["ast", f"{__spec__.parent}._tokenizer"]
+
 import ast
 from typing import List, Literal, NamedTuple, Sequence, Tuple, Union
 

--- a/src/packaging/_tokenizer.py
+++ b/src/packaging/_tokenizer.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+__lazy_modules__ = ["contextlib", "typing"]
+
 import contextlib
 import re
 from dataclasses import dataclass

--- a/src/packaging/dependency_groups.py
+++ b/src/packaging/dependency_groups.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+__lazy_modules__ = [
+    "collections",
+    "collections.abc",
+    f"{__spec__.parent}.errors",
+    f"{__spec__.parent}.requirements",
+]
+
 import re
 from collections.abc import Mapping, Sequence
 

--- a/src/packaging/direct_url.py
+++ b/src/packaging/direct_url.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+__lazy_modules__ = ["collections", "collections.abc", "urllib", "urllib.parse"]
+
 import dataclasses
 import re
 import urllib.parse

--- a/src/packaging/errors.py
+++ b/src/packaging/errors.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+__lazy_modules__ = ["builtins", "contextlib", "typing"]
+
 import contextlib
 import dataclasses
 import sys

--- a/src/packaging/licenses/__init__.py
+++ b/src/packaging/licenses/__init__.py
@@ -31,6 +31,8 @@
 #######################################################################################
 from __future__ import annotations
 
+__lazy_modules__ = [f"{__spec__.parent}._spdx"]
+
 import re
 from typing import NewType, cast
 

--- a/src/packaging/markers.py
+++ b/src/packaging/markers.py
@@ -4,6 +4,16 @@
 
 from __future__ import annotations
 
+__lazy_modules__ = [
+    f"{__spec__.parent}._parser",
+    f"{__spec__.parent}._tokenizer",
+    f"{__spec__.parent}.specifiers",
+    f"{__spec__.parent}.utils",
+    "os",
+    "platform",
+    "sys",
+]
+
 import operator
 import os
 import platform

--- a/src/packaging/metadata.py
+++ b/src/packaging/metadata.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+__lazy_modules__ = [f"{__spec__.parent}.errors", "keyword", "pathlib"]
+
 import email.header
 import email.message
 import email.parser

--- a/src/packaging/pylock.py
+++ b/src/packaging/pylock.py
@@ -1,5 +1,17 @@
 from __future__ import annotations
 
+__lazy_modules__ = [
+    "collections",
+    "collections.abc",
+    "datetime",
+    f"{__spec__.parent}.markers",
+    f"{__spec__.parent}.specifiers",
+    f"{__spec__.parent}.utils",
+    f"{__spec__.parent}.version",
+    "urllib",
+    "urllib.parse",
+]
+
 import dataclasses
 import logging
 import re

--- a/src/packaging/requirements.py
+++ b/src/packaging/requirements.py
@@ -3,6 +3,15 @@
 # for complete details.
 from __future__ import annotations
 
+__lazy_modules__ = [
+    f"{__spec__.parent}._parser",
+    f"{__spec__.parent}._tokenizer",
+    f"{__spec__.parent}.markers",
+    f"{__spec__.parent}.specifiers",
+    f"{__spec__.parent}.utils",
+    "typing",
+]
+
 from typing import Iterator
 
 from ._parser import parse_requirement as _parse_requirement

--- a/src/packaging/specifiers.py
+++ b/src/packaging/specifiers.py
@@ -10,6 +10,8 @@
 
 from __future__ import annotations
 
+__lazy_modules__ = [f"{__spec__.parent}.utils", "itertools"]
+
 import abc
 import itertools
 import re

--- a/src/packaging/tags.py
+++ b/src/packaging/tags.py
@@ -4,6 +4,16 @@
 
 from __future__ import annotations
 
+__lazy_modules__ = [
+    "importlib",
+    "importlib.machinery",
+    "platform",
+    "re",
+    "subprocess",
+    "sys",
+    "sysconfig",
+]
+
 import logging
 import platform
 import re

--- a/src/packaging/utils.py
+++ b/src/packaging/utils.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+__lazy_modules__ = [f"{__spec__.parent}.tags", f"{__spec__.parent}.version"]
+
 import re
 from typing import NewType, Tuple, Union, cast
 

--- a/src/packaging/version.py
+++ b/src/packaging/version.py
@@ -9,6 +9,8 @@
 
 from __future__ import annotations
 
+__lazy_modules__ = ["functools", "warnings"]
+
 import re
 import sys
 import typing


### PR DESCRIPTION
This is the output of `uvx flake8-lazy --apply src/**.py`. See post: https://iscinumpy.dev/post/flake8-lazy

Opening this as draft for awareness and to get eyes on the changes; it's
possible I've forgotten some or added too many. Probably should wait to put
this in until 3.15b1. It's easy to rerun if there are conflicts in the future.

I don't really know how to test this, other than running a python process and checking to see what's in `sys.modules` (which I did locally), or checking `-Ximporttime`, etc. We don't have a CLI [(yet?)](#795)) to check import times on.