### PR TITLE
chore: avoid importing TYPE_CHECKING

### DIFF
--- a/benchmarks/__init__.py
+++ b/benchmarks/__init__.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, TypeVar
-
+TYPE_CHECKING = False
 if TYPE_CHECKING:
     from collections.abc import Callable
+    from typing import Any, TypeVar
 
-F = TypeVar("F", bound="Callable[..., Any]")
+    F = TypeVar("F", bound="Callable[..., Any]")
 
 
 def add_attributes(**attrs: object) -> Callable[[F], F]:

--- a/noxfile.py
+++ b/noxfile.py
@@ -20,14 +20,15 @@ import textwrap
 import time
 import urllib.request
 from pathlib import Path
-from typing import IO, TYPE_CHECKING
 
 import nox
 
 import packaging.version  # will always be present with nox
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
     from collections.abc import Generator
+    from typing import IO
 
 nox.needs_version = ">=2025.02.09"
 nox.options.reuse_existing_virtualenvs = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -156,6 +156,9 @@ ignore = [
 flake8-comprehensions.allow-dict-calls-with-keyword-arguments = true
 flake8-unused-arguments.ignore-variadic-names = true
 
+[tool.ruff.lint.flake8-tidy-imports.banned-api]
+"typing.TYPE_CHECKING".msg = "Use TYPE_CHECKING=False instead"
+
 [tool.ruff.lint.per-file-ignores]
 "tests/test_*.py" = ["PYI024", "PLR", "SIM201", "T20", "S301"]
 "tasks/*.py" = ["T20"]

--- a/src/packaging/_elffile.py
+++ b/src/packaging/_elffile.py
@@ -12,7 +12,10 @@ from __future__ import annotations
 import enum
 import os
 import struct
-from typing import IO
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from typing import IO
 
 
 class ELFInvalid(ValueError):

--- a/src/packaging/_manylinux.py
+++ b/src/packaging/_manylinux.py
@@ -7,10 +7,11 @@ import os
 import re
 import sys
 import warnings
-from typing import TYPE_CHECKING, NamedTuple
+from typing import NamedTuple
 
 from ._elffile import EIClass, EIData, ELFFile, EMachine
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
     from collections.abc import Generator, Iterator, Sequence
 

--- a/src/packaging/_musllinux.py
+++ b/src/packaging/_musllinux.py
@@ -10,10 +10,11 @@ import functools
 import re
 import subprocess
 import sys
-from typing import TYPE_CHECKING, NamedTuple
+from typing import NamedTuple
 
 from ._elffile import ELFFile
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
     from collections.abc import Iterator, Sequence
 

--- a/src/packaging/_ranges.py
+++ b/src/packaging/_ranges.py
@@ -7,17 +7,13 @@ from __future__ import annotations
 
 import enum
 import functools
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Final,
-)
 
 from .version import InvalidVersion, Version
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable, Iterator, Sequence
-    from typing import Union
+    from typing import Any, Final, Union
 
 __all__ = [
     "FULL_RANGE",

--- a/src/packaging/_tokenizer.py
+++ b/src/packaging/_tokenizer.py
@@ -3,12 +3,13 @@ from __future__ import annotations
 import contextlib
 import re
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, NoReturn
 
 from .specifiers import Specifier
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
     from collections.abc import Generator, Mapping
+    from typing import NoReturn
 
 
 @dataclass

--- a/src/packaging/direct_url.py
+++ b/src/packaging/direct_url.py
@@ -4,16 +4,25 @@ import dataclasses
 import re
 import urllib.parse
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, Protocol, TypeVar
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:  # pragma: no cover
     import sys
     from collections.abc import Collection
+    from typing import Any, Protocol, TypeVar
 
     if sys.version_info >= (3, 11):
         from typing import Self
     else:
         from typing_extensions import Self
+
+    _T = TypeVar("_T")
+
+    class _FromMappingProtocol(Protocol):  # pragma: no cover
+        @classmethod
+        def _from_dict(cls, d: Mapping[str, Any]) -> Self: ...
+
+    _FromMappingProtocolT = TypeVar("_FromMappingProtocolT", bound=_FromMappingProtocol)
 
 __all__ = [
     "ArchiveInfo",
@@ -26,17 +35,6 @@ __all__ = [
 
 def __dir__() -> list[str]:
     return __all__
-
-
-_T = TypeVar("_T")
-
-
-class _FromMappingProtocol(Protocol):  # pragma: no cover
-    @classmethod
-    def _from_dict(cls, d: Mapping[str, Any]) -> Self: ...
-
-
-_FromMappingProtocolT = TypeVar("_FromMappingProtocolT", bound=_FromMappingProtocol)
 
 
 def _json_dict_factory(data: list[tuple[str, Any]]) -> dict[str, Any]:

--- a/src/packaging/errors.py
+++ b/src/packaging/errors.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 import contextlib
 import dataclasses
 import sys
-import typing
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    import typing
 
 __all__ = ["ExceptionGroup"]
 

--- a/src/packaging/markers.py
+++ b/src/packaging/markers.py
@@ -9,7 +9,7 @@ import os
 import platform
 import sys
 from collections.abc import Set as AbstractSet
-from typing import TYPE_CHECKING, Callable, Literal, TypedDict, Union, cast
+from typing import Callable, Literal, TypedDict, Union, cast
 
 from ._parser import MarkerAtom, MarkerList, Op, Value, Variable
 from ._parser import parse_marker as _parse_marker
@@ -17,6 +17,7 @@ from ._tokenizer import ParserSyntaxError
 from .specifiers import InvalidSpecifier, Specifier
 from .utils import canonicalize_name
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
     from collections.abc import Mapping
 

--- a/src/packaging/metadata.py
+++ b/src/packaging/metadata.py
@@ -20,7 +20,8 @@ from . import licenses, requirements, specifiers, utils
 from . import version as version_module
 from .errors import ExceptionGroup, _ErrorCollector
 
-if typing.TYPE_CHECKING:
+TYPE_CHECKING = False
+if TYPE_CHECKING:
     from .licenses import NormalizedLicenseExpression
 
 T = typing.TypeVar("T")

--- a/src/packaging/pylock.py
+++ b/src/packaging/pylock.py
@@ -7,7 +7,6 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime
 from typing import (
-    TYPE_CHECKING,
     Any,
     Callable,
     Protocol,
@@ -32,6 +31,7 @@ from .utils import (
 )
 from .version import Version
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:  # pragma: no cover
     from collections.abc import Collection, Iterator
     from pathlib import Path

--- a/src/packaging/requirements.py
+++ b/src/packaging/requirements.py
@@ -3,14 +3,13 @@
 # for complete details.
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 from ._parser import parse_requirement as _parse_requirement
 from ._tokenizer import ParserSyntaxError
 from .markers import Marker, _normalize_extra_values
 from .specifiers import SpecifierSet
 from .utils import canonicalize_name
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
     from collections.abc import Iterator
 

--- a/src/packaging/specifiers.py
+++ b/src/packaging/specifiers.py
@@ -12,10 +12,8 @@ from __future__ import annotations
 
 import abc
 import re
-import sys
 import typing
 from typing import (
-    TYPE_CHECKING,
     Any,
     Callable,
     Final,
@@ -35,13 +33,15 @@ from ._ranges import (
 from .utils import canonicalize_version
 from .version import InvalidVersion, Version
 
-if sys.version_info >= (3, 10):
-    from typing import TypeGuard  # pragma: no cover
-elif TYPE_CHECKING:
-    from typing_extensions import TypeGuard
-
+TYPE_CHECKING = False
 if TYPE_CHECKING:
+    import sys
     from collections.abc import Iterable, Iterator, Sequence
+
+    if sys.version_info >= (3, 10):
+        from typing import TypeGuard  # pragma: no cover
+    elif TYPE_CHECKING:
+        from typing_extensions import TypeGuard
 
     from ._ranges import VersionRange
 

--- a/src/packaging/tags.py
+++ b/src/packaging/tags.py
@@ -14,14 +14,11 @@ import sys
 import sysconfig
 from collections.abc import Iterable, Iterator, Sequence
 from importlib.machinery import EXTENSION_SUFFIXES
-from typing import (
-    TYPE_CHECKING,
-    TypeVar,
-    cast,
-)
+from typing import TypeVar, cast
 
 from . import _manylinux, _musllinux
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
     from collections.abc import Callable
     from collections.abc import Set as AbstractSet

--- a/src/packaging/version.py
+++ b/src/packaging/version.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 
 import re
 import sys
-import typing
 from typing import (
     Any,
     Callable,
@@ -22,12 +21,13 @@ from typing import (
     Union,
 )
 
-if typing.TYPE_CHECKING:
+TYPE_CHECKING = False
+if TYPE_CHECKING:
     from typing_extensions import Self, Unpack
 
 if sys.version_info >= (3, 13):  # pragma: no cover
     from warnings import deprecated as _deprecated
-elif typing.TYPE_CHECKING:
+elif TYPE_CHECKING:
     from typing_extensions import deprecated as _deprecated
 else:  # pragma: no cover
     import functools
@@ -137,7 +137,7 @@ class _BaseVersion:
     # This can also be a normal member (see the packaging_legacy package);
     # we are just requiring it to be readable. Actually defining a property
     # has runtime effect on subclasses, so it's typing only.
-    if typing.TYPE_CHECKING:
+    if TYPE_CHECKING:
 
         @property
         def _key(self) -> tuple[Any, ...]: ...

--- a/tests/property/test_specifier_extended.py
+++ b/tests/property/test_specifier_extended.py
@@ -4,8 +4,6 @@
 
 from __future__ import annotations
 
-import typing
-
 import pytest
 from hypothesis import assume, given
 from hypothesis import strategies as st
@@ -20,7 +18,8 @@ from tests.property.strategies import (
     specifier_sets,
 )
 
-if typing.TYPE_CHECKING:
+TYPE_CHECKING = False
+if TYPE_CHECKING:
     from packaging.version import Version
 
 pytestmark = pytest.mark.property

--- a/tests/test_dependency_groups.py
+++ b/tests/test_dependency_groups.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 
 import re
-import sys
 import unittest.mock
-from typing import Any
 
 import pytest
 
@@ -18,12 +16,17 @@ from packaging.dependency_groups import (
 from packaging.errors import ExceptionGroup
 from packaging.requirements import Requirement
 
-if sys.version_info >= (3, 10):
-    from typing import TypeAlias
-else:
-    from typing_extensions import TypeAlias
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    import sys
+    from typing import Any
 
-GroupsTable: TypeAlias = "dict[str, list[str | dict[str, str]]]"
+    if sys.version_info >= (3, 10):
+        from typing import TypeAlias
+    else:
+        from typing_extensions import TypeAlias
+
+    GroupsTable: TypeAlias = "dict[str, list[str | dict[str, str]]]"
 
 
 def _group_contains(

--- a/tests/test_manylinux.py
+++ b/tests/test_manylinux.py
@@ -12,9 +12,6 @@ import sys
 import types
 import typing
 
-if typing.TYPE_CHECKING:
-    from collections.abc import Generator
-
 import pretend
 import pytest
 
@@ -29,6 +26,10 @@ from packaging._manylinux import (
     _parse_elf,
     _parse_glibc_version,
 )
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Generator
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -4,14 +4,14 @@ import email
 import inspect
 import pathlib
 import textwrap
-import typing
 
 import pytest
 
 from packaging import metadata, requirements, specifiers, utils, version
 from packaging.errors import ExceptionGroup
 
-if typing.TYPE_CHECKING:
+TYPE_CHECKING = False
+if TYPE_CHECKING:
     from packaging.metadata import RawMetadata
 
 

--- a/tests/test_musllinux.py
+++ b/tests/test_musllinux.py
@@ -10,7 +10,8 @@ import pytest
 from packaging import _musllinux
 from packaging._musllinux import _get_musl_version, _MuslVersion, _parse_musl_version
 
-if typing.TYPE_CHECKING:
+TYPE_CHECKING = False
+if TYPE_CHECKING:
     from collections.abc import Generator
 
 

--- a/tests/test_pylock_select.py
+++ b/tests/test_pylock_select.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import dataclasses
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING, cast
+from typing import cast
 
 import pytest
 
@@ -27,6 +27,7 @@ if sys.version_info >= (3, 11):
 else:
     import tomli as tomllib
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
     from packaging.markers import Environment
     from packaging.utils import NormalizedName

--- a/tests/test_specifiers.py
+++ b/tests/test_specifiers.py
@@ -18,7 +18,8 @@ from packaging.version import Version, parse
 
 from .test_version import VERSIONS
 
-if typing.TYPE_CHECKING:
+TYPE_CHECKING = False
+if TYPE_CHECKING:
     from collections.abc import Callable
 
 LEGACY_SPECIFIERS = [

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -28,7 +28,8 @@ from packaging import tags
 from packaging._manylinux import _GLibCVersion
 from packaging._musllinux import _MuslVersion
 
-if typing.TYPE_CHECKING:
+TYPE_CHECKING = False
+if TYPE_CHECKING:
     from collections.abc import Callable
 
 

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -22,7 +22,8 @@ from packaging.version import (
     parse,
 )
 
-if typing.TYPE_CHECKING:
+TYPE_CHECKING = False
+if TYPE_CHECKING:
     from collections.abc import Callable
 
     from typing_extensions import Self, Unpack


### PR DESCRIPTION
Using `TYPE_CHECKING=False` rather than importing it allows not to import typing altogether which can help with import time.
This PR forbids the use of `typing.TYPE_CHECKING` to ensure `typing` will not be imported if unneeded.
