### PR TITLE
fix: raise correct exception on invalid license

### DIFF
--- a/src/packaging/licenses/__init__.py
+++ b/src/packaging/licenses/__init__.py
@@ -168,10 +168,10 @@ def canonicalize_license_expression(
                 suffix = ""
 
             if final_token.startswith("licenseref-"):
-                if not license_ref_allowed.match(final_token):
-                    message = f"Invalid licenseref: {final_token!r}"
+                if suffix or not license_ref_allowed.match(final_token):
+                    message = f"Invalid licenseref: {token!r}"
                     raise InvalidLicenseExpression(message)
-                normalized_tokens.append(license_refs[final_token] + suffix)
+                normalized_tokens.append(license_refs[final_token])
             else:
                 if final_token not in LICENSES:
                     message = f"Unknown license: {final_token!r}"

--- a/tests/test_licenses.py
+++ b/tests/test_licenses.py
@@ -1,3 +1,9 @@
+import pytest
+
+from packaging.licenses import (
+    InvalidLicenseExpression,
+    canonicalize_license_expression,
+)
 from packaging.licenses._spdx import EXCEPTIONS, LICENSES
 
 
@@ -9,3 +15,8 @@ def test_licenses() -> None:
 def test_exceptions() -> None:
     for exception_id in EXCEPTIONS:
         assert exception_id == exception_id.lower()
+
+
+def test_licenseref_plus_suffix_is_invalid() -> None:
+    with pytest.raises(InvalidLicenseExpression, match="Invalid licenseref"):
+        canonicalize_license_expression("LicenseRef-Foo+")

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -807,6 +807,7 @@ class TestMetadata:
             "Use-it-after-midnight",
             "LicenseRef-License with spaces",
             "LicenseRef-License_with_underscores",
+            "LicenseRef-Foo+",
             "or",
             "and",
             "with",


### PR DESCRIPTION
The SPDX license [spec](https://spdx.github.io/spdx-spec/v2.2.2/SPDX-license-expressions/) says that a valid `license-id` can have a `+` suffix:
```
MIT
MIT+
```

But this does not apply to `license-ref`:
```python
LicenseRef-Foo  # valid
LicenseRef-Foo+  # not valid
```

Currently, during canocalization,  if we encounter `LicenseRef-Foo+`, we get an unhandled `KeyError` exception. This PR fixes that by instead checking for a suffix and raising the correct `InvalidLicenseExpression` exception instead.

cc @miketheman 