### PR TITLE
fix(utils): is_normalized_name rejects collapsed double-hyphen names (a--b)

### DIFF
--- a/src/packaging/utils.py
+++ b/src/packaging/utils.py
@@ -58,7 +58,7 @@ class InvalidSdistFilename(ValueError):
 _validate_regex = re.compile(
     r"[a-z0-9]|[a-z0-9][a-z0-9._-]*[a-z0-9]", re.IGNORECASE | re.ASCII
 )
-_normalized_regex = re.compile(r"[a-z0-9]|[a-z0-9]([a-z0-9-](?!--))*[a-z0-9]", re.ASCII)
+_normalized_regex = re.compile(r"[a-z0-9]+(?:-[a-z0-9]+)*", re.ASCII)
 # PEP 427: The build number must start with a digit.
 _build_tag_regex = re.compile(r"(\d+)(.*)", re.ASCII)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -70,6 +70,8 @@ def test_canonicalize_name_invalid(name: str, expected: str) -> None:
         ("foo___bar", "foo-bar"),
         ("foo-bar", "foo-bar"),
         ("foo----bar", "foo-bar"),
+        ("a--b", "a-b"),
+        ("1--1", "1-1"),
     ],
 )
 def test_is_normalized_name(name: str, expected: str) -> None:


### PR DESCRIPTION
`is_normalized_name()` is documented to return `True` iff `canonicalize_name` would roundtrip the name unchanged. It currently returns `True` for a single-char-flanked collapsed double hyphen, e.g. `a--b` / `1--1`, even though `canonicalize_name("a--b") == "a-b"` — so they don't roundtrip, contradicting the docstring and PEP 503.

**Cause:** in `_normalized_regex`, the negative lookahead `(?!--)` sits *after* the consumed character, so on a hyphen it inspects the next two chars instead of (this hyphen + the next one), letting a single interior `--` through.

**Fix:** replace the pattern with the equivalent `[a-z0-9]+(?:-[a-z0-9]+)*` (alphanumeric runs joined by single hyphens), dropping the error-prone lookahead. `re.ASCII` and the `fullmatch` call site are unchanged. Verified by exhaustive enumeration over `{a,1,-}` up to length 7: the new pattern diverges from the old one *only* on previously-accepted names that fail to roundtrip (now correctly rejected) — no name the old pattern correctly accepted changes. Added `a--b`/`1--1` regression cases (they fail on `main`, pass with the fix).