### PR TITLE
docs(specifiers): note the `key` filter parameter was added in 26.1

### DIFF
--- a/src/packaging/specifiers.py
+++ b/src/packaging/specifiers.py
@@ -720,6 +720,10 @@ class Specifier(BaseSpecifier):
         ... [{"ver": "1.2"}, {"ver": "1.3"}],
         ... key=lambda x: x["ver"]))
         [{'ver': '1.3'}]
+
+        .. versionchanged:: 26.1
+
+            Added the ``key`` parameter.
         """
         if prereleases is None:
             if self._prereleases is not None:
@@ -1296,6 +1300,10 @@ class SpecifierSet(BaseSpecifier):
         ['1.3', '1.5a1']
         >>> list(SpecifierSet("").filter(["1.3", "1.5a1"], prereleases=True))
         ['1.3', '1.5a1']
+
+        .. versionchanged:: 26.1
+
+            Added the ``key`` parameter.
         """
         # Determine if we're forcing a prerelease or not, if we're not forcing
         # one for this particular filter call, then we'll use whatever the


### PR DESCRIPTION
The `key=` argument to `Specifier.filter()` / `SpecifierSet.filter()` shipped in 26.1 (#1068) and is documented (`:param key:` + a worked example) but carries no version directive. The recent #1207 errata sweep added `.. versionadded:: 26.1` to `is_unsatisfiable` in this same file; this adds the matching `.. versionchanged:: 26.1` for the `key` parameter on both `filter()` methods.

`versionchanged` (not `versionadded`) since `filter()` itself is years old — only the `key` parameter is new in 26.1.
