### PR TITLE
docs(getting-started): add 3.15 to nox example to match new test matrix

### DIFF
--- a/docs/development/getting-started.rst
+++ b/docs/development/getting-started.rst
@@ -36,8 +36,10 @@ each supported Python version and run the tests. For example:
     nox > * tests-3.12: success
     nox > * tests-3.13: success
     nox > * tests-3.14: success
+    nox > * tests-3.15: success
     nox > * tests-3.13t: success
     nox > * tests-3.14t: success
+    nox > * tests-3.15t: success
     nox > * tests-pypy3.9: skipped
     nox > * tests-pypy3.10: skipped
     nox > * tests-pypy3.11: skipped


### PR DESCRIPTION
## What does this PR do?

Adds the two new `3.15` rows that `nox -s tests` now prints, so the example output in `docs/development/getting-started.rst` matches the actual test matrix after #1190 added Python 3.15 (CPython and free-threaded) to `pyproject.toml` classifiers and `noxfile.py`.

Net diff: `+2 / -0`.

```diff
     nox > * tests-3.14: success
+    nox > * tests-3.15: success
     nox > * tests-3.13t: success
     nox > * tests-3.14t: success
+    nox > * tests-3.15t: success
```

## Related Issue

Follow-up to #1190 (added 3.15 + 3.15t to test matrix, nox sessions, and classifiers). Same form as the merged #1184 nox example sync.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)

## Changes Made

- `docs/development/getting-started.rst`: insert `tests-3.15: success` between `tests-3.14` and `tests-3.13t`, and `tests-3.15t: success` after `tests-3.14t`, matching the order in `noxfile.py` (`*PYTHON_VERSIONS, "3.13t", "3.14t", "3.15t", "pypy3.9", ...`).

## How to Test

Read-only docs sync; no test changes. The rendered output now mirrors what `nox -s tests` will print on a machine with 3.9–3.15 + 3.13t/3.14t/3.15t installed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/pypa/packaging/blob/main/CONTRIBUTING.rst)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/pypa/packaging/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature
- [x] N/A — docs-only change
