### PR TITLE
Fix versionadded for Version.from_parts()

### DIFF
--- a/src/packaging/version.py
+++ b/src/packaging/version.py
@@ -461,7 +461,7 @@ class Version(_BaseVersion):
         :param epoch:
         :param release: This version tuple is required
 
-        .. versionadded:: 26.0
+        .. versionadded:: 26.1
         """
         _epoch = _validate_epoch(epoch)
         _release = _validate_release(release)


### PR DESCRIPTION
Literally a single character fix :smile: 
Not much to explain - packaging 26.0 didn't add `from_parts()` method - it was added later:
https://github.com/pypa/packaging/commits/main/?after=ee13ba2c1c9a01c97a08ca9d98ff9fa6f0a0a67b+0

It hasn't been released yet, but I assume that the next version will be 26.1, so I used that as the corrected version number. It's consistent with the `versionadded` for e.g. `normalize_pre()`.