### PR TITLE
fix(markers): handle version pattern on LHS when marker variable is on RHS

### DIFF
--- a/src/packaging/markers.py
+++ b/src/packaging/markers.py
@@ -14,6 +14,7 @@ from ._parser import MarkerAtom, MarkerList, Op, Value, Variable
 from ._parser import parse_marker as _parse_marker
 from ._tokenizer import ParserSyntaxError
 from .specifiers import InvalidSpecifier, Specifier
+from .version import Version, InvalidVersion
 from .utils import canonicalize_name
 
 __all__ = [
@@ -221,7 +222,24 @@ def _eval_op(lhs: str, op: Op, rhs: str | AbstractSet[str], *, key: str) -> bool
         except InvalidSpecifier:
             pass
         else:
-            return spec.contains(lhs, prereleases=True)
+            if spec.contains(lhs, prereleases=True):
+                return True
+            # When the marker variable is on the RHS, lhs may be a version
+            # pattern (e.g. "3.12.*") while rhs is the resolved env value.
+            # Building the specifier from rhs produced no match (above), so
+            # try building it from lhs instead — but only when lhs doesn't
+            # parse as a concrete version (to avoid wrong answers for
+            # asymmetric operators like "<" / ">").
+            try:
+                Version(lhs)
+            except InvalidVersion:
+                try:
+                    swapped = Specifier(f"{op_str}{lhs}")
+                except InvalidSpecifier:
+                    pass
+                else:
+                    if swapped.contains(rhs, prereleases=True):
+                        return True
 
     oper: Operator | None = _operators.get(op_str)
     if oper is None:


### PR DESCRIPTION
## Summary

Fixes #934

When a marker expression has the version **pattern** (e.g. `'3.12.*'`) on the left-hand side and the **variable** (e.g. `python_full_version`) on the right-hand side, evaluation produced incorrect results.

For example, `"'3.12.*' == python_full_version"` evaluated to `False` even when the Python version was 3.12.3, because the resolved env value (`'3.12.3'`) was used as the specifier pattern while the literal (`'3.12.*'`) — which is not a valid PEP 440 version — was passed to `Specifier.contains()`, which silently returned `False`.

## Details

The fix in `_eval_op()`: after the normal `spec.contains(lhs)` attempt doesn't match, check whether `lhs` looks like a version **pattern** rather than a concrete version (by checking if it can be parsed as a `Version`). If it can't, try building the specifier from `lhs` instead and checking `rhs` against it.

The guard using `Version(lhs)` ensures we don't accidentally flip the meaning of asymmetric operators like `<` / `>` where both sides are concrete versions — only actual version patterns (wildcards, pre-release tags used as patterns, etc.) trigger the fallback.

## Testing

All existing tests pass (2262/2262). Verified with the exact case from the issue:
- `"'3.12.*' == python_full_version"` → `True` (was `False`)
- Normal-order markers unchanged
- Asymmetric operators with concrete versions unaffected