### PR TITLE
docs: add errors section and fix missing details

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,10 +23,14 @@ The `documentation`_ provides information and the API for the following:
 - Version Handling
 - Specifiers
 - Markers
+- Licenses
 - Requirements
-- Tags
 - Metadata
-- Lockfiles
+- Tags
+- Lockfiles (pylock)
+- Direct URL helpers
+- Dependency groups
+- Errors
 - Utilities
 
 Installation

--- a/docs/errors.rst
+++ b/docs/errors.rst
@@ -1,0 +1,51 @@
+Errors
+======
+
+Error classes and error-handling helpers used by the packaging library.
+
+Currently this contains :class:`~packaging.errors.ExceptionGroup`, a simple
+backport of the stdlib :class:`ExceptionGroup`. It is recommended to use
+the stdlib module on Python 3.11+, but this does reexport that as well.
+
+Recommended Usage
+-----------------
+
+
+.. code-block:: python
+
+   if sys.version_info < (3, 11):
+       from packaging.errors import ExceptionGroup
+
+   try:
+       ...
+   except ExceptionGroup as err:
+       for error in err.exceptions:
+           ...
+
+
+Reference
+---------
+
+.. This has to be listed here so building it on newer Python keeps the docs
+
+.. py:class:: packaging.errors.ExceptionGroup(message: str, exceptions: list[Exception])
+
+   On older Pythons, this is a small fallback implementation of the
+   :class:`ExceptionGroup` introduced in Python 3.11.
+
+   :param message: The message for the group.
+   :param exceptions: A list of exceptions contained in the group.
+
+   Attributes
+   ----------
+
+   message (str)
+       The message passed to the group.
+
+   exceptions (list[Exception])
+       The exceptions contained in the group.
+
+
+.. automodule:: packaging.errors
+   :members:
+   :exclude-members: ExceptionGroup

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -33,6 +33,7 @@ The ``packaging`` library uses calendar-based versioning (``YY.N``).
     pylock
     direct_url
     dependency_groups
+    errors
     utils
 
 .. toctree::

--- a/docs/metadata.rst
+++ b/docs/metadata.rst
@@ -58,8 +58,12 @@ Exceptions
 .. autoclass:: packaging.metadata.InvalidMetadata
     :members:
 
-.. autoclass:: packaging.metadata.ExceptionGroup
-    :members:
+.. note::
+
+    ``packaging.metadata.ExceptionGroup`` is a backward-compatible re-export
+    of :class:`packaging.errors.ExceptionGroup` and is omitted here to avoid
+    duplicate documentation. See :mod:`packaging.errors` for the canonical
+    documentation.
 
 
 .. _source distributions: https://packaging.python.org/en/latest/specifications/source-distribution-format/


### PR DESCRIPTION
Credit to @ichard26 on Discord for noticing this was missing.

:robot: Assisted-by: Copilot:gpt-5-mini - used copilot CLI to get the structure set up to match the other pages. Also synced the README to the index list while at it.
