### PR TITLE
docs(dependency_groups): add `.. versionadded:: 26.1` to DependencyGroupInclude

### DIFF
--- a/src/packaging/dependency_groups.py
+++ b/src/packaging/dependency_groups.py
@@ -73,6 +73,12 @@ class InvalidDependencyGroupObject(ValueError):
 
 
 class DependencyGroupInclude:
+    """
+    A reference to another dependency group by name.
+
+    .. versionadded:: 26.1
+    """
+
     __slots__ = ("include_group",)
 
     def __init__(self, include_group: str) -> None:


### PR DESCRIPTION
`DependencyGroupInclude` is the only public symbol in `packaging.dependency_groups` missing `.. versionadded:: 26.1` — the #1207/#1209 sweep skipped it because it had no class docstring to append to. Added a one-line class docstring carrying the directive.