### PR TITLE
docs(errors): import sys in ExceptionGroup recommended-usage example

### DIFF
--- a/docs/errors.rst
+++ b/docs/errors.rst
@@ -13,6 +13,8 @@ Recommended Usage
 
 .. code-block:: python
 
+   import sys
+
    if sys.version_info < (3, 11):
        from packaging.errors import ExceptionGroup
 


### PR DESCRIPTION
The "Recommended Usage" block in `docs/errors.rst` calls `sys.version_info` but never imports `sys`, so copy-pasting it raises `NameError`. Add `import sys`.