### PR TITLE
fix(version): raise InvalidVersion for non-str pre letters in from_parts

### DIFF
--- a/src/packaging/version.py
+++ b/src/packaging/version.py
@@ -287,10 +287,15 @@ def _validate_pre(value: object, /) -> tuple[Literal["a", "b", "rc"], int] | Non
         return value
     if isinstance(value, tuple) and len(value) == 2:
         letter, number = value
-        letter = normalize_pre(letter)
-        if letter in {"a", "b", "rc"} and isinstance(number, int) and number >= 0:
+        # The letter must be a string before it can be normalized.
+        if (
+            isinstance(letter, str)
+            and (normalized := normalize_pre(letter)) in {"a", "b", "rc"}
+            and isinstance(number, int)
+            and number >= 0
+        ):
             # type checkers can't infer the Literal type here on letter
-            return (letter, number)  # type: ignore[return-value]
+            return (normalized, number)  # type: ignore[return-value]
     msg = f"pre must be a tuple of ('a'|'b'|'rc', non-negative int), got {value}"
     raise InvalidVersion(msg)
 

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1269,6 +1269,13 @@ def test_from_parts(args: dict[str, typing.Any], string: str) -> None:
     assert v == Version(string)
 
 
+def test_from_parts_rejects_non_str_pre_letter() -> None:
+    # A non-string pre letter must raise InvalidVersion rather than escaping
+    # as an AttributeError from the normalization step.
+    with pytest.raises(InvalidVersion, match="pre must be a tuple"):
+        Version.from_parts(release=(1,), pre=(1, 1))  # type: ignore[arg-type]
+
+
 @pytest.mark.parametrize(
     "version",
     [


### PR DESCRIPTION
I removed the bool rejection; I don't think rejecting bools is Pythonic.

:robot: _AI text below_ :robot:

Part of #1239.

`_validate_pre` (reachable through `Version.from_parts` and `__replace__`) normalized the pre letter with `.lower()` before any type check, so a non-string first element escaped as `AttributeError` instead of `InvalidVersion`:

```pycon
>>> Version.from_parts(release=(1,), pre=(1, 1))
AttributeError: 'int' object has no attribute 'lower'
```

The letter is now type-checked before it is normalized, so the call raises `InvalidVersion` like the sibling validators do for bad types. A regression test is included.

This PR originally also rejected `bool` where the validators expect an `int` (e.g. `post=True` producing `1.postTrue`); that part was dropped as it is arguably just a quirk of Python rather than a validation gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)