### PR TITLE
docs(changelog): note Specifier/SpecifierSet pickle-safe fix from #1168

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,8 @@ Fixes:
 * Make ``Version`` pickle-safe and backward-compatible with pickles created
   before 26.1 that reference the removed ``packaging._structures`` module
   (:pull:`1163`)
+* Make ``Specifier`` and ``SpecifierSet`` pickle-safe, as a followup to
+  :pull:`1163` applying the same pattern (:pull:`1168`)
 
 26.1 - 2026-04-14
 ~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Follow-up to #1168 (merged earlier today by @henryiii) adding a parallel entry for the companion pickle-safety fix in `CHANGELOG.rst` under *unreleased* / Fixes.

#1163 (Version pickle-safe, merged 2026-04-16) added a changelog entry with this wording:

```rst
* Make ``Version`` pickle-safe and backward-compatible with pickles created
  before 26.1 that reference the removed ``packaging._structures`` module
  (:pull:`1163`)
```

#1168 (merged 2026-04-23 03:34Z) applied the same pattern to `Specifier` / `SpecifierSet` ("I've had an model apply the same changes/logic in that PR to Specifier/SpecifierSet" — PR body) but the changelog update was not included. This mirrors the #1163 entry:

```rst
* Make ``Specifier`` and ``SpecifierSet`` pickle-safe, as a followup to
  :pull:`1163` applying the same pattern (:pull:`1168`)
```

Pure docs, no code logic change. Happy to reword if a more specific phrasing (e.g. referencing `_BaseSpecifier` internals) is preferred.