### PR TITLE
fix(utils): reject empty tag components in parse_wheel_filename/parse_tag (#577)

### DIFF
--- a/docs/tags.rst
+++ b/docs/tags.rst
@@ -50,6 +50,8 @@ items that applications should need to reference, in order to parse and check ta
 
 .. autoexception:: UnsortedTagsError
 
+.. autoexception:: InvalidTag
+
 
 
 Low Level Interface

--- a/src/packaging/tags.py
+++ b/src/packaging/tags.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
 __all__ = [
     "INTERPRETER_SHORT_NAMES",
     "AppleVersion",
+    "InvalidTag",
     "PythonVersion",
     "Tag",
     "UnsortedTagsError",
@@ -81,6 +82,14 @@ class UnsortedTagsError(ValueError):
     Raised when a tag component is not in sorted order per PEP 425.
 
     .. versionadded:: 26.1
+    """
+
+
+class InvalidTag(ValueError):
+    """
+    Raised when a tag has an empty interpreter, ABI, or platform component.
+
+    .. versionadded:: 26.3
     """
 
 
@@ -216,12 +225,20 @@ def parse_tag(tag: str, *, validate_order: bool = False) -> frozenset[Tag]:
         are in sorted order.
     :raises UnsortedTagsError: If **validate_order** is true and any compressed tag
         set component is not in sorted order.
+    :raises InvalidTag: If the interpreter, ABI, or platform field (or any member
+        of a compressed tag set) is empty.
 
     .. versionadded:: 26.1
        The *validate_order* parameter.
+
+    .. versionadded:: 26.3
+       Raises :class:`InvalidTag` on empty tag components.
     """
     tags = set()
     interpreters, abis, platforms = tag.split("-")
+    for component in (interpreters, abis, platforms):
+        if "" in component.split("."):
+            raise InvalidTag(f"Tag {tag!r} has an empty component: {component!r}")
     if validate_order:
         for component in (interpreters, abis, platforms):
             parts = component.split(".")

--- a/src/packaging/utils.py
+++ b/src/packaging/utils.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import re
 from typing import NewType, Union, cast
 
-from .tags import Tag, UnsortedTagsError, parse_tag
+from .tags import InvalidTag, Tag, UnsortedTagsError, parse_tag
 from .version import InvalidVersion, Version, _TrimmedRelease
 
 __all__ = [
@@ -247,6 +247,10 @@ def parse_wheel_filename(
         raise InvalidWheelFilename(
             f"Invalid wheel filename (compressed tag set components must be in "
             f"sorted order per PEP 425): {filename!r}"
+        ) from None
+    except InvalidTag:
+        raise InvalidWheelFilename(
+            f"Invalid wheel filename (empty tag component): {filename!r}"
         ) from None
     return (name, version, build, tags)
 

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -196,6 +196,21 @@ class TestParseTag:
         assert tags.Tag("py2", "none", "any") in result
         assert tags.Tag("py3", "none", "any") in result
 
+    @pytest.mark.parametrize(
+        "tag",
+        [
+            "-none-any",  # Empty interpreter
+            "py3--any",  # Empty ABI
+            "py3-none-",  # Empty platform
+            "py3.-none-any",  # Empty member of a compressed interpreter set
+            "py3-none-any.",  # Empty member of a compressed platform set
+            "--",  # All empty
+        ],
+    )
+    def test_empty_component_raises(self, tag: str) -> None:
+        with pytest.raises(tags.InvalidTag, match="empty component"):
+            tags.parse_tag(tag)
+
 
 class TestInterpreterName:
     def test_sys_implementation_name(self, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -180,6 +180,9 @@ def test_parse_wheel_filename(
         # Build number doesn't start with a digit (`abc`)
         ("foo-1.0-abc-py3-none-any.whl"),
         ("foo-1.0-200-py3-none-any-junk.whl"),  # Too many dashes (`-junk`)
+        ("foo-1.0--none-any.whl"),  # Empty interpreter component
+        ("foo-1.0-py3-none-.whl"),  # Empty platform component
+        ("foo-1.0-py3.-none-any.whl"),  # Empty member in a compressed tag set
     ],
 )
 def test_parse_wheel_invalid_filename(filename: str) -> None:


### PR DESCRIPTION
Closes part of #577.

`parse_wheel_filename` / `parse_tag` silently build nonsense `Tag('', 'none', 'any')` instances from filenames with an empty interpreter/ABI/platform component, e.g.:

- `foo-1.0--none-any.whl` (empty interpreter)
- `foo-1.0-py3-none-.whl` (empty platform)
- `foo-1.0-py3.-none-any.whl` (empty member of a compressed tag set)

An empty component can never match a real `sys_tags()` entry, so accepting it silently masks upstream filename corruption/truncation instead of surfacing it.

This raises a new `InvalidTag(ValueError)` from `parse_tag` and wraps it as `InvalidWheelFilename`, mirroring the `UnsortedTagsError` handling added in #1150.

Deliberately narrow: it only rejects **empty** components — the slice that is illegal under every spec reading. It does **not** add the broader interpreter-format grammar check discussed in #577 (the `\w+\d+` / shortname-grammar variants), which was left unresolved feature-vs-bug in the original thread.