### PR TITLE
fix(requirements): make Requirement.__hash__ consistent with __eq__ for trailing-zero-equivalent specifiers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,10 @@ Behavior adaptations:
 
 Fixes:
 
+* Make ``Requirement.__hash__`` consistent with ``__eq__`` for
+  trailing-zero-equivalent specifiers (e.g. ``foo==1.0.0`` and
+  ``foo==1.0.0.0``), so equal requirements hash equal and deduplicate in
+  sets and dicts. (:pull:`1232`)
 * Preserve a ``Requirement``'s specifier ``prereleases`` override across a
   pickle round trip. (:issue:`1204`)
 

--- a/src/packaging/requirements.py
+++ b/src/packaging/requirements.py
@@ -136,7 +136,20 @@ class Requirement:
         return f"<{self.__class__.__name__}({str(self)!r})>"
 
     def __hash__(self) -> int:
-        return hash(tuple(self._iter_parts(canonicalize_name(self.name))))
+        # Mirror __eq__ by hashing the canonical specifier object rather than
+        # its raw string. ``_iter_parts`` yields ``str(self.specifier)``, which
+        # is non-canonical, so trailing-zero-equivalent requirements such as
+        # ``foo==1.0.0`` and ``foo==1.0.0.0`` (which compare equal) would
+        # otherwise hash differently, breaking the hash/__eq__ invariant.
+        return hash(
+            (
+                canonicalize_name(self.name),
+                frozenset(self.extras),
+                self.specifier,
+                self.url,
+                self.marker,
+            )
+        )
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, Requirement):

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -30,6 +30,15 @@ EQUAL_DEPENDENCIES = [
 
 EQUIVALENT_DEPENDENCIES = [
     ("scikit-learn==1.0.1", "scikit_learn==1.0.1"),
+    # Trailing-zero-equivalent specifiers compare equal, so they must hash
+    # equal too (regression guard for the __hash__/__eq__ invariant).
+    ("foo==1.0.0", "foo==1.0.0.0"),
+    ("foo>=1.0", "foo>=1.0.0"),
+    # Canonical-specifier hashing must hold alongside extras + marker.
+    (
+        'foo[a]==1.0.0; python_version>="3.8"',
+        'foo[a]==1.0.0.0; python_version>="3.8"',
+    ),
 ]
 
 DIFFERENT_DEPENDENCIES = [


### PR DESCRIPTION
`Requirement` is a public hashable class, but `__hash__` violated the `a == b ⇒ hash(a) == hash(b)` invariant for trailing-zero-equivalent specifiers:

```python
>>> from packaging.requirements import Requirement
>>> a, b = Requirement("foo==1.0.0"), Requirement("foo==1.0.0.0")
>>> a == b
True
>>> hash(a) == hash(b)
False        # -> they don't dedup in sets/dicts
>>> len({a, b})
2
```

`__hash__` hashed `str(self.specifier)` (non-canonical) via `_iter_parts`, while `__eq__` compares the canonical `SpecifierSet`. So equal requirements silently failed to deduplicate in sets/dicts used by resolvers and lockfile tooling. The existing `test_equivalent_reqs_equal_hashes_unequal_strings` docstring already states equivalent reqs *should* share a hash.

Fix: hash the same components `__eq__` uses (canonical name, extras, the `SpecifierSet` object, url, marker) instead of the rendered string. `str(req)`/`repr(req)` are unchanged (they still use `_iter_parts`).

Regression tests added to `EQUIVALENT_DEPENDENCIES` (trailing-zero specifiers, alone and combined with extras + marker); all fail on `main`, pass with the fix. Full suite: 5309 passing.
