### PR TITLE
Validate packages.index as a URL in pylock parsing

### DIFF
--- a/src/packaging/pylock.py
+++ b/src/packaging/pylock.py
@@ -243,6 +243,14 @@ def _validate_path_url(path: str | None, url: str | None) -> None:
         raise PylockValidationError("path or url must be provided")
 
 
+def _validate_absolute_url(url: str | None, context: str) -> None:
+    if url is None:
+        return
+    parsed = urlparse(url)
+    if not parsed.scheme or not parsed.netloc:
+        raise PylockValidationError("URL must be absolute", context=context)
+
+
 def _path_name(path: str | None) -> str | None:
     if not path:
         return None
@@ -352,6 +360,7 @@ class PackageVcs:
             subdirectory=_get(d, str, "subdirectory"),
         )
         _validate_path_url(package_vcs.path, package_vcs.url)
+        _validate_absolute_url(package_vcs.url, "url")
         return package_vcs
 
 
@@ -420,6 +429,7 @@ class PackageArchive:
             subdirectory=_get(d, str, "subdirectory"),
         )
         _validate_path_url(package_archive.path, package_archive.url)
+        _validate_absolute_url(package_archive.url, "url")
         return package_archive
 
 
@@ -461,6 +471,7 @@ class PackageSdist:
             hashes=_get_required_as(d, Mapping, _validate_hashes, "hashes"),  # type: ignore[type-abstract]
         )
         _validate_path_url(package_sdist.path, package_sdist.url)
+        _validate_absolute_url(package_sdist.url, "url")
         return package_sdist
 
     @property
@@ -510,6 +521,7 @@ class PackageWheel:
             hashes=_get_required_as(d, Mapping, _validate_hashes, "hashes"),  # type: ignore[type-abstract]
         )
         _validate_path_url(package_wheel.path, package_wheel.url)
+        _validate_absolute_url(package_wheel.url, "url")
         return package_wheel
 
     @property
@@ -599,6 +611,7 @@ class Package:
                 "Exactly one of vcs, directory, archive must be set "
                 "if sdist and wheels are not set"
             )
+        _validate_absolute_url(package.index, "index")
         for i, wheel in enumerate(package.wheels or []):
             try:
                 (name, version, _, _) = parse_wheel_filename(wheel.filename)

--- a/tests/test_pylock.py
+++ b/tests/test_pylock.py
@@ -282,6 +282,54 @@ def test_pylock_invalid_vcs() -> None:
 
 
 @pytest.mark.parametrize(
+    ("data", "expected"),
+    [
+        (
+            {
+                "lock-version": "1.0",
+                "created-by": "pip",
+                "packages": [
+                    {
+                        "name": "example",
+                        "index": "not-a-url",
+                        "wheels": [
+                            {
+                                "name": "example-1.0-py3-none-any.whl",
+                                "url": "https://example.com/example-1.0-py3-none-any.whl",
+                                "hashes": {"sha256": "f" * 40},
+                            }
+                        ],
+                    }
+                ],
+            },
+            "URL must be absolute in 'packages[0].index'",
+        ),
+        (
+            {
+                "lock-version": "1.0",
+                "created-by": "pip",
+                "packages": [
+                    {
+                        "name": "example",
+                        "vcs": {
+                            "type": "git",
+                            "url": "not-a-url",
+                            "commit-id": "f" * 40,
+                        },
+                    }
+                ],
+            },
+            "URL must be absolute in 'packages[0].vcs.url'",
+        ),
+    ],
+)
+def test_pylock_invalid_urls(data: dict[str, Any], expected: str) -> None:
+    with pytest.raises(PylockValidationError) as exc_info:
+        Pylock.from_dict(data)
+    assert str(exc_info.value) == expected
+
+
+@pytest.mark.parametrize(
     ("dist", "expected_filename"),
     [
         # sdists


### PR DESCRIPTION
## Summary

pypa/packaging accepts invalid non-URL strings such as packages.index = "not-a-url" in pylock.toml data. The selected task was to add minimal code and test coverage so pylock parsing rejects non-absolute URLs, matching issue #1185's expected behavior.

## Verification

Ran python3 -m pytest tests/test_pylock.py, but verification was environment-blocked during test collection because tomli_w is not installed. As a fallback sanity check, ran python3 -m compileall src/packaging/pylock.py tests/test_pylock.py successfully. Patch submission review passed.

## Risk

- Selected task risk: low
- Files changed: src/packaging/pylock.py, tests/test_pylock.py

## External Live PR Notice

This PR was opened by the ContribArena harness through a bot account after local quality, eligibility, maintainer-fit, and governance gates passed. The change was AI-assisted and is intended to be low-risk and reviewable.