### PR TITLE
docs: add `.. versionadded:: 26.1` to remaining 26.1 public API

### DIFF
--- a/src/packaging/pylock.py
+++ b/src/packaging/pylock.py
@@ -312,7 +312,10 @@ class PylockUnsupportedVersionError(PylockValidationError):
 
 
 class PylockSelectError(Exception):
-    """Base exception for errors raised by :meth:`Pylock.select`."""
+    """Base exception for errors raised by :meth:`Pylock.select`.
+
+    .. versionadded:: 26.1
+    """
 
 
 @dataclass(frozen=True, init=False)
@@ -767,6 +770,8 @@ class Pylock:
         This method must be used on valid Pylock instances (i.e. one obtained
         from :meth:`Pylock.from_dict` or if constructed manually, after calling
         :meth:`Pylock.validate`).
+
+        .. versionadded:: 26.1
         """
         compatible_tags_selector = create_compatible_tags_selector(tags or sys_tags())
 

--- a/src/packaging/specifiers.py
+++ b/src/packaging/specifiers.py
@@ -1079,6 +1079,8 @@ class SpecifierSet(BaseSpecifier):
         False
         >>> SpecifierSet("==1.0,!=1.0").is_unsatisfiable()
         True
+
+        .. versionadded:: 26.1
         """
         cached = self._is_unsatisfiable
         if cached is not None:


### PR DESCRIPTION
The 26.1 public additions `SpecifierSet.is_unsatisfiable` (#1119), `Pylock.select` (#1092), and `PylockSelectError` (#1153) lack the `.. versionadded:: 26.1` directive their 26.1 peers carry (e.g. `UnsortedTagsError`, `create_compatible_tags_selector`). Completes the coverage.
