### PR TITLE
docs(requirements): mirror `.. versionchanged:: 26.3` into requirements.rst

### DIFF
--- a/docs/requirements.rst
+++ b/docs/requirements.rst
@@ -83,6 +83,11 @@ Reference
         from packaging < 26.2 is supported but may be removed in a future
         release.
 
+    .. versionchanged:: 26.3
+
+        The specifier's explicit :attr:`~packaging.specifiers.SpecifierSet.prereleases`
+        override is now preserved across a pickle round trip.
+
     :param str requirement: The string representation of a requirement.
     :raises InvalidRequirement: If the given ``requirement`` is not parseable,
                                 then this exception will be raised.

--- a/docs/requirements.rst
+++ b/docs/requirements.rst
@@ -85,8 +85,9 @@ Reference
 
     .. versionchanged:: 26.3
 
-        The specifier's explicit :attr:`~packaging.specifiers.SpecifierSet.prereleases`
-        override is now preserved across a pickle round trip.
+        The dedicated pickle support introduced in 26.2 did not preserve the
+        specifier's explicit :attr:`~packaging.specifiers.SpecifierSet.prereleases`
+        override; it is now included again.
 
     :param str requirement: The string representation of a requirement.
     :raises InvalidRequirement: If the given ``requirement`` is not parseable,

--- a/src/packaging/requirements.py
+++ b/src/packaging/requirements.py
@@ -49,8 +49,9 @@ class Requirement:
 
     .. versionchanged:: 26.3
 
-        The specifier's explicit :attr:`~packaging.specifiers.SpecifierSet.prereleases`
-        override is now preserved across a pickle round trip.
+        The dedicated pickle support introduced in 26.2 did not preserve the
+        specifier's explicit :attr:`~packaging.specifiers.SpecifierSet.prereleases`
+        override; it is now included again.
     """
 
     # TODO: Can we test whether something is contained within a requirement?


### PR DESCRIPTION
The `Requirement` docstring gained a `.. versionchanged:: 26.3` note in #1206, but the hand-written `docs/requirements.rst` reference (which mirrors the docstring's versionchanged blocks — 26.2 is present) wasn't synced. This adds the matching 26.3 block.