### PR TITLE
Fix reversed version marker equality with RHS variables

### DIFF
--- a/src/packaging/markers.py
+++ b/src/packaging/markers.py
@@ -213,9 +213,25 @@ _operators: dict[str, Operator] = {
 }
 
 
-def _eval_op(lhs: str, op: Op, rhs: str | AbstractSet[str], *, key: str) -> bool:
+def _eval_op(
+    lhs: str,
+    op: Op,
+    rhs: str | AbstractSet[str],
+    *,
+    key: str,
+    rhs_is_environment: bool = False,
+) -> bool:
     op_str = op.serialize()
     if key in MARKERS_REQUIRING_VERSION:
+        if rhs_is_environment and op_str in {"==", "!=", "==="}:
+            try:
+                spec = Specifier(f"{op_str}{lhs}")
+            except InvalidSpecifier:
+                pass
+            else:
+                assert isinstance(rhs, str), "rhs must be a string"
+                return spec.contains(rhs, prereleases=True)
+
         try:
             spec = Specifier(f"{op_str}{rhs}")
         except InvalidSpecifier:
@@ -273,7 +289,15 @@ def _evaluate_markers(
 
             assert isinstance(lhs_value, str), "lhs must be a string"
             lhs_value, rhs_value = _normalize(lhs_value, rhs_value, key=environment_key)
-            groups[-1].append(_eval_op(lhs_value, op, rhs_value, key=environment_key))
+            groups[-1].append(
+                _eval_op(
+                    lhs_value,
+                    op,
+                    rhs_value,
+                    key=environment_key,
+                    rhs_is_environment=not isinstance(lhs, Variable),
+                )
+            )
         elif marker == "or":
             groups.append([])
         elif marker == "and":

--- a/tests/test_markers.py
+++ b/tests/test_markers.py
@@ -109,6 +109,29 @@ class TestOperatorEvaluation:
             {"python_full_version": "3.11.0a5"}
         )
 
+    @pytest.mark.parametrize(
+        ("marker_string", "python_full_version", "expected"),
+        [
+            ('python_full_version == "3.13.*"', "3.13.7", True),
+            ('"3.13.*" == python_full_version', "3.13.7", True),
+            ('python_full_version == "3.13.*"', "3.14.0", False),
+            ('"3.13.*" == python_full_version', "3.14.0", False),
+            ('python_full_version != "3.13.*"', "3.13.7", False),
+            ('"3.13.*" != python_full_version', "3.13.7", False),
+            ('python_full_version != "3.13.*"', "3.14.0", True),
+            ('"3.13.*" != python_full_version', "3.14.0", True),
+        ],
+    )
+    def test_version_marker_rhs_variable_arbitrary_equality(
+        self,
+        marker_string: str,
+        python_full_version: str,
+        expected: bool,
+    ) -> None:
+        assert Marker(marker_string).evaluate(
+            {"python_full_version": python_full_version}
+        ) is expected
+
 
 class FakeVersionInfo(NamedTuple):
     major: int


### PR DESCRIPTION
## Summary
- handle reversed version marker equality/inequality when the environment variable is on the right-hand side
- add regression coverage for wildcard `python_full_version` comparisons in both operand orders

## Reproduction
Before this change:
- `Marker("python_full_version == "3.13.*"").evaluate({...})` returned `True`
- `Marker(""3.13.*" == python_full_version").evaluate({...})` returned `False`

With `python_full_version="3.13.7"`, both now evaluate to `True`, and the corresponding `!=` cases stay symmetric.

Closes #934.

## Validation
- `PYTHONPATH=src .venv/bin/python -m pytest tests/test_markers.py -q`
- `PYTHONPATH=src .venv/bin/python -m pytest -q`
