### PR TITLE
test(tags): make the test suite pass on musl/Alpine (#850)

### DIFF
--- a/tests/test_manylinux.py
+++ b/tests/test_manylinux.py
@@ -175,7 +175,10 @@ def test_glibc_version_string_ctypes_raise_oserror(
     assert _glibc_version_string_ctypes() is None
 
 
-@pytest.mark.skipif(platform.system() != "Linux", reason="requires Linux")
+@pytest.mark.skipif(
+    platform.system() != "Linux" or _glibc_version_string() is None,
+    reason="requires a glibc-based Linux",
+)
 def test_is_manylinux_compatible_old() -> None:
     # Assuming no one is running this test with a version of glibc released in
     # 1997.

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -572,6 +572,17 @@ class TestAndroidPlatforms:
         ]
 
 
+@pytest.fixture
+def _disable_musl_detection(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The manylinux platform tests assert exact tag lists and do not expect
+    # musllinux_* entries. On a musl host (e.g. Alpine), ``_get_musl_version()``
+    # returns a real version and those tags leak into ``_linux_platforms()`` /
+    # ``sys_tags()``, breaking the assertions. Neutralize musl detection by
+    # default; tests that exercise musllinux re-patch ``_get_musl_version``.
+    monkeypatch.setattr(tags._musllinux, "_get_musl_version", lambda _: None)  # type: ignore[attr-defined]
+
+
+@pytest.mark.usefixtures("_disable_musl_detection")
 class TestManylinuxPlatform:
     def teardown_method(self) -> None:
         # Clear the version cache
@@ -1546,6 +1557,7 @@ class TestCompatibleTags:
         ]
 
 
+@pytest.mark.usefixtures("_disable_musl_detection")
 class TestSysTags:
     def teardown_method(self) -> None:
         # Clear the version cache


### PR DESCRIPTION
Fixes the test-suite failures on musl/Alpine reported in #850.

Two independent issues:

1. **`_linux_platforms()` assertions leak musllinux tags.** `TestManylinuxPlatform` / `TestSysTags` monkeypatch manylinux/glibc detection and assert exact tag lists with no `musllinux_*` entries. On a musl host `_get_musl_version()` returns a real version, so musllinux tags get appended and the `==` assertions fail. This adds a small shared fixture (applied to both classes via `usefixtures`) that neutralizes musl detection by default, mirroring the existing `monkeypatch.setattr(tags._musllinux, "_get_musl_version", ...)` idiom. `test_linux_platforms_musllinux` re-patches it itself, so it is unaffected.

2. **`test_is_manylinux_compatible_old` asserts glibc under a Linux-only skip.** musl is Linux, but with no glibc `_get_glibc_version()` returns the `(-1, -1)` sentinel and `_is_compatible("any", _GLibCVersion(2, 0))` is `False`, so the bare assert fails. The skip is extended to also skip when glibc is absent. It uses the uncached `_glibc_version_string()` rather than the cached `_get_glibc_version()` so the marker does not populate the `lru_cache` at collection time.

Verified locally: simulating a musl host turns 19 of these into failures on `main`; with the patch they pass, and the normal (glibc/non-musl) run is unchanged.

@brettcannon noted on #850 that it might be worth centralizing the monkeypatching — I kept this minimal and scoped to the two affected classes, but happy to fold it into a broader fixture refactor if you prefer.