### PR TITLE
docs(tags): fix versionchanged for abi3t (27.0 -> 26.1)

### DIFF
--- a/src/packaging/tags.py
+++ b/src/packaging/tags.py
@@ -864,7 +864,7 @@ def sys_tags(*, warn: bool = False) -> Iterator[Tag]:
 
     .. versionchanged:: 21.3
         Added the `pp3-none-any` tag (:issue:`311`).
-    .. versionchanged:: 27.0
+    .. versionchanged:: 26.1
         Added the `abi3t` tag (:issue:`1099`).
     """
 


### PR DESCRIPTION
`sys_tags()` docstring (`src/packaging/tags.py:867`) says abi3t was added in 27.0, but it actually shipped in 26.1 — `CHANGELOG.rst` lists #1099 under `26.1 - 2026-04-14`, and current `__version__` is `26.3.dev0` (no 27.0 has been released).