### PR TITLE
Propagate int-max-str-digits ValueError

### DIFF
--- a/src/packaging/version.py
+++ b/src/packaging/version.py
@@ -405,7 +405,12 @@ class Version(_BaseVersion):
             try:
                 self._release = tuple(map(int, version.split(".")))
             except ValueError:
-                raise InvalidVersion(f"Invalid version: {version!r}") from None
+                # Empty parts (from "1..2", ".1", etc.) are invalid versions.
+                # Any other ValueError (e.g. int str-digits limit) should
+                # propagate to the caller.
+                if "" in version.split("."):
+                    raise InvalidVersion(f"Invalid version: {version!r}") from None
+                raise  # something else is wrong (e.g. oversized int)
 
             self._epoch = 0
             self._pre = None

--- a/src/packaging/version.py
+++ b/src/packaging/version.py
@@ -410,7 +410,8 @@ class Version(_BaseVersion):
                 # propagate to the caller.
                 if "" in version.split("."):
                     raise InvalidVersion(f"Invalid version: {version!r}") from None
-                raise  # something else is wrong (e.g. oversized int)
+                # TODO: remove "no cover" when Python 3.9 is dropped.
+                raise  # pragma: no cover
 
             self._epoch = 0
             self._pre = None

--- a/tests/test_specifiers.py
+++ b/tests/test_specifiers.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import itertools
 import operator
 import re
+import sys
 import typing
 
 import pytest
@@ -2064,6 +2065,27 @@ class TestSpecifierSet:
     ) -> None:
         spec = SpecifierSet(specifier, prereleases=True)
         assert not spec.contains(input)
+
+    @pytest.mark.skipif(
+        not hasattr(sys, "get_int_max_str_digits"),
+        reason="requires int max str digits limit",
+    )
+    @pytest.mark.parametrize(
+        "specifier",
+        [
+            ">=" + "1" * 5000,
+            ">=1.0a" + "1" * 5000,
+        ],
+    )
+    def test_contains_oversized_version_raises_valueerror(self, specifier: str) -> None:
+        old = sys.get_int_max_str_digits()
+        sys.set_int_max_str_digits(4300)
+        try:
+            spec = SpecifierSet(specifier)
+            with pytest.raises(ValueError, match="Exceeds the limit"):
+                spec.contains("1.0")
+        finally:
+            sys.set_int_max_str_digits(old)
 
     @pytest.mark.parametrize(
         ("version", "specifier", "expected"),

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -213,6 +213,28 @@ class TestVersion:
         with pytest.raises(InvalidVersion):
             Version(version)
 
+    @pytest.mark.skipif(
+        not hasattr(sys, "get_int_max_str_digits"),
+        reason="requires int max str digits limit",
+    )
+    @pytest.mark.parametrize(
+        "version",
+        [
+            # Simple path (digits only)
+            "1" * 5000,
+            # Regex path (has pre-release)
+            "1.0a" + "1" * 5000,
+        ],
+    )
+    def test_oversized_version_raises_valueerror(self, version: str) -> None:
+        old = sys.get_int_max_str_digits()
+        sys.set_int_max_str_digits(4300)
+        try:
+            with pytest.raises(ValueError, match="Exceeds the limit"):
+                Version(version)
+        finally:
+            sys.set_int_max_str_digits(old)
+
     @pytest.mark.parametrize(
         ("version", "normalized"),
         [


### PR DESCRIPTION
Fixes #1154

Let the CPython int-max-str-digits `ValueError` propagate from `Version()` instead of converting it to `InvalidVersion`.