### PR TITLE
ci: add Python 3.15 to test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         os: [Ubuntu, Windows, macOS]
         python_version:
-          ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "3.13t", "3.14t", "pypy3.9", "pypy3.10", "pypy3.11"]
+          ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "3.15", "3.13t", "3.14t", "3.15t", "pypy3.9", "pypy3.10", "pypy3.11"]
         include:
           - os: Ubuntu
             python_version: "3.11.0"

--- a/noxfile.py
+++ b/noxfile.py
@@ -42,6 +42,7 @@ PYTHON_VERSIONS = nox.project.python_versions(PYPROJECT)
         *PYTHON_VERSIONS,
         "3.13t",
         "3.14t",
+        "3.15t",
         "pypy3.9",
         "pypy3.10",
         "pypy3.11",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",
+  "Programming Language :: Python :: 3.15",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
   "Programming Language :: Python :: Free Threading :: 4 - Resilient",


### PR DESCRIPTION
Now that the first beta is out, let's test and declare support (if all goes well).

:robot: *Human guided, AI assisted PR ([using this skill](https://github.com/henryiii/skills/blob/main/branch-and-pr/SKILL.md)). AI text below.* :robot:

Add Python 3.15 (CPython and free-threaded) to the CI test matrix, nox sessions, and pyproject.toml classifiers.

Assisted-by: OpenCode:glm-5.1