### PR TITLE
docs(tags): add `.. versionchanged:: 26.3` for native linux_* tag ordering (#160)

### DIFF
--- a/src/packaging/tags.py
+++ b/src/packaging/tags.py
@@ -868,6 +868,9 @@ def sys_tags(*, warn: bool = False) -> Iterator[Tag]:
         Added the `pp3-none-any` tag (:issue:`311`).
     .. versionchanged:: 26.1
         Added the `abi3t` tag (:issue:`1099`).
+    .. versionchanged:: 26.3
+        Native ``linux_*`` platform tags are now ordered before ``manylinux``
+        and ``musllinux`` tags (:issue:`160`).
     """
 
     interp_name = interpreter_name()


### PR DESCRIPTION
`sys_tags()` carries `.. versionchanged::` for the pp3 (21.3) and abi3t (26.1) tag additions but not for the 26.3 native `linux_*` > `manylinux`/`musllinux` ordering change (CHANGELOG unreleased, #160). Adds the directive in the autodoc-rendered docstring, matching the in-flight `requirements.py` 26.3 practice (#1206/#1208).