### PR TITLE
tests: cover <V.postN pre-release exclusion

### DIFF
--- a/tests/test_specifiers.py
+++ b/tests/test_specifiers.py
@@ -1949,6 +1949,22 @@ class TestSpecifierSet:
             (">=1!0,!=1!1.*,!=1!2.*,<1!3", True, "0!5.0", False),
             (">=1!0,!=1!1.*,!=1!2.*,<1!3", False, "1!0.5", True),
             (">=1!0,!=1!1.*,!=1!2.*,<1!3", False, "0!5.0", False),
+            # <V.postN excludes pre-releases of base but accepts the
+            # final release and prior post-releases.
+            ("==1.0.dev0,<1.0.post1", None, "1.0.dev0", False),
+            ("==1.0a1,<1.0.post0", None, "1.0a1", False),
+            ("==1.0.post0.dev0,<1.0.post1", None, "1.0.post0.dev0", False),
+            (">=1.0,<1.0.post1", None, "1.0", True),
+            (">=1.0,<1.0.post1", None, "1.0.post0", True),
+            (">=1.0,<1.0.post1", None, "1.0.dev0", False),
+            (">=1.0,<1.0.post1", True, "1.0.dev0", False),
+            # != removes survivors, leaving only excluded pre-releases
+            (">=1.0.dev0,<1.0.post1,!=1.0,!=1.0.post0", True, "1.0", False),
+            (">=1.0.dev0,<1.0.post1,!=1.0,!=1.0.post0", True, "1.0.dev0", False),
+            (">=1.0.dev0,<1.0.post1,!=1.0,!=1.0.post0", True, "1.0.post0.dev0", False),
+            # But if one survivor remains, it matches
+            (">=1.0.dev0,<1.0.post2,!=1.0,!=1.0.post0", True, "1.0.post1", True),
+            (">=1.0.dev0,<1.0.post2,!=1.0", True, "1.0.post0", True),
         ],
     )
     def test_contains_exclusionary_bridges(


### PR DESCRIPTION
Discovered while looking for edge cases for #1119.

`<V.postN` excludes pre-releases of the base release the same way `<V` does for final releases, but there were no tests covering this. Added cases for dev, alpha, rc, and post-dev candidates against `<1.0.post0` and `<1.0.post1`, plus the non-pre-release versions they should still accept.