### PR TITLE
fix(tags): raise InvalidTag for malformed tag field counts

### DIFF
--- a/src/packaging/tags.py
+++ b/src/packaging/tags.py
@@ -286,10 +286,10 @@ def parse_tag(
             f"limit {limit}"
         )
 
-    if len(component_parts) != 3:
-        raise InvalidTag(f"Tag {tag!r} must have exactly three components")
-
-    interpreters, abis, platforms = component_parts
+    try:
+        interpreters, abis, platforms = component_parts
+    except ValueError as exc:
+        raise InvalidTag(f"Tag {tag!r} must have exactly three components") from exc
     return frozenset(
         Tag(interpreter, abi, platform_)
         for interpreter in interpreters

--- a/src/packaging/tags.py
+++ b/src/packaging/tags.py
@@ -286,6 +286,9 @@ def parse_tag(
             f"limit {limit}"
         )
 
+    if len(component_parts) != 3:
+        raise InvalidTag(f"Tag {tag!r} must have exactly three components")
+
     interpreters, abis, platforms = component_parts
     return frozenset(
         Tag(interpreter, abi, platform_)

--- a/src/packaging/tags.py
+++ b/src/packaging/tags.py
@@ -95,7 +95,8 @@ class UnsortedTagsError(ValueError):
 
 class InvalidTag(ValueError):
     """
-    Raised when a tag has an empty interpreter, ABI, or platform component.
+    Raised when a tag has an empty interpreter, ABI, or platform component, or
+    does not have exactly three components.
 
     .. versionadded:: 26.3
     """
@@ -248,7 +249,8 @@ def parse_tag(
     :raises UnsortedTagsError: If **validate_order** is true and any compressed tag
         set component is not in sorted order.
     :raises InvalidTag: If the interpreter, ABI, or platform field (or any member
-        of a compressed tag set) is empty.
+        of a compressed tag set) is empty, or the tag does not have exactly three
+        components.
     :raises TooManyTagsError: If **limit** is not ``None`` and the compressed tag
         set would generate more than **limit** tags.
     :raises ValueError: If **limit** is negative.
@@ -257,7 +259,8 @@ def parse_tag(
        The *validate_order* parameter.
 
     .. versionadded:: 26.3
-       Raises :class:`InvalidTag` on empty tag components.
+       Raises :class:`InvalidTag` on empty tag components, or a tag that does
+       not have exactly three components.
        Added the *limit* parameter. Raises :class:`TooManyTagsError` if the compressed
        tag set would generate more than *limit* tags.
     """

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -234,6 +234,17 @@ class TestParseTag:
         with pytest.raises(tags.InvalidTag, match="empty component"):
             tags.parse_tag(tag)
 
+    @pytest.mark.parametrize(
+        "tag",
+        [
+            "py3-none",
+            "py3-none-any-extra",
+        ],
+    )
+    def test_invalid_component_count_raises(self, tag: str) -> None:
+        with pytest.raises(tags.InvalidTag, match="exactly three components"):
+            tags.parse_tag(tag)
+
 
 class TestInterpreterName:
     def test_sys_implementation_name(self, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

`parse_tag()` already raises `InvalidTag` for empty tag components, but malformed tags with too few or too many hyphen-separated fields still reached the tuple unpack and leaked `ValueError`.

This adds an explicit field-count check before unpacking so inputs such as `py3-none` and `py3-none-any-extra` follow the same public error contract.

## Verification

- `uv run pytest tests/test_tags.py -q`
- `uv run ruff check src/packaging/tags.py tests/test_tags.py`
- `uv run ruff format --check src/packaging/tags.py tests/test_tags.py`
- Codex adversarial review: `VERDICT: approve`