### PR TITLE
docs(specifiers): add is_unsatisfiable() usage example

### DIFF
--- a/docs/specifiers.rst
+++ b/docs/specifiers.rst
@@ -54,6 +54,11 @@ Usage
     True
     >>> SpecifierSet(">=1.0,<2.0").is_unsatisfiable()
     False
+    >>> # Compound sets built with ``&`` may also become unsatisfiable
+    >>> (SpecifierSet(">=3.9,<4.0") & SpecifierSet("==3.12.*")).is_unsatisfiable()
+    False
+    >>> (SpecifierSet(">=3.13,<4.0") & SpecifierSet("==3.12.*")).is_unsatisfiable()
+    True
 
 
 Reference

--- a/docs/specifiers.rst
+++ b/docs/specifiers.rst
@@ -49,6 +49,11 @@ Usage
     >>> # contained within our specifier.
     >>> list(combined_spec.filter([v1, v2, "1.4"]))
     [<Version('1.0')>, '1.4']
+    >>> # We can check if a specifier set can never be satisfied
+    >>> SpecifierSet(">=2.0,<1.0").is_unsatisfiable()
+    True
+    >>> SpecifierSet(">=1.0,<2.0").is_unsatisfiable()
+    False
 
 
 Reference


### PR DESCRIPTION
Fixes #1165

PR #1119 added `SpecifierSet.is_unsatisfiable()` but the usage examples in `docs/specifiers.rst` don't demonstrate it. Users scanning the Usage section have no way to discover this method without reading the full API reference.

Added a doctest example showing `is_unsatisfiable()` on both an unsatisfiable set (`>=2.0,<1.0` → `True`) and a satisfiable one (`>=1.0,<2.0` → `False`), placed after the existing `filter()` example.