### PR TITLE
docs(getting-started): sync nox example to current Python support matrix

### DIFF
--- a/docs/development/getting-started.rst
+++ b/docs/development/getting-started.rst
@@ -30,15 +30,17 @@ each supported Python version and run the tests. For example:
     $ nox -s tests
     ...
     nox > Ran multiple sessions:
-    nox > * tests-3.8: success
     nox > * tests-3.9: success
     nox > * tests-3.10: success
     nox > * tests-3.11: success
     nox > * tests-3.12: success
     nox > * tests-3.13: success
-    nox > * tests-pypy3.8: skipped
+    nox > * tests-3.14: success
+    nox > * tests-3.13t: success
+    nox > * tests-3.14t: success
     nox > * tests-pypy3.9: skipped
     nox > * tests-pypy3.10: skipped
+    nox > * tests-pypy3.11: skipped
 
 You may not have all the required Python versions installed, in which case you
 will see one or more ``InterpreterNotFound`` errors.


### PR DESCRIPTION
After #1157 dropped Python 3.8, the example output in `docs/development/getting-started.rst` for `nox -s tests` was left referencing `tests-3.8: success` and `tests-pypy3.8: skipped`. The same example also pre-dates the addition of CPython 3.14, the free-threaded `3.13t` / `3.14t` sessions, and PyPy 3.11 to the noxfile decorator.

This patch syncs the illustrative output to match the current `noxfile.py` `tests` session decorator:

```python
@nox.session(
    python=[
        *PYTHON_VERSIONS,   # 3.9..3.14 from pyproject.toml
        "3.13t",
        "3.14t",
        "pypy3.9",
        "pypy3.10",
        "pypy3.11",
    ],
    ...
)
```

Following the precedent of #783 ("Add 3.13 + drop 3.7") and #500 ("Remove 3.6"), which kept this docs example fully in sync each time the version matrix changed.

CHANGELOG intentionally untouched — `*unreleased*` is batch-updated at release time per the convention noted in #1173 and #1183.

Happy to trim back to a 3.8-only removal (or expand to additional clarifying prose) if you'd prefer a different scope.
