### PR TITLE
docs(metadata): document RFC822Policy in the Low Level Interface

### DIFF
--- a/docs/metadata.rst
+++ b/docs/metadata.rst
@@ -53,6 +53,8 @@ Low Level Interface
 
 .. autoclass:: packaging.metadata.RFC822Message
 
+.. autoclass:: packaging.metadata.RFC822Policy
+
 
 Exceptions
 ''''''''''


### PR DESCRIPTION
`RFC822Policy` is the only `packaging.metadata.__all__` export with no entry in the API reference, while its sibling `RFC822Message` is documented and references it inline. Adds the missing bare `.. autoclass::` (mirrors the merged `PylockSelectError` fix in #1202).