### PR TITLE
Narrow <V.postN pre-release exclusion to match spec

### DIFF
--- a/src/packaging/specifiers.py
+++ b/src/packaging/specifiers.py
@@ -63,6 +63,14 @@ def _base_version(version: Version) -> Version:
     return version.__replace__(pre=None, post=None, dev=None, local=None)
 
 
+def _earliest_prerelease(version: Version) -> Version:
+    """Earliest pre-release of *version*.
+
+    1.2 -> 1.2.dev0, 1.2.post1 -> 1.2.post1.dev0.
+    """
+    return version.__replace__(dev=0, local=None)
+
+
 class InvalidSpecifier(ValueError):
     """
     Raised when attempting to create a :class:`Specifier` with a specifier
@@ -561,14 +569,12 @@ class Specifier(BaseSpecifier):
         if not prospective < spec:
             return False
 
-        # This special case is here so that, unless the specifier itself
-        # includes is a pre-release version, that we do not accept pre-release
-        # versions for the version mentioned in the specifier (e.g. <3.1 should
-        # not match 3.1.dev0, but should match 3.0.dev0).
+        # The spec says: "<V MUST NOT allow a pre-release of the specified
+        # version unless the specified version is itself a pre-release."
         if (
             not spec.is_prerelease
             and prospective.is_prerelease
-            and _base_version(prospective) == _base_version(spec)
+            and prospective >= _earliest_prerelease(spec)
         ):
             return False
 

--- a/tests/test_specifiers.py
+++ b/tests/test_specifiers.py
@@ -780,6 +780,35 @@ class TestSpecifier:
             ("<=2.0.dev1", "1.0a1", None, None, True),
             ("<2.0", "2.0a1", None, None, False),
             ("<2.0a2", "2.0a1", None, None, True),
+            # <V.postN: pre-releases of V.postN itself are excluded
+            ("<1.0.post1", "1.0.post1.dev0", None, None, False),
+            ("<1.0.post0", "1.0.post0.dev0", None, None, False),
+            # <V.postN: pre-releases of the base release are NOT
+            # pre-releases of V.postN, so they are accepted
+            ("<1.0.post1", "1.0.dev0", None, None, True),
+            ("<1.0.post1", "1.0a1", None, None, True),
+            ("<1.0.post1", "1.0rc1", None, None, True),
+            ("<1.0.post0", "1.0.dev0", None, None, True),
+            ("<1.0.post0", "1.0a1", None, None, True),
+            ("<1.0.post0", "1.0b1", None, None, True),
+            ("<1.0.post0", "1.0rc2", None, None, True),
+            # <V.postN: dev of a different post is not a pre-release
+            # of V.postN either
+            ("<1.0.post1", "1.0.post0.dev0", None, None, True),
+            ("<1.0.post2", "1.0.post1.dev0", None, None, True),
+            # <V.postN: non-pre-release versions below V.postN
+            ("<1.0.post1", "1.0", None, None, True),
+            ("<1.0.post1", "1.0.post0", None, None, True),
+            ("<1.0.post1", "0.9", None, None, True),
+            ("<1.0.post0", "1.0", None, None, True),
+            # <V.postN: higher post numbers
+            ("<1.0.post10", "1.0.dev0", None, None, True),
+            ("<1.0.post10", "1.0.post9.dev0", None, None, True),
+            ("<1.0.post10", "1.0.post9", None, None, True),
+            # <V.postN: locals and different bases
+            ("<1.0.post1", "1.0+local", None, None, True),
+            ("<1.0.post1", "1.0.post0+local", None, None, True),
+            ("<1.0.post1", "0.9.dev0", None, None, True),
             ("<=2.0", "1.0.dev1", False, None, False),
             ("<=2.0a1", "1.0.dev1", False, None, False),
             ("<=2.0", "1.0.dev1", None, False, False),
@@ -1933,6 +1962,26 @@ class TestSpecifierSet:
             (">=1!0,!=1!1.*,!=1!2.*,<1!3", True, "0!5.0", False),
             (">=1!0,!=1!1.*,!=1!2.*,<1!3", False, "1!0.5", True),
             (">=1!0,!=1!1.*,!=1!2.*,<1!3", False, "0!5.0", False),
+            # <V.postN combined with other specifiers: pre-releases of
+            # the base release are accepted (they are not pre-releases
+            # of V.postN).
+            ("==1.0.dev0,<1.0.post1", None, "1.0.dev0", True),
+            ("==1.0a1,<1.0.post0", None, "1.0a1", True),
+            ("==1.0.post0.dev0,<1.0.post1", None, "1.0.post0.dev0", True),
+            (">=1.0,<1.0.post1", None, "1.0", True),
+            (">=1.0,<1.0.post1", None, "1.0.post0", True),
+            # 1.0.dev0 < 1.0, so it fails >=1.0 regardless of <
+            (">=1.0,<1.0.post1", True, "1.0.dev0", False),
+            # With a lower bound that includes pre-releases
+            (">=1.0.dev0,<1.0.post1", True, "1.0.dev0", True),
+            (">=1.0.dev0,<1.0.post1", True, "1.0.a1", True),
+            (">=1.0.dev0,<1.0.post1", True, "1.0.post0.dev0", True),
+            # != can remove non-pre-releases but pre-releases still match
+            (">=1.0.dev0,<1.0.post1,!=1.0,!=1.0.post0", True, "1.0.dev0", True),
+            (">=1.0.dev0,<1.0.post1,!=1.0,!=1.0.post0", True, "1.0.post0.dev0", True),
+            # Post-release survivors still match
+            (">=1.0.dev0,<1.0.post2,!=1.0,!=1.0.post0", True, "1.0.post1", True),
+            (">=1.0.dev0,<1.0.post2,!=1.0", True, "1.0.post0", True),
         ],
     )
     def test_contains_exclusionary_bridges(


### PR DESCRIPTION
Discovered while looking for edge cases for #1119.

The spec says:

> The exclusive ordered comparison `<V` MUST NOT allow a pre-release of the specified version unless the specified version is itself a pre-release.

For `<1.0.post1` the specified version is `1.0.post1`, so only `1.0.post1.devN` should be excluded. The current code uses `_base_version` which also excludes `1.0.dev0`, `1.0a1`, etc. For example `Specifier("<1.0.post1").contains(Version("1.0.dev0"))` returns `False` but should return `True`.

The fix replaces the `_base_version` check with a comparison against `_earliest_prerelease(spec)` (i.e. `spec.__replace__(dev=0)`). For `<2.0` this changes nothing. For `<1.0.post1` it stops excluding pre-releases of `1.0`.

I don't love this change. The current behavior feels intuitive, but the spec as written means `<2.0` excludes `2.0b1` while `<2.0.post1` does not. The current behavior also creates problems for interval-based specifier representations (#1119, #1120), where `<V.postN` requires N+2 intervals to model the `_base_version` exclusion correctly.

Subsumes #1139.