### PR TITLE
docs(changelog): record the DirectUrl auth-stripping fix (#1218)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,8 @@ Behavior adaptations:
 
 Fixes:
 
+* Fix ``DirectUrl`` netloc auth stripping when the password contains an
+  ``@`` character. (:pull:`1218`)
 * Preserve a ``Requirement``'s specifier ``prereleases`` override across a
   pickle round trip. (:issue:`1204`)
 


### PR DESCRIPTION
Merged #1218 fixed `DirectUrl` netloc auth stripping (`split("@", 1)` → `rsplit("@", 1)` in `_strip_auth_from_netloc`, so a password containing `@` no longer leaks part of the URL) and added a regression test, but it didn't add a changelog entry. This backfills the one-line Fixes bullet to the *unreleased* section.

`docs/development/submitting-patches.rst` asks for a changelog entry on significant fixes, and a partial credential/netloc leak is the kind of fix security auditors scan the changelog for. Source-verified against `src/packaging/direct_url.py` on `main`; no other open PR backfills it.
