### PR TITLE
docs(tags): add `.. versionadded:: 26.1` to UnsortedTagsError docstring

### DIFF
--- a/src/packaging/tags.py
+++ b/src/packaging/tags.py
@@ -79,6 +79,8 @@ _32_BIT_INTERPRETER = _compute_32_bit_interpreter()
 class UnsortedTagsError(ValueError):
     """
     Raised when a tag component is not in sorted order per PEP 425.
+
+    .. versionadded:: 26.1
     """
 
 


### PR DESCRIPTION
`UnsortedTagsError` is public (in `__all__`) and was added in 26.1, but its docstring lacks the `.. versionadded:: 26.1` directive that its 26.1 siblings carry (`parse_tag`'s `validate_order` param, `create_compatible_tags_selector`). #1196 added `.. autoexception:: UnsortedTagsError`, so the bare docstring now renders on the API page next to those siblings. This adds the directive for consistency.