### PR TITLE
Validate pylock URL fields

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Fixes:
 
 * Preserve a ``Requirement``'s specifier ``prereleases`` override across a
   pickle round trip. (:issue:`1204`)
+* Validate URL fields when parsing ``pylock.toml`` data. (:issue:`1185`)
 
 26.2 - 2026-04-24
 ~~~~~~~~~~~~~~~~~

--- a/src/packaging/pylock.py
+++ b/src/packaging/pylock.py
@@ -244,6 +244,12 @@ def _validate_path_url(path: str | None, url: str | None) -> None:
         raise PylockValidationError("path or url must be provided")
 
 
+def _validate_url(url: str) -> str:
+    if not urlparse(url).scheme:
+        raise PylockValidationError(f"URL {url!r} is missing a scheme")
+    return url
+
+
 def _path_name(path: str | None) -> str | None:
     if not path:
         return None
@@ -349,7 +355,7 @@ class PackageVcs:
     def _from_dict(cls, d: Mapping[str, Any]) -> Self:
         package_vcs = cls(
             type=_get_required(d, str, "type"),
-            url=_get(d, str, "url"),
+            url=_get_as(d, str, _validate_url, "url"),
             path=_get(d, str, "path"),
             requested_revision=_get(d, str, "requested-revision"),
             commit_id=_get_required(d, str, "commit-id"),
@@ -416,7 +422,7 @@ class PackageArchive:
     @classmethod
     def _from_dict(cls, d: Mapping[str, Any]) -> Self:
         package_archive = cls(
-            url=_get(d, str, "url"),
+            url=_get_as(d, str, _validate_url, "url"),
             path=_get(d, str, "path"),
             size=_get(d, int, "size"),
             upload_time=_get(d, datetime, "upload-time"),
@@ -459,7 +465,7 @@ class PackageSdist:
         package_sdist = cls(
             name=_get(d, str, "name"),
             upload_time=_get(d, datetime, "upload-time"),
-            url=_get(d, str, "url"),
+            url=_get_as(d, str, _validate_url, "url"),
             path=_get(d, str, "path"),
             size=_get(d, int, "size"),
             hashes=_get_required_as(d, Mapping, _validate_hashes, "hashes"),  # type: ignore[type-abstract]
@@ -508,7 +514,7 @@ class PackageWheel:
         package_wheel = cls(
             name=_get(d, str, "name"),
             upload_time=_get(d, datetime, "upload-time"),
-            url=_get(d, str, "url"),
+            url=_get_as(d, str, _validate_url, "url"),
             path=_get(d, str, "path"),
             size=_get(d, int, "size"),
             hashes=_get_required_as(d, Mapping, _validate_hashes, "hashes"),  # type: ignore[type-abstract]
@@ -584,7 +590,7 @@ class Package:
             vcs=_get_object(d, PackageVcs, "vcs"),
             directory=_get_object(d, PackageDirectory, "directory"),
             archive=_get_object(d, PackageArchive, "archive"),
-            index=_get(d, str, "index"),
+            index=_get_as(d, str, _validate_url, "index"),
             sdist=_get_object(d, PackageSdist, "sdist"),
             wheels=_get_sequence_of_objects(d, PackageWheel, "wheels"),
             attestation_identities=_get_sequence(d, Mapping, "attestation-identities"),  # type: ignore[type-abstract]

--- a/tests/test_pylock.py
+++ b/tests/test_pylock.py
@@ -282,6 +282,83 @@ def test_pylock_invalid_vcs() -> None:
 
 
 @pytest.mark.parametrize(
+    ("package_data", "expected_context"),
+    [
+        (
+            {
+                "name": "example",
+                "index": "not-a-url",
+                "wheels": [
+                    {
+                        "name": "example-1.0-py3-none-any.whl",
+                        "url": "https://example.com/example-1.0-py3-none-any.whl",
+                        "hashes": {"sha256": "f" * 40},
+                    }
+                ],
+            },
+            "packages[0].index",
+        ),
+        (
+            {
+                "name": "example",
+                "vcs": {
+                    "type": "git",
+                    "url": "not-a-url",
+                    "commit-id": "f" * 40,
+                },
+            },
+            "packages[0].vcs.url",
+        ),
+        (
+            {
+                "name": "example",
+                "archive": {
+                    "url": "not-a-url",
+                    "hashes": {"sha256": "f" * 40},
+                },
+            },
+            "packages[0].archive.url",
+        ),
+        (
+            {
+                "name": "example",
+                "sdist": {
+                    "url": "not-a-url",
+                    "hashes": {"sha256": "f" * 40},
+                },
+            },
+            "packages[0].sdist.url",
+        ),
+        (
+            {
+                "name": "example",
+                "wheels": [
+                    {
+                        "url": "not-a-url",
+                        "hashes": {"sha256": "f" * 40},
+                    }
+                ],
+            },
+            "packages[0].wheels[0].url",
+        ),
+    ],
+)
+def test_pylock_invalid_url_fields(
+    package_data: dict[str, Any], expected_context: str
+) -> None:
+    data = {
+        "lock-version": "1.0",
+        "created-by": "pip",
+        "packages": [package_data],
+    }
+    with pytest.raises(PylockValidationError) as exc_info:
+        Pylock.from_dict(data)
+    assert str(exc_info.value) == (
+        f"URL 'not-a-url' is missing a scheme in {expected_context!r}"
+    )
+
+
+@pytest.mark.parametrize(
     ("dist", "expected_filename"),
     [
         # sdists


### PR DESCRIPTION
Closes #1185.

This validates `pylock.toml` URL fields while parsing, including `packages.index` and package artifact/source URLs. URL values without a scheme are rejected; relative `path` fields keep their existing behavior.

Regression coverage covers `packages.index`, `vcs.url`, `archive.url`, `sdist.url`, and `wheels.url`.

Tests:
- `pytest tests/test_pylock.py -q`
- `pytest tests/test_pylock_select.py -q`
- `pytest -q`
- `ruff check src/packaging/pylock.py tests/test_pylock.py`
- `ruff format --check src/packaging/pylock.py tests/test_pylock.py`
