### PR TITLE
docs(errors): reference the stdlib `ExceptionGroup` via `:external:exc:`

### DIFF
--- a/docs/errors.rst
+++ b/docs/errors.rst
@@ -4,7 +4,7 @@ Errors
 Error classes and error-handling helpers used by the packaging library.
 
 Currently this contains :class:`~packaging.errors.ExceptionGroup`, a simple
-backport of the stdlib :class:`ExceptionGroup`. It is recommended to use
+backport of the stdlib :external:exc:`ExceptionGroup`. It is recommended to use
 the stdlib module on Python 3.11+, but this does reexport that as well.
 
 Recommended Usage
@@ -33,7 +33,7 @@ Reference
 .. py:class:: packaging.errors.ExceptionGroup(message: str, exceptions: list[Exception])
 
    On older Pythons, this is a small fallback implementation of the
-   :class:`ExceptionGroup` introduced in Python 3.11.
+   :external:exc:`ExceptionGroup` introduced in Python 3.11.
 
    :param message: The message for the group.
    :param exceptions: A list of exceptions contained in the group.


### PR DESCRIPTION
Under nitpicky mode (#1196), `docs/errors.rst` refers to the *stdlib* `ExceptionGroup` twice with a bare `` :class:`ExceptionGroup` `` (lines 7 and 36). With no `currentmodule`, those resolve to packaging's own backport class (the page's own `.. py:class::`), not docs.python.org — a circular/wrong target. The module's own docstring already uses the correct `:external:exc:` role (`errors.py:20,22`).

This switches the two stdlib references to `` :external:exc:`ExceptionGroup` ``. The local-class reference on line 6 (`` :class:`~packaging.errors.ExceptionGroup` ``) is intentionally left as-is.
