### PR TITLE
Enable nitpicky mode for the docs build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -88,6 +88,13 @@ autodoc_typehints = "description"
 # Don't show class signature with the class' name.
 autodoc_class_signature = "separated"
 
+# Rewrite bare ``Path`` in rendered annotations to the stdlib target so
+# intersphinx resolves it (annotations are strings under
+# ``from __future__ import annotations``).
+autodoc_type_aliases = {
+    "Path": "pathlib.Path",
+}
+
 # -- Options for extlinks -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/extensions/extlinks.html#configuration
 
@@ -103,3 +110,22 @@ intersphinx_mapping = {
     "python": ("https://docs.python.org/3/", None),
     "pypug": ("https://packaging.python.org/", None),
 }
+
+# -- Options for nitpicky mode ------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-nitpick_ignore
+
+# Built with ``-n`` so unresolved cross-references fail the build. These
+# targets have no documentation page on purpose, so they are allowed to
+# stay unresolved: private internal types, and TypeVars / type aliases the
+# Python domain cannot resolve as classes.
+nitpick_ignore = [
+    ("py:class", "packaging.version._BaseVersion"),
+    ("py:class", "_Validator"),
+    ("py:class", "_MetadataVersion"),
+    ("py:class", "_VersionReplace"),
+    ("py:class", "T"),
+    ("py:class", "_T"),
+    ("py:class", "packaging.specifiers.T"),
+    ("py:class", "UnparsedVersion"),
+    ("py:class", "UnparsedVersionVar"),
+]

--- a/docs/markers.rst
+++ b/docs/markers.rst
@@ -1,6 +1,8 @@
 Markers
 =======
 
+.. currentmodule:: packaging.markers
+
 One extra requirement of dealing with dependencies is the ability to specify
 if it is required depending on the operating system or Python version in use.
 The :ref:`specification of dependency specifiers <pypug:dependency-specifiers>`

--- a/docs/metadata.rst
+++ b/docs/metadata.rst
@@ -51,6 +51,8 @@ Low Level Interface
 
 .. autofunction:: packaging.metadata.parse_email
 
+.. autoclass:: packaging.metadata.RFC822Message
+
 
 Exceptions
 ''''''''''

--- a/docs/tags.rst
+++ b/docs/tags.rst
@@ -48,6 +48,8 @@ items that applications should need to reference, in order to parse and check ta
 
 .. autofunction:: create_compatible_tags_selector
 
+.. autoexception:: UnsortedTagsError
+
 
 
 Low Level Interface

--- a/noxfile.py
+++ b/noxfile.py
@@ -214,6 +214,7 @@ def docs(session: nox.Session) -> None:
         session.run(
             "sphinx-build",
             "-W",
+            "-n",
             "-b",
             builder,
             "-d",

--- a/src/packaging/metadata.py
+++ b/src/packaging/metadata.py
@@ -22,6 +22,7 @@ from .errors import ExceptionGroup, _ErrorCollector
 
 if typing.TYPE_CHECKING:
     from .licenses import NormalizedLicenseExpression
+    from .version import Version
 
 T = typing.TypeVar("T")
 
@@ -597,7 +598,7 @@ class _Validator(Generic[T]):
         else:
             return value
 
-    def _process_version(self, value: str) -> version_module.Version:
+    def _process_version(self, value: str) -> Version:
         if not value:
             raise self._invalid_metadata("{field} is a required field")
         try:
@@ -853,7 +854,7 @@ class Metadata:
     """:external:ref:`core-metadata-name`
     (required; validated using :func:`~packaging.utils.canonicalize_name` and its
     *validate* parameter)"""
-    version: _Validator[version_module.Version] = _Validator()
+    version: _Validator[Version] = _Validator()
     """:external:ref:`core-metadata-version` (required)"""
     dynamic: _Validator[list[str] | None] = _Validator(
         added="2.2",

--- a/src/packaging/specifiers.py
+++ b/src/packaging/specifiers.py
@@ -625,7 +625,7 @@ class Specifier(BaseSpecifier):
 
         :param item:
             The item to check for, which can be a version string or a
-            :class:`Version` instance.
+            :class:`~packaging.version.Version` instance.
         :param prereleases:
             Whether or not to match prereleases with this Specifier. If set to
             ``None`` (the default), it will follow the recommendation from
@@ -694,16 +694,17 @@ class Specifier(BaseSpecifier):
         """Filter items in the given iterable, that match the specifier.
 
         :param iterable:
-            An iterable that can contain version strings and :class:`Version` instances.
-            The items in the iterable will be filtered according to the specifier.
+            An iterable that can contain version strings and
+            :class:`~packaging.version.Version` instances. The items in the
+            iterable will be filtered according to the specifier.
         :param prereleases:
             Whether or not to allow prereleases in the returned iterator. If set to
             ``None`` (the default), it will follow the recommendation from :pep:`440`
             and match prereleases if there are no other versions.
         :param key:
             A callable that takes a single argument (an item from the iterable) and
-            returns a version string or :class:`Version` instance to be used for
-            filtering.
+            returns a version string or :class:`~packaging.version.Version`
+            instance to be used for filtering.
 
         >>> list(Specifier(">=1.2.3").filter(["1.2", "1.3", "1.5a1"]))
         ['1.3']
@@ -1168,7 +1169,7 @@ class SpecifierSet(BaseSpecifier):
 
         :param item:
             The item to check for, which can be a version string or a
-            :class:`Version` instance.
+            :class:`~packaging.version.Version` instance.
         :param prereleases:
             Whether or not to match prereleases with this SpecifierSet. If set to
             ``None`` (the default), it will follow the recommendation from :pep:`440`
@@ -1255,16 +1256,17 @@ class SpecifierSet(BaseSpecifier):
         """Filter items in the given iterable, that match the specifiers in this set.
 
         :param iterable:
-            An iterable that can contain version strings and :class:`Version` instances.
-            The items in the iterable will be filtered according to the specifier.
+            An iterable that can contain version strings and
+            :class:`~packaging.version.Version` instances. The items in the
+            iterable will be filtered according to the specifier.
         :param prereleases:
             Whether or not to allow prereleases in the returned iterator. If set to
             ``None`` (the default), it will follow the recommendation from :pep:`440`
             and match prereleases if there are no other versions.
         :param key:
             A callable that takes a single argument (an item from the iterable) and
-            returns a version string or :class:`Version` instance to be used for
-            filtering.
+            returns a version string or :class:`~packaging.version.Version`
+            instance to be used for filtering.
 
         >>> list(SpecifierSet(">=1.2.3").filter(["1.2", "1.3", "1.5a1"]))
         ['1.3']


### PR DESCRIPTION
The docs build already runs with `-W`, but Sphinx renders unresolved cross-references as plain text rather than failing unless nitpicky mode is on. This adds `-n` so dead links fail the build in CI instead of shipping silently.

Turning it on flagged some genuinely broken references, which are fixed here: `markers.rst` was the only API page missing the `currentmodule` directive, `UnsortedTagsError` and `RFC822Message` are public but were never documented, a bare `Path` annotation in `pylock.py` had no target, and a few `Version` references in the specifier docstrings weren't qualified. The `Metadata.version` annotation rendered as `version_module.Version` because `metadata.py` imported the version module under an alias, so this imports the `Version` class directly and lets it link to `packaging.version.Version`.

Everything left has no documentation page on purpose, so it goes in `nitpick_ignore`: private helpers like `_Validator`, and TypeVars and aliases such as `T` and `UnparsedVersion` that the Python domain can't resolve as classes. They're listed by name rather than matched with a broad pattern, so a new missing reference still fails the build.
