### PR TITLE
Add parse_tag limit for compressed tags

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,8 @@ Features:
   representing the versions a specifier set accepts as an interval set that
   supports intersection, union, complement, membership tests, and filtering.
   (:pull:`1267`)
+* Add a ``limit`` argument to ``parse_tag()`` for compressed tag sets.
+  (:issue:`1220`)
 
 Behavior adaptations:
 

--- a/docs/tags.rst
+++ b/docs/tags.rst
@@ -48,6 +48,8 @@ items that applications should need to reference, in order to parse and check ta
 
 .. autofunction:: create_compatible_tags_selector
 
+.. autoexception:: TooManyTagsError
+
 .. autoexception:: UnsortedTagsError
 
 .. autoexception:: InvalidTag

--- a/src/packaging/tags.py
+++ b/src/packaging/tags.py
@@ -33,6 +33,7 @@ __all__ = [
     "InvalidTag",
     "PythonVersion",
     "Tag",
+    "TooManyTagsError",
     "UnsortedTagsError",
     "android_platforms",
     "compatible_tags",
@@ -95,6 +96,14 @@ class UnsortedTagsError(ValueError):
 class InvalidTag(ValueError):
     """
     Raised when a tag has an empty interpreter, ABI, or platform component.
+
+    .. versionadded:: 26.3
+    """
+
+
+class TooManyTagsError(ValueError):
+    """
+    Raised when a compressed tag set exceeds the configured limit.
 
     .. versionadded:: 26.3
     """
@@ -215,7 +224,9 @@ class Tag:
         raise TypeError(f"Cannot restore Tag from {state!r}")
 
 
-def parse_tag(tag: str, *, validate_order: bool = False) -> frozenset[Tag]:
+def parse_tag(
+    tag: str, *, validate_order: bool = False, limit: int | None = None
+) -> frozenset[Tag]:
     """
     Parses the provided tag (e.g. `py3-none-any`) into a frozenset of
     :class:`Tag` instances.
@@ -227,20 +238,33 @@ def parse_tag(tag: str, *, validate_order: bool = False) -> frozenset[Tag]:
     If **validate_order** is true, compressed tag set components are checked
     to be in sorted order as required by PEP 425.
 
+    If **limit** is not ``None``, the compressed tag set must generate at most
+    that many tags.
+
     :param str tag: The tag to parse, e.g. ``"py3-none-any"``.
     :param bool validate_order: Check whether compressed tag set components
         are in sorted order.
+    :param int limit: The maximum number of tags to parse.
     :raises UnsortedTagsError: If **validate_order** is true and any compressed tag
         set component is not in sorted order.
     :raises InvalidTag: If the interpreter, ABI, or platform field (or any member
         of a compressed tag set) is empty.
+    :raises TooManyTagsError: If **limit** is not ``None`` and the compressed tag
+        set would generate more than **limit** tags.
+    :raises ValueError: If **limit** is negative.
 
     .. versionadded:: 26.1
        The *validate_order* parameter.
 
     .. versionadded:: 26.3
        Raises :class:`InvalidTag` on empty tag components.
+       Added the *limit* parameter. Raises :class:`TooManyTagsError` if the compressed
+       tag set would generate more than *limit* tags.
     """
+
+    if limit is not None and limit < 0:
+        raise ValueError("limit must be non-negative")
+
     component_parts = [component.split(".") for component in tag.split("-")]
     for parts in component_parts:
         if "" in parts:
@@ -251,6 +275,16 @@ def parse_tag(tag: str, *, validate_order: bool = False) -> frozenset[Tag]:
             raise UnsortedTagsError(
                 f"Tag component {component!r} is not in sorted order per PEP 425"
             )
+
+    tag_count = 1
+    for parts in component_parts:
+        tag_count *= len(parts)
+
+    if limit is not None and tag_count > limit:
+        raise TooManyTagsError(
+            f"Compressed tag set would generate {tag_count} tags, exceeding "
+            f"limit {limit}"
+        )
 
     interpreters, abis, platforms = component_parts
     return frozenset(

--- a/src/packaging/tags.py
+++ b/src/packaging/tags.py
@@ -238,7 +238,7 @@ def parse_tag(
     If **validate_order** is true, compressed tag set components are checked
     to be in sorted order as required by PEP 425.
 
-    If **limit** is not ``None``, the compressed tag set must generate at most
+    If **limit** is not ``None``, the compressed tag set can generate at most
     that many tags.
 
     :param str tag: The tag to parse, e.g. ``"py3-none-any"``.

--- a/src/packaging/tags.py
+++ b/src/packaging/tags.py
@@ -244,7 +244,7 @@ def parse_tag(
     :param str tag: The tag to parse, e.g. ``"py3-none-any"``.
     :param bool validate_order: Check whether compressed tag set components
         are in sorted order.
-    :param int limit: The maximum number of tags to parse.
+    :param int | None limit: The maximum number of tags to parse.
     :raises UnsortedTagsError: If **validate_order** is true and any compressed tag
         set component is not in sorted order.
     :raises InvalidTag: If the interpreter, ABI, or platform field (or any member

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -167,6 +167,29 @@ class TestParseTag:
         )
         assert given == expected
 
+    def test_limit_allows_exact_number_of_tags(self) -> None:
+        expected = {tags.Tag("py2", "none", "any"), tags.Tag("py3", "none", "any")}
+        given = tags.parse_tag("py2.py3-none-any", limit=2)
+        assert given == expected
+
+    def test_limit_raises_when_exceeded(self) -> None:
+        with pytest.raises(tags.TooManyTagsError, match="would generate 2 tags"):
+            tags.parse_tag("py2.py3-none-any", limit=1)
+
+    def test_limit_counts_cartesian_product_entries(self) -> None:
+        # "py3.py3" generates two entries, even though both collapse to the
+        # same Tag in the returned frozenset.
+        with pytest.raises(tags.TooManyTagsError, match="would generate 2 tags"):
+            tags.parse_tag("py3.py3-none-any", limit=1)
+
+    def test_limit_rejects_negative_value(self) -> None:
+        with pytest.raises(ValueError, match="limit must be non-negative"):
+            tags.parse_tag("py3-none-any", limit=-1)
+
+    def test_limit_can_be_combined_with_validate_order(self) -> None:
+        with pytest.raises(ValueError, match="not in sorted order"):
+            tags.parse_tag("py3.py2-none-any", validate_order=True, limit=2)
+
     def test_unsorted_interpreter_parses_by_default(self) -> None:
         # Unsorted tags should parse fine without validate_order
         result = tags.parse_tag("py3.py2-none-any")


### PR DESCRIPTION
This PR adds a new kw-only parameter to `parse_tags()` to limit the amout of tags that can be generated from compressed tags. If the limit is exceeded, a new exception (`TooManyTagsError`) is raised.

The parameter is `limit: int | None` and defaults to `None`.

Fixes https://github.com/pypa/packaging/issues/1220