### PR TITLE
docs(pylock): import is_valid_pylock_path in usage example

### DIFF
--- a/docs/pylock.rst
+++ b/docs/pylock.rst
@@ -13,7 +13,7 @@ Usage
     import tomllib
     from pathlib import Path
 
-    from packaging.pylock import Package, PackageWheel, Pylock
+    from packaging.pylock import Package, PackageWheel, Pylock, is_valid_pylock_path
     from packaging.utils import NormalizedName
     from packaging.version import Version
 


### PR DESCRIPTION
The usage example in `docs/pylock.rst` calls `is_valid_pylock_path()` but never imports it, so copy-pasting the example raises `NameError`. Add it to the existing `from packaging.pylock import ...` line.