### PR TITLE
fix: preserve marker quote semantics when serializing values

### DIFF
--- a/src/packaging/_parser.py
+++ b/src/packaging/_parser.py
@@ -68,7 +68,14 @@ class Value(Node):
     __slots__ = ()
 
     def serialize(self) -> str:
-        return f'"{self}"'
+        value = str(self)
+        if '"' not in value:
+            return f'"{value}"'
+        if "'" not in value:
+            return f"'{value}'"
+        raise ValueError(
+            "Cannot serialize marker value containing both quote characters"
+        )
 
 
 class Op(Node):

--- a/tests/test_markers.py
+++ b/tests/test_markers.py
@@ -77,6 +77,26 @@ class TestNode:
         with pytest.raises(NotImplementedError):
             Node("cover all the code").serialize()
 
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            ("plain", '"plain"'),
+            ('a"b', "'a\"b'"),
+            ("a'b", '"a\'b"'),
+        ],
+    )
+    def test_value_serialize_chooses_quote_delimiter(
+        self, value: str, expected: str
+    ) -> None:
+        assert Value(value).serialize() == expected
+
+    def test_value_serialize_rejects_both_quote_delimiters(self) -> None:
+        with pytest.raises(
+            ValueError,
+            match="Cannot serialize marker value containing both quote characters",
+        ):
+            Value("a\"b'c").serialize()
+
 
 class TestOperatorEvaluation:
     def test_prefers_pep440(self) -> None:
@@ -204,6 +224,10 @@ class TestMarker:
             # Test the different quoting rules
             ("python_version == '2.7'", 'python_version == "2.7"'),
             ('python_version == "2.7"', 'python_version == "2.7"'),
+            (
+                '\'a" == os_name or python_version >= "0" or "b\' == os_name',
+                '\'a" == os_name or python_version >= "0" or "b\' == os_name',
+            ),
             # Test and/or expressions
             (
                 'python_version == "2.7" and os_name == "linux"',

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -165,6 +165,18 @@ def test_normalized_requirements(input_req: str, norm_req: str) -> None:
     assert str(req) == norm_req
 
 
+def test_requirement_marker_with_embedded_double_quote_round_trips() -> None:
+    req_string = 'demo; \'a" == os_name or python_version >= "0" or "b\' == os_name'
+    req = Requirement(req_string)
+
+    assert str(req) == req_string
+    assert req.marker is not None
+    assert req.marker.evaluate() is False
+    round_tripped_marker = Requirement(str(req)).marker
+    assert round_tripped_marker is not None
+    assert round_tripped_marker.evaluate() is False
+
+
 class TestRequirementParsing:
     @pytest.mark.parametrize(
         "marker",


### PR DESCRIPTION
Currently, marker values are always serialized with double quotes:

https://github.com/pypa/packaging/blob/0030fb8c17d60f7735d56cf004dbd455defe81d7/src/packaging/_parser.py#L70-L71

This means one could craft a marker that evaluates differently after serialization. For example (note the single quotes from `a` to `b`):
```
test; 'a" == os_name or python_version >= "0" or "b' == os_name
```
which evaluates as false because the left-hand side (`'a...b'`) is one big string literal, becomes:
```
test; "a" == os_name or python_version >= "0" or "b" == os_name
```
which can evaluate to true depending on the environment


This PR restricts serialization so that string literals can contain only one type of quote character (using the other one to serialize the value).

(there might be a more correct fix for this, in any case this PR should be useful to illustrate the issue)

cc @miketheman 
