### PR TITLE
Remove unnecessary `from __future__ import annotations`

### DIFF
--- a/src/packaging/version.py
+++ b/src/packaging/version.py
@@ -7,8 +7,6 @@
     from packaging.version import parse, normalize_pre, Version, _cmpkey
 """
 
-from __future__ import annotations
-
 import re
 import sys
 import typing


### PR DESCRIPTION
Should not be necessary from Python 3.7 and up:
https://docs.python.org/3/library/__future__.html#module-contents