### PR TITLE
Fix DirectUrl auth stripping with @ in passwords

### DIFF
--- a/src/packaging/direct_url.py
+++ b/src/packaging/direct_url.py
@@ -83,7 +83,7 @@ _PEP610_USER_PASS_ENV_VARS_REGEX = re.compile(
 def _strip_auth_from_netloc(netloc: str, safe_user_passwords: Collection[str]) -> str:
     if "@" not in netloc:
         return netloc
-    user_pass, netloc_no_user_pass = netloc.split("@", 1)
+    user_pass, netloc_no_user_pass = netloc.rsplit("@", 1)
     if user_pass in safe_user_passwords:
         return netloc
     if _PEP610_USER_PASS_ENV_VARS_REGEX.match(user_pass):

--- a/tests/test_direct_url.py
+++ b/tests/test_direct_url.py
@@ -260,6 +260,7 @@ def test_validate_error() -> None:
     [
         ("https://g.c/user/repo.git", ["git"], "https://g.c/user/repo.git"),
         ("https://user:pass@g.c/user/repo.git", ["git"], "https://g.c/user/repo.git"),
+        ("https://user:pa@ss@g.c/user/repo.git", ["git"], "https://g.c/user/repo.git"),
         ("ssh://git@g.c/user/repo.git", [], "ssh://g.c/user/repo.git"),
         ("ssh://git@g.c/user/repo.git", ["git"], "ssh://git@g.c/user/repo.git"),
         ("ssh://cvs@g.c/user/repo.git", ["git"], "ssh://g.c/user/repo.git"),
@@ -293,6 +294,14 @@ def test_strip_url(url: str, safe_user_passwords: list[str], expected_url: str) 
 def test_to_dict_strip_url() -> None:
     direct_url = DirectUrl(
         url="https://user:pass@g.c/user/repo.git",
+        vcs_info=VcsInfo(vcs="git", commit_id="a" * 40),
+    )
+    assert direct_url.to_dict()["url"] == "https://g.c/user/repo.git"
+
+
+def test_to_dict_strip_url_with_at_in_password() -> None:
+    direct_url = DirectUrl(
+        url="https://user:pa@ss@g.c/user/repo.git",
         vcs_info=VcsInfo(vcs="git", commit_id="a" * 40),
     )
     assert direct_url.to_dict()["url"] == "https://g.c/user/repo.git"


### PR DESCRIPTION
When calling `DirectUrl.to_dict()`, the user and password are stripped from the url:
```python
"https://user:pass@example.com/repo.git"
# becomes
"https://example.com/repo.git"
```

However, since it does it by calling `split` on the `@` symbol, this might happen:
```python
"https://user:p@ss@example.com/repo.git"
# becomes
"https://ss@example.com/repo.git"
```

This PR fixes that by calling `rsplit()` instead of `split()`

cc @miketheman 