### PR TITLE
docs: add `.. versionadded:: 26.1` to the new direct_url and dependency_groups modules

### DIFF
--- a/src/packaging/dependency_groups.py
+++ b/src/packaging/dependency_groups.py
@@ -28,12 +28,16 @@ def __dir__() -> list[str]:
 class DuplicateGroupNames(ValueError):
     """
     The same dependency groups were defined twice, with different non-normalized names.
+
+    .. versionadded:: 26.1
     """
 
 
 class CyclicDependencyGroup(ValueError):
     """
     The dependency group includes form a cycle.
+
+    .. versionadded:: 26.1
     """
 
     def __init__(self, requested_group: str, group: str, include_group: str) -> None:
@@ -58,6 +62,8 @@ class InvalidDependencyGroupObject(ValueError):
     """
     A member of a dependency group was identified as a dict, but was not in a valid
     format.
+
+    .. versionadded:: 26.1
     """
 
 
@@ -91,6 +97,8 @@ class DependencyGroupResolver:
 
     :param dependency_groups: A mapping, as provided via pyproject
         ``[dependency-groups]``.
+
+    .. versionadded:: 26.1
     """
 
     def __init__(
@@ -261,6 +269,8 @@ def resolve_dependency_groups(
     :param dependency_groups: the parsed contents of the ``[dependency-groups]`` table
         from ``pyproject.toml``
     :param groups: the name of the group(s) to resolve
+
+    .. versionadded:: 26.1
     """
     resolver = DependencyGroupResolver(dependency_groups)
     return tuple(str(r) for group in groups for r in resolver.resolve(group))

--- a/src/packaging/direct_url.py
+++ b/src/packaging/direct_url.py
@@ -110,7 +110,10 @@ def _strip_url(url: str, safe_user_passwords: Collection[str]) -> str:
 
 
 class DirectUrlValidationError(Exception):
-    """Raised when when input data is not spec-compliant."""
+    """Raised when when input data is not spec-compliant.
+
+    .. versionadded:: 26.1
+    """
 
     context: str | None = None
     message: str
@@ -237,7 +240,10 @@ class DirInfo:
 
 @dataclasses.dataclass(frozen=True, init=False)
 class DirectUrl:
-    """A class representing a direct URL."""
+    """A class representing a direct URL.
+
+    .. versionadded:: 26.1
+    """
 
     url: str
     archive_info: ArchiveInfo | None = None


### PR DESCRIPTION
`packaging.direct_url` (#944) and `packaging.dependency_groups` (#1065) were added in 26.1, but their public API carries no `.. versionadded::` directive — unlike the rest of the 26.1 surface after #1207. This adds it to the docstring-bearing autodoc'd symbols in both modules.