### PR TITLE
docs(licenses): fix InvalidLicenseExpression docstring example error message

### DIFF
--- a/src/packaging/licenses/__init__.py
+++ b/src/packaging/licenses/__init__.py
@@ -64,7 +64,7 @@ class InvalidLicenseExpression(ValueError):
     >>> canonicalize_license_expression("invalid")
     Traceback (most recent call last):
         ...
-    packaging.licenses.InvalidLicenseExpression: Invalid license expression: 'invalid'
+    packaging.licenses.InvalidLicenseExpression: Unknown license: 'invalid'
     """
 
 


### PR DESCRIPTION
The `InvalidLicenseExpression` docstring example shows `canonicalize_license_expression("invalid")` raising `Invalid license expression: 'invalid'`, but it actually raises `Unknown license: 'invalid'` — 'invalid' hits the final `not in LICENSES` branch (same path as the documented `Use-it-after-midnight` example), not an 'Invalid license expression' path. One-line correction to the rendered example output.