### PR TITLE
fix: add missing TYPE_CHECKING guard in tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,6 +35,7 @@ repos:
           - tomli
           - tomli_w
           - types-invoke
+          - 'typing_extensions>=4.5'
           - httpx
 
   - repo: https://github.com/crate-ci/typos

--- a/src/packaging/specifiers.py
+++ b/src/packaging/specifiers.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 
 import abc
 import re
-import sys
 import typing
 from typing import (
     TYPE_CHECKING,
@@ -35,13 +34,14 @@ from ._ranges import (
 from .utils import canonicalize_version
 from .version import InvalidVersion, Version
 
-if sys.version_info >= (3, 10):
-    from typing import TypeGuard  # pragma: no cover
-elif TYPE_CHECKING:
-    from typing_extensions import TypeGuard
-
 if TYPE_CHECKING:
+    import sys
     from collections.abc import Iterable, Iterator, Sequence
+
+    if sys.version_info >= (3, 10):
+        from typing import TypeGuard
+    else:
+        from typing_extensions import TypeGuard
 
     from ._ranges import VersionRange
 

--- a/tests/test_dependency_groups.py
+++ b/tests/test_dependency_groups.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
 import re
-import sys
 import unittest.mock
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
@@ -18,12 +17,15 @@ from packaging.dependency_groups import (
 from packaging.errors import ExceptionGroup
 from packaging.requirements import Requirement
 
-if sys.version_info >= (3, 10):
-    from typing import TypeAlias
-else:
-    from typing_extensions import TypeAlias
+if TYPE_CHECKING:
+    import sys
 
-GroupsTable: TypeAlias = "dict[str, list[str | dict[str, str]]]"
+    if sys.version_info >= (3, 10):
+        from typing import TypeAlias
+    else:
+        from typing_extensions import TypeAlias
+
+    GroupsTable: TypeAlias = "dict[str, list[str | dict[str, str]]]"
 
 
 def _group_contains(


### PR DESCRIPTION
`typing_extensions` is not part of the test dependency group.
When re-using an existing environment for Python 3.9 tests (default with the current noxfile), tests might fail at collection time because of the missing `typing_extensions` module. I did run into this.

When looking at all `typing_extensions` usage, `TypeGuard` import at runtime depended on the Python version so moved the whole block under the `if TYPE_CHECKING:` block for consistency.