### PR TITLE
docs: add canonicalize_name version annotations

### DIFF
--- a/src/packaging/utils.py
+++ b/src/packaging/utils.py
@@ -87,6 +87,11 @@ def canonicalize_name(name: str, *, validate: bool = False) -> NormalizedName:
     'oslo-concurrency'
     >>> canonicalize_name("requests")
     'requests'
+
+    .. versionadded:: 16.2
+
+    .. versionchanged:: 20.4
+       The return type was changed to :class:`NormalizedName`.
     """
     if validate and not _validate_regex.fullmatch(name):
         raise InvalidName(f"name is invalid: {name!r}")


### PR DESCRIPTION
Add missing API reference version annotations for `packaging.utils.canonicalize_name`:

- `.. versionadded:: 16.2` for the original PEP 503 canonicalization helper
- `.. versionchanged:: 20.4` for the `NormalizedName` return type

Refs #597.

Verification:

```bash
python -m compileall -q src/packaging
PYTHONPATH=src .venv-docs/bin/sphinx-build -b html -W docs docs/_build/html
```