### PR TITLE
docs(changelog): correct PR reference for DirectUrl typo fix in 26.2 (#1167 → #1169)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,7 +21,7 @@ Documentation:
 
 * Add errors section and fix missing details in (:pull:`1159`)
 * Document our property-based test suite in (:pull:`1167`)
-* Fix a ``DirectUrl`` typo in (:pull:`1167`)
+* Fix a ``DirectUrl`` typo in (:pull:`1169`)
 * Add example of ``is_unsatisfiable`` in (:pull:`1166`)
 
 Internal:


### PR DESCRIPTION
The 26.2 changelog entry currently lists:

```
* Document our property-based test suite in (:pull:`1167`)
* Fix a ``DirectUrl`` typo in (:pull:`1167`)
```

The second bullet's PR reference is wrong:

- #1167 is `docs(dev): document property-based test suite` (already correctly attributed on the line above; touches `docs/development/getting-started.rst`).
- The actual `DirectUrl` typo fix (`DirectUrlalidationError` → `DirectUrlValidationError` in `docs/direct_url.rst`) landed in #1169 by @sbidoul, merged the same afternoon.

Single-character fix on `CHANGELOG.rst:24`.

> **Note on convention**: per @henryiii's redirect on #1173, changelog updates are normally batched into the release PR (#1161 here). This is a post-release errata correction in an already-published 26.2 section, so a release-PR suggestion path no longer exists. Happy to close this and wait for the next release-prep window if you'd prefer to fold it into the next batch.
