### PR TITLE
fix(pylock): add PylockSelectError to __all__

### DIFF
--- a/src/packaging/pylock.py
+++ b/src/packaging/pylock.py
@@ -50,6 +50,7 @@ __all__ = [
     "PackageVcs",
     "PackageWheel",
     "Pylock",
+    "PylockSelectError",
     "PylockUnsupportedVersionError",
     "PylockValidationError",
     "is_valid_pylock_path",


### PR DESCRIPTION
`PylockSelectError` is defined in `src/packaging/pylock.py:313` (base exception for `Pylock.select` errors with `_DefaultSelectionError`, `_AmbiguousMatchError`, `_NoMatchError` subclasses) and is publicly documented in `docs/pylock.rst` (`.. autoexception:: PylockSelectError`, alongside the other Pylock exceptions). Its sibling base exceptions are both already in `packaging.pylock.__all__`:

- `PylockValidationError` — base, has subclass `_PylockRequiredKeyError`, also subclassed by `PylockUnsupportedVersionError`
- `PylockUnsupportedVersionError` — derives from `PylockValidationError`

Adding `"PylockSelectError"` to `__all__` (alphabetically between `Pylock` and `PylockUnsupportedVersionError`) makes the export surface consistent with the docs and with the established sibling pattern: documented base exceptions go in `__all__`. Star-imports (`from packaging.pylock import *`) then expose the three Pylock exceptions uniformly, and downstream introspection (type-stub generation, doc tooling, error-handler scaffolds) sees a uniform shape.

Single-line change. No behavioral change.
