### PR TITLE
tests: add a pickle check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,6 +94,23 @@ jobs:
           MATRIX_PROJECT: ${{ matrix.project }}
         run: pipx run nox -s "downstream(project='$MATRIX_PROJECT')"
 
+  pickle:
+    name: Pickle test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        name: Install Python 3.14
+        with:
+          python-version: "3.14"
+          cache: "pip"
+
+      - name: Run nox
+        run: pipx run nox -s test_pickle
+
   pass:
     name: All pass
     if: always()

--- a/docs/requirements.rst
+++ b/docs/requirements.rst
@@ -73,6 +73,16 @@ Reference
     This class abstracts handling the details of a requirement for a project.
     Each requirement will be parsed according to the specification.
 
+    Instances are safe to serialize with :mod:`pickle`. They use a stable
+    format so the same pickle can be loaded in future packaging releases.
+
+    .. versionchanged:: 26.2
+
+        Added a stable pickle format. Pickles created with packaging 26.2+ can
+        be unpickled with future releases.  Backward compatibility with pickles
+        from packaging < 26.2 is supported but may be removed in a future
+        release.
+
     :param str requirement: The string representation of a requirement.
     :raises InvalidRequirement: If the given ``requirement`` is not parseable,
                                 then this exception will be raised.

--- a/noxfile.py
+++ b/noxfile.py
@@ -336,6 +336,38 @@ def update_licenses(session: nox.Session) -> None:
     session.run("python", "tasks/licenses.py")
 
 
+@nox.session(default=False)
+@nox.parametrize("version", ["21.0", "24.0", "25.0", "26.0", "26.1"])
+def test_pickle(session: nox.Session, version: str) -> None:
+    """
+    Make sure pickles written by an older packaging release can be read
+    by the current code.
+    """
+    tmp_dir = Path(session.create_tmp())
+    pickle_file = tmp_dir / f"packaging_{version}_pickles.pkl"
+
+    # Step 1: install the old release so the generator pickles objects in
+    # the format that version serialises.
+    session.install(f"packaging=={version}")
+    session.run(
+        "python",
+        "tasks/pickle_compat.py",
+        "write",
+        version,
+        str(tmp_dir),
+    )
+
+    # Step 2: install the current (in-tree) packaging so we can verify
+    # backward compatibility of the load path.
+    session.install("-e.")
+    session.run(
+        "python",
+        "tasks/pickle_compat.py",
+        "verify",
+        str(pickle_file),
+    )
+
+
 # -----------------------------------------------------------------------------
 # Helpers
 # -----------------------------------------------------------------------------

--- a/noxfile.py
+++ b/noxfile.py
@@ -364,6 +364,8 @@ def test_pickle(session: nox.Session, version: str) -> None:
         "python",
         "tasks/pickle_compat.py",
         "verify",
+        "--version",
+        version,
         str(pickle_file),
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,8 +158,9 @@ flake8-unused-arguments.ignore-variadic-names = true
 
 [tool.ruff.lint.per-file-ignores]
 "tests/test_*.py" = ["PYI024", "PLR", "SIM201", "T20", "S301"]
-"tasks/check.py" = ["UP032", "T20"]
-"tasks/check_frozen_revs.py" = ["T20", "ANN401"]
+"tasks/*.py" = ["T20"]
+"tasks/check.py" = ["UP032"]
+"tasks/check_frozen_revs.py" = ["ANN401"]
 "tests/test_requirements.py" = ["UP032"]
 "src/packaging/_musllinux.py" = ["T20"]
 "docs/conf.py" = ["INP001", "S", "A001"]

--- a/src/packaging/markers.py
+++ b/src/packaging/markers.py
@@ -322,6 +322,16 @@ class Marker:
 
     :param marker: The string representation of a marker expression.
     :raises InvalidMarker: If ``marker`` cannot be parsed.
+
+    Instances are safe to serialize with :mod:`pickle`. They use a stable
+    format so the same pickle can be loaded in future packaging releases.
+
+    .. versionchanged:: 26.2
+
+        Added a stable pickle format. Pickles created with packaging 26.2+ can
+        be unpickled with future releases.  Backward compatibility with pickles
+        from packaging < 26.2 is supported but may be removed in a future
+        release.
     """
 
     __slots__ = ("_markers",)

--- a/src/packaging/requirements.py
+++ b/src/packaging/requirements.py
@@ -33,6 +33,16 @@ class Requirement:
     Parse a given requirement string into its parts, such as name, specifier,
     URL, and extras. Raises InvalidRequirement on a badly-formed requirement
     string.
+
+    Instances are safe to serialize with :mod:`pickle`. They use a stable
+    format so the same pickle can be loaded in future packaging releases.
+
+    .. versionchanged:: 26.2
+
+        Added a stable pickle format. Pickles created with packaging 26.2+ can
+        be unpickled with future releases.  Backward compatibility with pickles
+        from packaging < 26.2 is supported but may be removed in a future
+        release.
     """
 
     # TODO: Can we test whether something is contained within a requirement?

--- a/src/packaging/specifiers.py
+++ b/src/packaging/specifiers.py
@@ -443,6 +443,16 @@ class Specifier(BaseSpecifier):
         It is generally not required to instantiate this manually. You should instead
         prefer to work with :class:`SpecifierSet` instead, which can parse
         comma-separated version specifiers (which is what package metadata contains).
+
+    Instances are safe to serialize with :mod:`pickle`. They use a stable
+    format so the same pickle can be loaded in future packaging releases.
+
+    .. versionchanged:: 26.2
+
+        Added a stable pickle format. Pickles created with packaging 26.2+ can
+        be unpickled with future releases.  Backward compatibility with pickles
+        from packaging < 26.2 is supported but may be removed in a future
+        release.
     """
 
     __slots__ = (
@@ -1326,6 +1336,18 @@ class SpecifierSet(BaseSpecifier):
 
     It can be passed a single specifier (``>=3.0``), a comma-separated list of
     specifiers (``>=3.0,!=3.1``), or no specifier at all.
+
+    Instances are safe to serialize with :mod:`pickle`. They use a stable
+    format so the same pickle can be loaded in future packaging
+    releases.
+
+    .. versionchanged:: 26.2
+
+        Added a stable pickle format. Pickles created with
+        packaging 26.2+ can be unpickled with future releases.
+        Backward compatibility with pickles from
+        packaging < 26.2 is supported but may be removed in a future
+        release.
     """
 
     __slots__ = (

--- a/src/packaging/tags.py
+++ b/src/packaging/tags.py
@@ -91,6 +91,16 @@ class Tag:
 
     Instances are considered immutable and thus are hashable. Equality checking
     is also supported.
+
+    Instances are safe to serialize with :mod:`pickle`. They use a stable
+    format so the same pickle can be loaded in future packaging releases.
+
+    .. versionchanged:: 26.2
+
+        Added a stable pickle format. Pickles created with packaging 26.2+ can
+        be unpickled with future releases.  Backward compatibility with pickles
+        from packaging < 26.2 is supported but may be removed in a future
+        release.
     """
 
     __slots__ = ["_abi", "_hash", "_interpreter", "_platform"]

--- a/src/packaging/version.py
+++ b/src/packaging/version.py
@@ -358,6 +358,16 @@ class Version(_BaseVersion):
 
     :class:`Version` is immutable; use :meth:`__replace__` to change
     part of a version.
+
+    Instances are safe to serialize with :mod:`pickle`. They use a stable
+    format so the same pickle can be loaded in future packaging releases.
+
+    .. versionchanged:: 26.2
+
+        Added a stable pickle format. Pickles created with packaging 26.2+ can
+        be unpickled with future releases.  Backward compatibility with pickles
+        from packaging < 26.2 is supported but may be removed in a future
+        release.
     """
 
     __slots__ = (

--- a/tasks/pickle_compat.py
+++ b/tasks/pickle_compat.py
@@ -1,0 +1,178 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+
+"""Generate or verify pickle files with packaging objects for cross-version testing.
+
+Usage:
+    python tasks/pickle.py write <version> <output_dir>
+    python tasks/pickle.py verify <pickle_file>
+
+The ``write`` command generates a pickle file using the *currently installed*
+release of ``packaging``.  ``<version>`` is recorded as metadata in the file
+(e.g. ``25.0``) so that ``verify`` can report what release created the pickle.
+
+The ``verify`` command loads a pickle and checks that every object:
+
+* has the expected type,
+* compares equal to a freshly constructed counterpart, and
+* round-trips through ``pickle.dumps`` / ``pickle.loads``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import pickle
+import sys
+from typing import Any
+
+from packaging.markers import Marker
+from packaging.specifiers import Specifier, SpecifierSet
+from packaging.tags import Tag
+from packaging.version import Version
+
+_OBJECTS = {
+    "version": [
+        Version("1.2.3"),
+        Version("1!2.3.4a5.post6.dev7+zzz"),
+        Version("0.1.0"),
+        Version("2.0a1"),
+        Version("1.0.post1"),
+        Version("1.0.dev3"),
+    ],
+    "marker": [
+        Marker('python_version >= "3.8"'),
+        Marker('os_name == "posix" and python_version >= "3.9"'),
+        Marker('extra == "test"'),
+    ],
+    "specifier": [
+        Specifier(">=1.0.0"),
+        Specifier("~=2.3"),
+        Specifier("==1.2.*"),
+        Specifier("!=2.0.0"),
+        Specifier("<3.0"),
+        Specifier(">1.0"),
+        Specifier("<=2.0"),
+    ],
+    "specifierset": [
+        SpecifierSet(">=1.0.0,<2.0.0"),
+        SpecifierSet("~=1.0,!=1.0.1"),
+        SpecifierSet(">=3.0"),
+    ],
+    "tag": [
+        Tag("cp39", "cp39", "linux_x86_64"),
+        Tag("py3", "none", "any"),
+        Tag("cp310", "abi3", "manylinux_2_17_x86_64"),
+    ],
+}
+
+_TYPE_CHECKS: dict[str, type[object]] = {
+    "version": Version,
+    "marker": Marker,
+    "specifier": Specifier,
+    "specifierset": SpecifierSet,
+    "tag": Tag,
+}
+
+
+def write(version: str, output_dir: pathlib.Path) -> pathlib.Path:
+    """Pickle a representative set of objects and write them to disk."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    path = output_dir / f"packaging_{version}_pickles.pkl"
+
+    with open(path, "wb") as f:
+        pickle.dump({"generated_with": version, "objects": _OBJECTS}, f)
+
+    return path
+
+
+def verify(path: pathlib.Path) -> int:
+    """Load a pickle file and verify its contents.
+
+    Returns 0 on success, 1 on failure.
+    """
+    with open(path, "rb") as f:
+        data: dict[str, Any] = pickle.load(f)  # noqa: S301
+
+    generated_with = data["generated_with"]
+    objects: dict[str, list[Any]] = data["objects"]
+    print(f"Verifying pickles generated with packaging=={generated_with}")
+
+    for kind, expected_cls in _TYPE_CHECKS.items():
+        loaded_list = objects[kind]
+        expected_list = _OBJECTS[kind]
+
+        if len(loaded_list) != len(expected_list):  # type: ignore[arg-type]
+            print(
+                f"FAIL: {kind} list length mismatch "
+                f"({len(loaded_list)} vs {len(expected_list)})",  # type: ignore[arg-type]
+                file=sys.stderr,
+            )
+            return 1
+
+        for i, (loaded, expected) in enumerate(
+            zip(loaded_list, expected_list)  # type: ignore[call-overload]
+        ):
+            if type(loaded) is not expected_cls:
+                print(
+                    f"FAIL: {kind}[{i}] is {type(loaded).__name__}, "
+                    f"expected {expected_cls.__name__}",
+                    file=sys.stderr,
+                )
+                return 1
+
+            if loaded != expected:
+                print(
+                    f"FAIL: {kind}[{i}] {loaded!r} != {expected!r}",
+                    file=sys.stderr,
+                )
+                return 1
+
+            reloaded = pickle.loads(pickle.dumps(loaded))  # noqa: S301
+            if reloaded != expected:
+                print(
+                    f"FAIL: {kind}[{i}] does not round-trip correctly",
+                    file=sys.stderr,
+                )
+                return 1
+
+    print("All pickle verifications passed!")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    write_parser = subparsers.add_parser("write", help="Generate a pickle file")
+    write_parser.add_argument(
+        "version", help="packaging version generating the pickles"
+    )
+    write_parser.add_argument(
+        "output_dir",
+        type=pathlib.Path,
+        default=pathlib.Path("."),
+        nargs="?",
+    )
+
+    verify_parser = subparsers.add_parser("verify", help="Verify a pickle file")
+    verify_parser.add_argument(
+        "pickle_file", type=pathlib.Path, help="path to the pickle file"
+    )
+
+    args = parser.parse_args()
+
+    if args.command == "write":
+        path = write(args.version, args.output_dir)
+        print(f"Wrote {path}")
+        return 0
+
+    if args.command == "verify":
+        return verify(args.pickle_file)
+
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tasks/pickle_compat.py
+++ b/tasks/pickle_compat.py
@@ -5,8 +5,8 @@
 """Generate or verify pickle files with packaging objects for cross-version testing.
 
 Usage:
-    python tasks/pickle.py write <version> <output_dir>
-    python tasks/pickle.py verify <pickle_file>
+    python tasks/pickle_compat.py write <version> <output_dir>
+    python tasks/pickle_compat.py verify [--version <version>] <pickle_file>
 
 The ``write`` command generates a pickle file using the *currently installed*
 release of ``packaging``.  ``<version>`` is recorded as metadata in the file
@@ -17,11 +17,15 @@ The ``verify`` command loads a pickle and checks that every object:
 * has the expected type,
 * compares equal to a freshly constructed counterpart, and
 * round-trips through ``pickle.dumps`` / ``pickle.loads``.
+
+When ``--version`` is supplied, ``verify`` also checks that the pickle was
+generated with that release of ``packaging``.
 """
 
 from __future__ import annotations
 
 import argparse
+import importlib.metadata
 import pathlib
 import pickle
 import sys
@@ -78,6 +82,12 @@ _TYPE_CHECKS: dict[str, type[object]] = {
 
 def write(version: str, output_dir: pathlib.Path) -> pathlib.Path:
     """Pickle a representative set of objects and write them to disk."""
+    installed = importlib.metadata.version("packaging")
+    if version != installed:
+        raise SystemExit(
+            f"Requested packaging=={version} but the installed version is {installed}"
+        )
+
     output_dir.mkdir(parents=True, exist_ok=True)
     path = output_dir / f"packaging_{version}_pickles.pkl"
 
@@ -87,7 +97,7 @@ def write(version: str, output_dir: pathlib.Path) -> pathlib.Path:
     return path
 
 
-def verify(path: pathlib.Path) -> int:
+def verify(path: pathlib.Path, expected_version: str | None = None) -> int:
     """Load a pickle file and verify its contents.
 
     Returns 0 on success, 1 on failure.
@@ -98,6 +108,14 @@ def verify(path: pathlib.Path) -> int:
     generated_with = data["generated_with"]
     objects: dict[str, list[Any]] = data["objects"]
     print(f"Verifying pickles generated with packaging=={generated_with}")
+
+    if expected_version is not None and generated_with != expected_version:
+        print(
+            f"FAIL: generated_with ({generated_with}) != expected version "
+            f"({expected_version})",
+            file=sys.stderr,
+        )
+        return 1
 
     for kind, expected_cls in _TYPE_CHECKS.items():
         loaded_list = objects[kind]
@@ -160,6 +178,9 @@ def main() -> int:
     verify_parser.add_argument(
         "pickle_file", type=pathlib.Path, help="path to the pickle file"
     )
+    verify_parser.add_argument(
+        "--version", dest="expected_version", help="expected packaging version"
+    )
 
     args = parser.parse_args()
 
@@ -169,7 +190,7 @@ def main() -> int:
         return 0
 
     if args.command == "verify":
-        return verify(args.pickle_file)
+        return verify(args.pickle_file, args.expected_version)
 
     return 1
 


### PR DESCRIPTION
This adds a job that tests older packaging's pickles. Also updating the docs to mention the support for pickling.

:robot: Assisted-by: OpenCode:Kimi-K2.6
