### PR TITLE
chore(noxfile): detach on tag checkout and mark release_build non-default; fix asv URL typo

### DIFF
--- a/asv.conf.json
+++ b/asv.conf.json
@@ -1,7 +1,7 @@
 {
     "version": 1,
     "project": "packaging",
-    "project_url": "https//github.com/pypa/packaging",
+    "project_url": "https://github.com/pypa/packaging",
     "show_commit_url": "https://github.com/pypa/packaging/commit/",
     "repo": ".",
     "environment_type": "virtualenv",

--- a/noxfile.py
+++ b/noxfile.py
@@ -284,7 +284,7 @@ def release(session: nox.Session) -> None:
     print()
 
 
-@nox.session
+@nox.session(default=False)
 def release_build(session: nox.Session) -> None:
     """
     Build version from command-line arguments otherwise current Git tag.
@@ -321,7 +321,7 @@ def release_build(session: nox.Session) -> None:
 
     # Check out the Git tag, if provided.
     if checkout:
-        session.run("git", "switch", "-q", release_version, external=True)
+        session.run("git", "switch", "--detach", "-q", release_version, external=True)
 
     # Build the distribution.
     _build_and_check(session, release_version)


### PR DESCRIPTION
You can tell I don't run nox without a `-s`. :)

:robot: _AI text below_ :robot:

Part of #1239

## Summary

Three small tooling fixes identified in the code review:

- **`noxfile.py` line 324**: Added `--detach` to `git switch` when checking out a release tag. Without this flag, `git switch <tag>` fails with exit 128 ("fatal: a branch is expected"), so `nox -s release_build -- <version>` has never worked with an explicit version argument.

- **`noxfile.py` line 287**: Marked the `release_build` session `default=False`, consistent with `release` and other non-default sessions in the file. Previously a bare `nox` run on any non-tagged commit would error because `git describe --exact-match` fails. The publish workflow (`publish.yml`) always selects the session explicitly with `-s release_build`, so this change is safe.

- **`asv.conf.json` line 4**: Fixed `"https//github.com/pypa/packaging"` → `"https://github.com/pypa/packaging"` (missing colon after `https`).

## Test plan

- `uv run nox -l` lists all sessions and shows `release_build` as non-default (prefixed with `-` not `*`).
- `prek -a --quiet` passes with no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)