### PR TITLE
fix: re-export ExceptionGroup for now

### DIFF
--- a/src/packaging/metadata.py
+++ b/src/packaging/metadata.py
@@ -27,6 +27,7 @@ T = typing.TypeVar("T")
 
 
 __all__ = [
+    "ExceptionGroup",  # Keep this in all for a bit (makes mypy happy with location from 26.0)
     "InvalidMetadata",
     "Metadata",
     "RFC822Message",

--- a/src/packaging/metadata.py
+++ b/src/packaging/metadata.py
@@ -27,7 +27,7 @@ T = typing.TypeVar("T")
 
 
 __all__ = [
-    "ExceptionGroup",  # Keep this in all for a bit (makes mypy happy with location from 26.0)
+    "ExceptionGroup",  # Keep this for a bit (makes mypy happy w/ 26.0 compat)
     "InvalidMetadata",
     "Metadata",
     "RFC822Message",


### PR DESCRIPTION
This makes it a bit easier to support older versions when running mypy. We should remove this once 26.1 is an old-enough minimum.

This was the intended effect, but I think it would be nice to keep it from happening for a bit longer.

See https://github.com/pypa/twine/pull/1310.
