### PR TITLE
Handle recursion errors as validation failures

### DIFF
--- a/src/packaging/dependency_groups.py
+++ b/src/packaging/dependency_groups.py
@@ -145,7 +145,13 @@ class DependencyGroupResolver:
         with _ErrorCollector().on_exit(
             f"[dependency-groups] data for {group!r} was malformed"
         ) as errors:
-            return self._resolve(group, group, errors)
+            try:
+                return self._resolve(group, group, errors)
+            except RecursionError:
+                errors.error(
+                    ValueError("Dependency group includes are too deeply nested")
+                )
+                return ()
 
     def _resolve(
         self, group: str, requested_group: str, errors: _ErrorCollector

--- a/src/packaging/markers.py
+++ b/src/packaging/markers.py
@@ -369,6 +369,8 @@ class Marker:
             # ]
         except ParserSyntaxError as e:
             raise InvalidMarker(str(e)) from e
+        except RecursionError as e:
+            raise InvalidMarker("Marker expression is too complex") from e
 
     @classmethod
     def _from_markers(cls, markers: MarkerList) -> Marker:

--- a/src/packaging/requirements.py
+++ b/src/packaging/requirements.py
@@ -63,6 +63,8 @@ class Requirement:
             parsed = _parse_requirement(requirement_string)
         except ParserSyntaxError as e:
             raise InvalidRequirement(str(e)) from e
+        except RecursionError as e:
+            raise InvalidRequirement("Requirement is too complex") from e
 
         self.name: str = parsed.name
         self.url: str | None = parsed.url or None

--- a/tests/test_dependency_groups.py
+++ b/tests/test_dependency_groups.py
@@ -210,6 +210,22 @@ def test_single_include_group() -> None:
     assert set(resolve_dependency_groups(groups, "test")) == {"pytest", "sqlalchemy"}
 
 
+def test_long_acyclic_include_chain_raises_validation_error() -> None:
+    groups: GroupsTable = {}
+    for i in range(1200):
+        groups[f"group{i}"] = [{"include-group": f"group{i + 1}"}]
+    groups["group1200"] = ["pytest"]
+
+    with pytest.raises(
+        ExceptionGroup, match=r"\[dependency-groups\] data for 'group0' was malformed"
+    ) as excinfo:
+        resolve_dependency_groups(groups, "group0")
+
+    assert _group_contains(
+        excinfo, ValueError, match="Dependency group includes are too deeply nested"
+    )
+
+
 def test_sdual_include_group() -> None:
     groups: GroupsTable = {
         "test": [

--- a/tests/test_markers.py
+++ b/tests/test_markers.py
@@ -14,6 +14,7 @@ from unittest import mock
 
 import pytest
 
+from packaging import markers as markers_module
 from packaging._parser import Node, Op, Value, Variable
 from packaging.markers import (
     InvalidMarker,
@@ -197,6 +198,16 @@ class TestMarker:
     def test_parses_invalid(self, marker_string: str) -> None:
         with pytest.raises(InvalidMarker):
             Marker(marker_string)
+
+    def test_rejects_marker_parser_recursion(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def raise_recursion_error(_marker: str) -> None:
+            raise RecursionError
+
+        monkeypatch.setattr(markers_module, "_parse_marker", raise_recursion_error)
+        with pytest.raises(InvalidMarker, match="too complex"):
+            Marker('python_version >= "0"')
 
     @pytest.mark.parametrize(
         ("marker_string", "expected"),

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -633,6 +633,23 @@ class TestMetadata:
             field="requires-dist",
         )
 
+    def test_complex_requires_dist_marker(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def raise_invalid_requirement(_requirement: str) -> None:
+            raise requirements.InvalidRequirement("Requirement is too complex")
+
+        monkeypatch.setattr(
+            metadata.requirements, "Requirement", raise_invalid_requirement
+        )
+        meta = metadata.Metadata.from_raw({"requires_dist": ["pytest"]}, validate=False)
+        self._invalid_with_cause(
+            meta,
+            "requires_dist",
+            requirements.InvalidRequirement,
+            field="requires-dist",
+        )
+
     def test_valid_dynamic(self) -> None:
         dynamic = ["Keywords", "Home-Page", "Author"]
         meta = metadata.Metadata.from_raw({"dynamic": dynamic}, validate=False)

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -8,6 +8,7 @@ import pickle
 
 import pytest
 
+from packaging import requirements as requirements_module
 from packaging.markers import Marker
 from packaging.requirements import InvalidRequirement, Requirement
 from packaging.specifiers import SpecifierSet
@@ -446,6 +447,19 @@ class TestRequirementParsing:
             "    name; invalid_name\n"
             "          ^"
         )
+
+    def test_error_requirement_parser_recursion(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # GIVEN
+        def raise_recursion_error(_requirement: str) -> None:
+            raise RecursionError
+
+        monkeypatch.setattr(
+            requirements_module, "_parse_requirement", raise_recursion_error
+        )
+        with pytest.raises(InvalidRequirement, match="too complex"):
+            Requirement("name")
 
     def test_error_invalid_marker_rvalue(self) -> None:
         # GIVEN


### PR DESCRIPTION
Currently, deeply nested marker expressions can raise `RecursionError`. Also long `dependency-group` include chains. See the tests in this PR for examples.

This PR converts those exceptions failures into the expected exception types for each error:
  - `Marker(...)` now raises `InvalidMarker` when marker parsing hits `RecursionError`.
  - `Requirement(...)` now raises `InvalidRequirement` when requirement parsing hits `RecursionError`.
  - `dependency-group` resolution now reports deeply nested includes through the existing `dependency-group` `ExceptionGroup` error.

This currently affects `warehouse`, where a crafted package for this results in:
```
HTTP/1.1 500 Internal Server Error

RecursionError: maximum recursion depth exceeded // Werkzeug Debugger
```

(the above is from my local warehouse instance)

whereas with the fix, it should result in something like:
```
400 Bad Request

$req is invalid for 'requires-dist'.
 See https://packaging.python.org/specifications/core-metadata for more information.
```


cc @miketheman 
