### PR TITLE
docs(direct_url): render ArchiveInfo, DirInfo, VcsInfo fields via autoclass

### DIFF
--- a/docs/direct_url.rst
+++ b/docs/direct_url.rst
@@ -65,11 +65,17 @@ Reference
     :members: from_dict, to_dict, validate
     :exclude-members: __init__, __new__
 
-.. class:: ArchiveInfo
+.. autoclass:: ArchiveInfo
+    :members:
+    :undoc-members:
 
-.. class:: DirInfo
+.. autoclass:: DirInfo
+    :members:
+    :undoc-members:
 
-.. class:: VcsInfo
+.. autoclass:: VcsInfo
+    :members:
+    :undoc-members:
 
 The following exception may be raised by this module:
 

--- a/docs/direct_url.rst
+++ b/docs/direct_url.rst
@@ -68,14 +68,17 @@ Reference
 .. autoclass:: ArchiveInfo
     :members:
     :undoc-members:
+    :exclude-members: __init__, __new__
 
 .. autoclass:: DirInfo
     :members:
     :undoc-members:
+    :exclude-members: __init__, __new__
 
 .. autoclass:: VcsInfo
     :members:
     :undoc-members:
+    :exclude-members: __init__, __new__
 
 The following exception may be raised by this module:
 

--- a/src/packaging/direct_url.py
+++ b/src/packaging/direct_url.py
@@ -149,6 +149,7 @@ class _DirectUrlRequiredKeyError(DirectUrlValidationError):
 
 @dataclasses.dataclass(frozen=True, init=False)
 class VcsInfo:
+    """The version control information of a :class:`DirectUrl`."""
     vcs: str
     commit_id: str
     requested_revision: str | None = None
@@ -176,6 +177,7 @@ class VcsInfo:
 
 @dataclasses.dataclass(frozen=True, init=False)
 class ArchiveInfo:
+    """The archive information of a :class:`DirectUrl`."""
     hashes: Mapping[str, str] | None = None
 
     def __init__(
@@ -222,6 +224,7 @@ class ArchiveInfo:
 
 @dataclasses.dataclass(frozen=True, init=False)
 class DirInfo:
+    """The local directory information of a :class:`DirectUrl`."""
     editable: bool | None = None
 
     def __init__(

--- a/src/packaging/direct_url.py
+++ b/src/packaging/direct_url.py
@@ -150,6 +150,7 @@ class _DirectUrlRequiredKeyError(DirectUrlValidationError):
 @dataclasses.dataclass(frozen=True, init=False)
 class VcsInfo:
     """The version control information of a :class:`DirectUrl`."""
+
     vcs: str
     commit_id: str
     requested_revision: str | None = None
@@ -178,6 +179,7 @@ class VcsInfo:
 @dataclasses.dataclass(frozen=True, init=False)
 class ArchiveInfo:
     """The archive information of a :class:`DirectUrl`."""
+
     hashes: Mapping[str, str] | None = None
 
     def __init__(
@@ -225,6 +227,7 @@ class ArchiveInfo:
 @dataclasses.dataclass(frozen=True, init=False)
 class DirInfo:
     """The local directory information of a :class:`DirectUrl`."""
+
     editable: bool | None = None
 
     def __init__(


### PR DESCRIPTION
The Reference section renders `ArchiveInfo`, `DirInfo`, and `VcsInfo` as bare `.. class::` stubs (just the class name), even though all three are public (`__all__`) frozen dataclasses whose keyword-only fields the Usage example above already constructs (`hashes`, `editable`, `vcs`/`commit_id`/`requested_revision`).

Switching them to `.. autoclass:: :members: :undoc-members:` (the same pattern `RawMetadata` uses in `metadata.rst`) renders those field signatures, matching the existing `DirectUrl` entry just above them.

Pure docs, no code change.