### PR TITLE
test(specifiers): guard non-ASCII local-version rejection (#469)

### DIFF
--- a/tests/test_specifiers.py
+++ b/tests/test_specifiers.py
@@ -94,6 +94,10 @@ class TestSpecifier:
             # Cannot use a prefix matching after a .devN version
             "==1.0.dev1.*",
             "!=1.0.dev1.*",
+            # Local segment with a non-ASCII letter that matches regex '[a-z]'
+            # when re.IGNORECASE is in force and re.ASCII is not (issue #469)
+            "==1.2+\u0130",
+            "==1.2+\u0130\u0131\u017fK",
         ],
     )
     def test_specifiers_invalid(self, specifier: str) -> None:


### PR DESCRIPTION
The `Version` side guards non-ASCII local-version rejection (`test_version.py`, `"1.0+\u0130"`), but the `Specifier` side — the actual reproducer in #469 — has no such test.

Rejection relies on the `(?a:)` inline scope in the local-segment regex (`specifiers.py`); dropping it silently re-accepts non-ASCII local letters under `re.IGNORECASE` with no test failure. This adds the two `Specifier` reproducers (`==1.2+\u0130` and the original `==1.2+\u0130\u0131\u017fK`) to `test_specifiers_invalid`, mirroring the existing `Version` guard.