### PR TITLE
ci: use native uv integration in rtd

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,10 +9,13 @@ build:
   os: ubuntu-24.04
   tools:
     python: "3.14"
-  commands:
-    - asdf plugin add uv
-    - asdf install uv latest
-    - asdf global uv latest
-    - uv sync --group docs
-    - uv run python -m sphinx -T -b html -d docs/_build/doctrees -D language=en
-      docs $READTHEDOCS_OUTPUT/html
+
+sphinx:
+  configuration: docs/conf.py
+
+python:
+  install:
+    - method: uv
+      command: sync
+      groups:
+        - docs


### PR DESCRIPTION
See https://about.readthedocs.com/blog/2026/04/uv-native-support for info. Just as fast as our manual setup was.
