### PR TITLE
docs(utils): clarify is_normalized_name shape check

### DIFF
--- a/src/packaging/utils.py
+++ b/src/packaging/utils.py
@@ -107,8 +107,11 @@ def canonicalize_name(name: str, *, validate: bool = False) -> NormalizedName:
 
 def is_normalized_name(name: str) -> bool:
     """
-    Check if a name is already normalized (i.e. :func:`canonicalize_name` would
-    roundtrip to the same value).
+    Check if a name is a valid normalized name.
+
+    This validates the normalized-name shape, so it is stricter than checking
+    whether :func:`canonicalize_name` would return the same value for invalid
+    inputs.
 
     :param str name: The name to check.
 


### PR DESCRIPTION
Follow-up to #1231 / the review on #1230.

`is_normalized_name()` checks the valid normalized-name shape, which is intentionally stricter than a plain `canonicalize_name(name) == name` roundtrip for invalid edge-hyphen inputs like `-not-legal`.

This is docstring-only: it keeps the current behavior and just removes the misleading roundtrip wording.