### PR TITLE
fix: make Version pickle-safe and backward-compatible with pre-26.1 pickles

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,9 @@ Changelog
 
 Fixes:
 
-* Make ``Version`` objects pickle-safe by implementing ``__reduce__``
+* Make ``Version`` objects pickle-safe by implementing ``__reduce__``, and
+  restore backward compatibility for ``Version`` pickles created before 26.1
+  that reference the removed ``packaging._structures`` module (:pull:`1163`)
 
 26.1 - 2026-04-14
 ~~~~~~~~~~~~~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,9 @@ Changelog
 *unreleased*
 ~~~~~~~~~~~~
 
-No unreleased changes.
+Fixes:
+
+* Make ``Version`` objects pickle-safe by implementing ``__reduce__``
 
 26.1 - 2026-04-14
 ~~~~~~~~~~~~~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,9 +6,9 @@ Changelog
 
 Fixes:
 
-* Make ``Version`` objects pickle-safe by implementing ``__reduce__``, and
-  restore backward compatibility for ``Version`` pickles created before 26.1
-  that reference the removed ``packaging._structures`` module (:pull:`1163`)
+* Make ``Version`` pickle-safe and backward-compatible with pickles created
+  before 26.1 that reference the removed ``packaging._structures`` module
+  (:pull:`1163`)
 
 26.1 - 2026-04-14
 ~~~~~~~~~~~~~~~~~

--- a/src/packaging/_structures.py
+++ b/src/packaging/_structures.py
@@ -1,0 +1,33 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+
+"""Backward-compatibility shim for unpickling Version objects serialized before
+packaging 26.1.
+
+Old pickles reference ``packaging._structures.InfinityType`` and
+``packaging._structures.NegativeInfinityType``.  This module provides minimal
+stand-in classes so that ``pickle.loads()`` can resolve those references.
+The deserialized objects are not used for comparisons — ``Version.__setstate__``
+discards the stale ``_key`` cache and recomputes it from the core version fields.
+"""
+
+from __future__ import annotations
+
+
+class InfinityType:
+    """Stand-in for the removed ``InfinityType`` used in old comparison keys."""
+
+    def __repr__(self) -> str:
+        return "Infinity"
+
+
+class NegativeInfinityType:
+    """Stand-in for the removed ``NegativeInfinityType`` used in old comparison keys."""
+
+    def __repr__(self) -> str:
+        return "-Infinity"
+
+
+Infinity = InfinityType()
+NegativeInfinity = NegativeInfinityType()

--- a/src/packaging/version.py
+++ b/src/packaging/version.py
@@ -741,10 +741,58 @@ class Version(_BaseVersion):
 
         return super().__ne__(other)
 
-    def __reduce__(self) -> tuple[type[Version], tuple[str]]:
-        return (self.__class__, (str(self),))
+    def __getstate__(
+        self,
+    ) -> tuple[
+        int,
+        tuple[int, ...],
+        tuple[str, int] | None,
+        tuple[str, int] | None,
+        tuple[str, int] | None,
+        LocalType | None,
+    ]:
+        # Return state as a 6-item tuple for compactness:
+        #   (epoch, release, pre, post, dev, local)
+        # Cache members are excluded and will be recomputed on demand
+        return (
+            self._epoch,
+            self._release,
+            self._pre,
+            self._post,
+            self._dev,
+            self._local,
+        )
 
     def __setstate__(self, state: object) -> None:
+        # Always discard cached values — they may contain stale references
+        # (e.g. packaging._structures.InfinityType from pre-26.1 pickles)
+        # and will be recomputed on demand from the core fields above.
+        self._key_cache = None
+        self._hash_cache = None
+
+        if isinstance(state, tuple):
+            if len(state) == 6:
+                # New format (26.2+): (epoch, release, pre, post, dev, local)
+                (
+                    self._epoch,
+                    self._release,
+                    self._pre,
+                    self._post,
+                    self._dev,
+                    self._local,
+                ) = state
+                return
+            if len(state) == 2:
+                # Format (packaging 26.x): (None, {slot: value}).
+                _, slot_dict = state
+                if isinstance(slot_dict, dict):
+                    self._epoch = slot_dict["_epoch"]
+                    self._release = slot_dict["_release"]
+                    self._pre = slot_dict.get("_pre")
+                    self._post = slot_dict.get("_post")
+                    self._dev = slot_dict.get("_dev")
+                    self._local = slot_dict.get("_local")
+                    return
         if isinstance(state, dict):
             # Old format (packaging <= 25.x, no __slots__): state is a plain
             # dict with "_version" (_Version NamedTuple) and "_key" entries.
@@ -756,27 +804,9 @@ class Version(_BaseVersion):
                 self._post = version_nt.post
                 self._dev = version_nt.dev
                 self._local = version_nt.local
-            else:
-                raise TypeError(f"Cannot restore Version from {state!r}")
-        elif isinstance(state, tuple) and len(state) == 2:
-            # New format (packaging 26.x, __slots__): (None, {slot: value}).
-            _, slot_dict = state
-            if isinstance(slot_dict, dict):
-                self._epoch = slot_dict["_epoch"]
-                self._release = slot_dict["_release"]
-                self._pre = slot_dict.get("_pre")
-                self._post = slot_dict.get("_post")
-                self._dev = slot_dict.get("_dev")
-                self._local = slot_dict.get("_local")
-            else:
-                raise TypeError(f"Cannot restore Version from {state!r}")
-        else:
-            raise TypeError(f"Cannot restore Version from {state!r}")
-        # Always discard cached values — they may contain stale references
-        # (e.g. packaging._structures.InfinityType from pre-26.1 pickles)
-        # and will be recomputed on demand from the core fields above.
-        self._key_cache = None
-        self._hash_cache = None
+                return
+
+        raise TypeError(f"Cannot restore Version from {state!r}")
 
     @property
     @_deprecated("Version._version is private and will be removed soon")

--- a/src/packaging/version.py
+++ b/src/packaging/version.py
@@ -783,7 +783,7 @@ class Version(_BaseVersion):
                 ) = state
                 return
             if len(state) == 2:
-                # Format (packaging 26.x): (None, {slot: value}).
+                # Format (packaging 26.0-26.1): (None, {slot: value}).
                 _, slot_dict = state
                 if isinstance(slot_dict, dict):
                     self._epoch = slot_dict["_epoch"]

--- a/src/packaging/version.py
+++ b/src/packaging/version.py
@@ -741,6 +741,9 @@ class Version(_BaseVersion):
 
         return super().__ne__(other)
 
+    def __reduce__(self) -> tuple[type[Version], tuple[str]]:
+        return (self.__class__, (str(self),))
+
     @property
     @_deprecated("Version._version is private and will be removed soon")
     def _version(self) -> _Version:

--- a/src/packaging/version.py
+++ b/src/packaging/version.py
@@ -744,6 +744,40 @@ class Version(_BaseVersion):
     def __reduce__(self) -> tuple[type[Version], tuple[str]]:
         return (self.__class__, (str(self),))
 
+    def __setstate__(self, state: object) -> None:
+        if isinstance(state, dict):
+            # Old format (packaging <= 25.x, no __slots__): state is a plain
+            # dict with "_version" (_Version NamedTuple) and "_key" entries.
+            version_nt = state.get("_version")
+            if version_nt is not None:
+                self._epoch = version_nt.epoch
+                self._release = version_nt.release
+                self._pre = version_nt.pre
+                self._post = version_nt.post
+                self._dev = version_nt.dev
+                self._local = version_nt.local
+            else:
+                raise TypeError(f"Cannot restore Version from {state!r}")
+        elif isinstance(state, tuple) and len(state) == 2:
+            # New format (packaging 26.x, __slots__): (None, {slot: value}).
+            _, slot_dict = state
+            if isinstance(slot_dict, dict):
+                self._epoch = slot_dict["_epoch"]
+                self._release = slot_dict["_release"]
+                self._pre = slot_dict.get("_pre")
+                self._post = slot_dict.get("_post")
+                self._dev = slot_dict.get("_dev")
+                self._local = slot_dict.get("_local")
+            else:
+                raise TypeError(f"Cannot restore Version from {state!r}")
+        else:
+            raise TypeError(f"Cannot restore Version from {state!r}")
+        # Always discard cached values — they may contain stale references
+        # (e.g. packaging._structures.InfinityType from pre-26.1 pickles)
+        # and will be recomputed on demand from the core fields above.
+        self._key_cache = None
+        self._hash_cache = None
+
     @property
     @_deprecated("Version._version is private and will be removed soon")
     def _version(self) -> _Version:

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -13,6 +13,7 @@ import typing
 import pretend
 import pytest
 
+from packaging._structures import Infinity, NegativeInfinity
 from packaging.version import (
     InvalidVersion,
     Version,
@@ -1398,7 +1399,5 @@ def test_pickle_setstate_rejects_invalid_state() -> None:
 
 def test_structures_shim_repr() -> None:
     # Cover the __repr__ methods on the backward-compatibility shim classes.
-    from packaging._structures import Infinity, NegativeInfinity
-
     assert repr(Infinity) == "Infinity"
     assert repr(NegativeInfinity) == "-Infinity"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1393,6 +1393,9 @@ def test_pickle_setstate_rejects_invalid_state() -> None:
     # tuple with non-dict second element
     with pytest.raises(TypeError, match="Cannot restore Version"):
         v.__setstate__((None, "not_a_dict"))
+    # tuple with unexpected length (not 2 or 6)
+    with pytest.raises(TypeError, match="Cannot restore Version"):
+        v.__setstate__((1, 2, 3))
     # completely wrong type
     with pytest.raises(TypeError, match="Cannot restore Version"):
         v.__setstate__(12345)

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import itertools
 import operator
+import pickle
 import sys
 import typing
 
@@ -1257,3 +1258,24 @@ def test_hatchling_usage__version() -> None:
 def test_from_parts(args: dict[str, typing.Any], string: str) -> None:
     v = Version.from_parts(**args)
     assert v == Version(string)
+
+
+@pytest.mark.parametrize(
+    "version",
+    [
+        "1.2.3",
+        "0.1.0",
+        "2.0a1",
+        "1.0b2",
+        "3.0rc1",
+        "1.0.post1",
+        "1.0.dev3",
+        "1!2.3.4a5.post6.dev7+zzz",
+    ],
+)
+def test_pickle_roundtrip(version: str) -> None:
+    # Make sure equality and str() work between a pickle/unpickle round trip.
+    v = Version(version)
+    loaded = pickle.loads(pickle.dumps(v))
+    assert loaded == v
+    assert str(loaded) == str(v)

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1359,19 +1359,20 @@ def test_pickle_26_0_slots_format_loads() -> None:
     assert v > Version("1.2.2")
 
 
-# Pickle bytes generated with packaging==26.2.dev0, Python 3.13.1, pickle protocol 2.
-# Uses string-based __reduce__ — only references packaging.version.Version.
-# This fixture uses a rich version exercising epoch, pre, post, dev, and local.
-_PACKAGING_26_2_PICKLE_V1E2_3_4A5_POST6_DEV7_ZZZ = (
-    b"\x80\x02cpackaging.version\nVersion\nq\x00X\x18\x00\x00\x00"
-    b"1!2.3.4a5.post6.dev7+zzzq\x01\x85q\x02Rq\x03."
+# Pickle bytes generated with packaging 26.2+ (6-tuple __getstate__ format),
+# Python 3.13.1, pickle protocol 2.
+_PACKAGING_26_2_TUPLE_PICKLE_V1E2_3_4A5_POST6_DEV7_ZZZ = (
+    b"\x80\x02cpackaging.version\nVersion\nq\x00)\x81q\x01(K\x01K\x02K\x03"
+    b"K\x04\x87q\x02X\x01\x00\x00\x00aq\x03K\x05\x86q\x04X\x04\x00\x00"
+    b"\x00postq\x05K\x06\x86q\x06X\x03\x00\x00\x00devq\x07K\x07\x86q\x08"
+    b"X\x03\x00\x00\x00zzzq\t\x85q\ntq\x0bb."
 )
 
 
-def test_pickle_26_2_string_reduce_loads() -> None:
-    # Verify that pickles created with packaging 26.2 (string-based __reduce__)
+def test_pickle_26_2_tuple_getstate_loads() -> None:
+    # Verify that pickles created with packaging 26.2+ (6-tuple __getstate__)
     # can be loaded and produce correct Version objects.
-    v = pickle.loads(_PACKAGING_26_2_PICKLE_V1E2_3_4A5_POST6_DEV7_ZZZ)
+    v = pickle.loads(_PACKAGING_26_2_TUPLE_PICKLE_V1E2_3_4A5_POST6_DEV7_ZZZ)
     assert isinstance(v, Version)
     assert str(v) == "1!2.3.4a5.post6.dev7+zzz"
     assert v == Version("1!2.3.4a5.post6.dev7+zzz")

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1380,3 +1380,25 @@ def test_pickle_26_2_string_reduce_loads() -> None:
     assert v.post == 6
     assert v.dev == 7
     assert v.local == "zzz"
+
+
+def test_pickle_setstate_rejects_invalid_state() -> None:
+    # Cover the TypeError branches in __setstate__ for invalid input.
+    v = Version.__new__(Version)
+    # dict without "_version" key
+    with pytest.raises(TypeError, match="Cannot restore Version"):
+        v.__setstate__({"bad_key": 123})
+    # tuple with non-dict second element
+    with pytest.raises(TypeError, match="Cannot restore Version"):
+        v.__setstate__((None, "not_a_dict"))
+    # completely wrong type
+    with pytest.raises(TypeError, match="Cannot restore Version"):
+        v.__setstate__(12345)
+
+
+def test_structures_shim_repr() -> None:
+    # Cover the __repr__ methods on the backward-compatibility shim classes.
+    from packaging._structures import Infinity, NegativeInfinity
+
+    assert repr(Infinity) == "Infinity"
+    assert repr(NegativeInfinity) == "-Infinity"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1284,7 +1284,7 @@ def test_pickle_roundtrip(version: str) -> None:
 # Pickle bytes generated with packaging==25.0, Python 3.13.1, pickle protocol 2.
 # These contain references to packaging._structures.InfinityType and
 # NegativeInfinityType in the _key cache, which were removed in packaging 26.1.
-_PRE_26_1_PICKLE_V1_2_3 = (
+_PACKAGING_25_0_PICKLE_V1_2_3 = (
     b"\x80\x02cpackaging.version\nVersion\nq\x00)\x81q\x01}q\x02"
     b"(X\x08\x00\x00\x00_versionq\x03cpackaging.version\n_Version\n"
     b"q\x04(K\x00K\x01K\x02K\x03\x87q\x05NNNNtq\x06\x81q\x07X\x04"
@@ -1293,7 +1293,7 @@ _PRE_26_1_PICKLE_V1_2_3 = (
     b"q\x0c)\x81q\rh\x0bh\rtq\x0eub."
 )
 
-_PRE_26_1_PICKLE_V2_0A1 = (
+_PACKAGING_25_0_PICKLE_V2_0A1 = (
     b"\x80\x02cpackaging.version\nVersion\nq\x00)\x81q\x01}q\x02"
     b"(X\x08\x00\x00\x00_versionq\x03cpackaging.version\n_Version\n"
     b"q\x04(K\x00K\x02K\x00\x86q\x05NX\x01\x00\x00\x00aq\x06K\x01"
@@ -1307,14 +1307,14 @@ _PRE_26_1_PICKLE_V2_0A1 = (
 def test_pickle_old_format_loads() -> None:
     # Verify that pickles created with packaging <= 25.x can be loaded
     # and produce correct Version objects.
-    v = pickle.loads(_PRE_26_1_PICKLE_V1_2_3)
+    v = pickle.loads(_PACKAGING_25_0_PICKLE_V1_2_3)
     assert isinstance(v, Version)
     assert str(v) == "1.2.3"
     assert v == Version("1.2.3")
     assert v < Version("2.0")
     assert v > Version("1.2.2")
 
-    v2 = pickle.loads(_PRE_26_1_PICKLE_V2_0A1)
+    v2 = pickle.loads(_PACKAGING_25_0_PICKLE_V2_0A1)
     assert isinstance(v2, Version)
     assert str(v2) == "2.0a1"
     assert v2 == Version("2.0a1")
@@ -1324,7 +1324,7 @@ def test_pickle_old_format_loads() -> None:
 def test_pickle_old_format_re_pickled_is_clean() -> None:
     # Verify that loading an old pickle and re-pickling it produces
     # a clean payload that no longer references packaging._structures.
-    v = pickle.loads(_PRE_26_1_PICKLE_V1_2_3)
+    v = pickle.loads(_PACKAGING_25_0_PICKLE_V1_2_3)
     new_data = pickle.dumps(v)
     assert b"_structures" not in new_data
     # And the re-pickled version still works.
@@ -1336,7 +1336,7 @@ def test_pickle_old_format_re_pickled_is_clean() -> None:
 # Pickle bytes generated with packaging==26.0, Python 3.13.1, pickle protocol 2.
 # 26.0 used __slots__ (no __dict__), so the pickle state is (None, {slot: value}).
 # The _key_cache slot still contains packaging._structures.InfinityType references.
-_PRE_26_1_PICKLE_V1_2_3_SLOTS = (
+_PACKAGING_26_0_PICKLE_V1_2_3 = (
     b"\x80\x02cpackaging.version\nVersion\nq\x00)\x81q\x01N}q\x02"
     b"(X\x04\x00\x00\x00_devq\x03NX\x06\x00\x00\x00_epochq\x04K\x00"
     b"X\n\x00\x00\x00_key_cacheq\x05(K\x00K\x01K\x02K\x03\x87q\x06"
@@ -1350,7 +1350,7 @@ _PRE_26_1_PICKLE_V1_2_3_SLOTS = (
 def test_pickle_26_0_slots_format_loads() -> None:
     # Verify that pickles created with packaging 26.0 (__slots__, no __reduce__)
     # can be loaded and produce correct Version objects.
-    v = pickle.loads(_PRE_26_1_PICKLE_V1_2_3_SLOTS)
+    v = pickle.loads(_PACKAGING_26_0_PICKLE_V1_2_3)
     assert isinstance(v, Version)
     assert str(v) == "1.2.3"
     assert v == Version("1.2.3")

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1279,3 +1279,80 @@ def test_pickle_roundtrip(version: str) -> None:
     loaded = pickle.loads(pickle.dumps(v))
     assert loaded == v
     assert str(loaded) == str(v)
+
+
+# Pickle bytes generated with packaging==25.0, Python 3.13.1, pickle protocol 2.
+# These contain references to packaging._structures.InfinityType and
+# NegativeInfinityType in the _key cache, which were removed in packaging 26.1.
+_PRE_26_1_PICKLE_V1_2_3 = (
+    b"\x80\x02cpackaging.version\nVersion\nq\x00)\x81q\x01}q\x02"
+    b"(X\x08\x00\x00\x00_versionq\x03cpackaging.version\n_Version\n"
+    b"q\x04(K\x00K\x01K\x02K\x03\x87q\x05NNNNtq\x06\x81q\x07X\x04"
+    b"\x00\x00\x00_keyq\x08(K\x00K\x01K\x02K\x03\x87q\tcpackaging._structures\n"
+    b"InfinityType\nq\n)\x81q\x0bcpackaging._structures\nNegativeInfinityType\n"
+    b"q\x0c)\x81q\rh\x0bh\rtq\x0eub."
+)
+
+_PRE_26_1_PICKLE_V2_0A1 = (
+    b"\x80\x02cpackaging.version\nVersion\nq\x00)\x81q\x01}q\x02"
+    b"(X\x08\x00\x00\x00_versionq\x03cpackaging.version\n_Version\n"
+    b"q\x04(K\x00K\x02K\x00\x86q\x05NX\x01\x00\x00\x00aq\x06K\x01"
+    b"\x86q\x07NNtq\x08\x81q\tX\x04\x00\x00\x00_keyq\n(K\x00K\x02"
+    b"\x85q\x0bh\x07cpackaging._structures\nNegativeInfinityType\n"
+    b"q\x0c)\x81q\rcpackaging._structures\nInfinityType\nq\x0e)\x81"
+    b"q\x0fh\rtq\x10ub."
+)
+
+
+def test_pickle_old_format_loads() -> None:
+    # Verify that pickles created with packaging <= 25.x can be loaded
+    # and produce correct Version objects.
+    v = pickle.loads(_PRE_26_1_PICKLE_V1_2_3)
+    assert isinstance(v, Version)
+    assert str(v) == "1.2.3"
+    assert v == Version("1.2.3")
+    assert v < Version("2.0")
+    assert v > Version("1.2.2")
+
+    v2 = pickle.loads(_PRE_26_1_PICKLE_V2_0A1)
+    assert isinstance(v2, Version)
+    assert str(v2) == "2.0a1"
+    assert v2 == Version("2.0a1")
+    assert v2 < Version("2.0")
+
+
+def test_pickle_old_format_re_pickled_is_clean() -> None:
+    # Verify that loading an old pickle and re-pickling it produces
+    # a clean payload that no longer references packaging._structures.
+    v = pickle.loads(_PRE_26_1_PICKLE_V1_2_3)
+    new_data = pickle.dumps(v)
+    assert b"_structures" not in new_data
+    # And the re-pickled version still works.
+    v2 = pickle.loads(new_data)
+    assert v2 == Version("1.2.3")
+    assert str(v2) == "1.2.3"
+
+
+# Pickle bytes generated with packaging==26.0, Python 3.13.1, pickle protocol 2.
+# 26.0 used __slots__ (no __dict__), so the pickle state is (None, {slot: value}).
+# The _key_cache slot still contains packaging._structures.InfinityType references.
+_PRE_26_1_PICKLE_V1_2_3_SLOTS = (
+    b"\x80\x02cpackaging.version\nVersion\nq\x00)\x81q\x01N}q\x02"
+    b"(X\x04\x00\x00\x00_devq\x03NX\x06\x00\x00\x00_epochq\x04K\x00"
+    b"X\n\x00\x00\x00_key_cacheq\x05(K\x00K\x01K\x02K\x03\x87q\x06"
+    b"cpackaging._structures\nInfinityType\nq\x07)\x81q\x08cpackaging._structures\n"
+    b"NegativeInfinityType\nq\t)\x81q\nh\x08h\ntq\x0bX\x06\x00\x00\x00"
+    b"_localq\x0cNX\x05\x00\x00\x00_postq\rNX\x04\x00\x00\x00_preq\x0e"
+    b"NX\x08\x00\x00\x00_releaseq\x0fh\x06u\x86q\x10b."
+)
+
+
+def test_pickle_26_0_slots_format_loads() -> None:
+    # Verify that pickles created with packaging 26.0 (__slots__, no __reduce__)
+    # can be loaded and produce correct Version objects.
+    v = pickle.loads(_PRE_26_1_PICKLE_V1_2_3_SLOTS)
+    assert isinstance(v, Version)
+    assert str(v) == "1.2.3"
+    assert v == Version("1.2.3")
+    assert v < Version("2.0")
+    assert v > Version("1.2.2")

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1356,3 +1356,27 @@ def test_pickle_26_0_slots_format_loads() -> None:
     assert v == Version("1.2.3")
     assert v < Version("2.0")
     assert v > Version("1.2.2")
+
+
+# Pickle bytes generated with packaging==26.2.dev0, Python 3.13.1, pickle protocol 2.
+# Uses string-based __reduce__ — only references packaging.version.Version.
+# This fixture uses a rich version exercising epoch, pre, post, dev, and local.
+_PACKAGING_26_2_PICKLE_V1E2_3_4A5_POST6_DEV7_ZZZ = (
+    b"\x80\x02cpackaging.version\nVersion\nq\x00X\x18\x00\x00\x00"
+    b"1!2.3.4a5.post6.dev7+zzzq\x01\x85q\x02Rq\x03."
+)
+
+
+def test_pickle_26_2_string_reduce_loads() -> None:
+    # Verify that pickles created with packaging 26.2 (string-based __reduce__)
+    # can be loaded and produce correct Version objects.
+    v = pickle.loads(_PACKAGING_26_2_PICKLE_V1E2_3_4A5_POST6_DEV7_ZZZ)
+    assert isinstance(v, Version)
+    assert str(v) == "1!2.3.4a5.post6.dev7+zzz"
+    assert v == Version("1!2.3.4a5.post6.dev7+zzz")
+    assert v.epoch == 1
+    assert v.release == (2, 3, 4)
+    assert v.pre == ("a", 5)
+    assert v.post == 6
+    assert v.dev == 7
+    assert v.local == "zzz"


### PR DESCRIPTION
## Summary

Fixes #1162 — `Version` objects pickled with `packaging` < 26.1 fail to unpickle after upgrading, because the removed `_structures.py` module is referenced in the pickle stream.

## Changes

This PR is structured as **two independent commits** so that commit 1 can land on its own if maintaining backward compatibility for old pickles (commit 2) is not desired.

### Commit 1: Forward-fix — `__reduce__`

- Adds `__reduce__` to `Version`, serializing as `(Version, ("1.2.3",))` — string-based reconstruction via `__init__`, never persisting internal caches or private types.
- Adds parametrized `test_pickle_roundtrip` covering simple, pre-release, post-release, dev, epoch, and local versions.
- Adds changelog entry under *unreleased* / Fixes.

### Commit 2: Backward-fix — `_structures.py` shim + `__setstate__`

- Restores a minimal `_structures.py` shim defining `InfinityType` and `NegativeInfinityType` — just enough to be unpicklable, not functional for comparisons. No import-time warning (would conflict with `filterwarnings = ["error"]` in pytest config).
- Adds `__setstate__` to `Version` that handles both old dict-based state (25.x) and tuple-based `__slots__` state (26.0), discarding `_key_cache` and `_hash_cache` so they recompute with the current `_cmpkey`.
- Tests use **real pickle fixtures** generated with `packaging==25.0` and `packaging==26.0` (with `hash(v)` called to force `_key_cache` population embedding `InfinityType`/`NegativeInfinityType` references).
- Includes a re-pickle cleanliness test verifying that loading an old pickle and re-pickling produces a clean `__reduce__`-based pickle with no `_structures` references.

## Testing

- All 51,511 existing tests pass (`python -m pytest tests/test_version.py -x`)
- 4 new test functions added, all passing