### PR TITLE
fix(pylock): reject bools where TOML integers are expected

### DIFF
--- a/src/packaging/pylock.py
+++ b/src/packaging/pylock.py
@@ -593,10 +593,7 @@ class Package:
             attestation_identities=_get_sequence(d, Mapping, "attestation-identities"),  # type: ignore[type-abstract]
             tool=_get(d, Mapping, "tool"),  # type: ignore[type-abstract]
         )
-        # The presence of the wheels key (even as an empty array) counts as wheels
-        # being specified, since ``[[packages.wheels]]`` is mutually exclusive with
-        # vcs, directory, and archive regardless of how many wheels it contains.
-        distributions = bool(package.sdist) + (package.wheels is not None)
+        distributions = bool(package.sdist) + len(package.wheels or [])
         direct_urls = (
             bool(package.vcs) + bool(package.directory) + bool(package.archive)
         )

--- a/src/packaging/pylock.py
+++ b/src/packaging/pylock.py
@@ -105,7 +105,10 @@ def _get(d: Mapping[str, Any], expected_type: type[_T], key: str) -> _T | None:
     """Get a value from the dictionary and verify it's the expected type."""
     if (value := d.get(key)) is None:
         return None
-    if not isinstance(value, expected_type):
+    if not isinstance(value, expected_type) or (
+        # Special case: bool is a subclass of int, but TOML distinguishes the two
+        expected_type is int and isinstance(value, bool)
+    ):
         raise PylockValidationError(
             f"Unexpected type {type(value).__name__} "
             f"(expected {expected_type.__name__})",

--- a/src/packaging/pylock.py
+++ b/src/packaging/pylock.py
@@ -593,7 +593,10 @@ class Package:
             attestation_identities=_get_sequence(d, Mapping, "attestation-identities"),  # type: ignore[type-abstract]
             tool=_get(d, Mapping, "tool"),  # type: ignore[type-abstract]
         )
-        distributions = bool(package.sdist) + len(package.wheels or [])
+        # The presence of the wheels key (even as an empty array) counts as wheels
+        # being specified, since ``[[packages.wheels]]`` is mutually exclusive with
+        # vcs, directory, and archive regardless of how many wheels it contains.
+        distributions = bool(package.sdist) + (package.wheels is not None)
         direct_urls = (
             bool(package.vcs) + bool(package.directory) + bool(package.archive)
         )

--- a/tests/test_pylock.py
+++ b/tests/test_pylock.py
@@ -99,6 +99,33 @@ def test_pylock_unexpected_type() -> None:
     )
 
 
+def test_pylock_bool_rejected_for_int() -> None:
+    # TOML distinguishes booleans from integers, so a boolean must be rejected
+    # where an integer is expected even though bool is a subclass of int.
+    data = {
+        "lock-version": "1.0",
+        "created-by": "pip",
+        "packages": [
+            {
+                "name": "example",
+                "wheels": [
+                    {
+                        "name": "example-1.0-py3-none-any.whl",
+                        "path": "./example-1.0-py3-none-any.whl",
+                        "hashes": {"sha256": "f" * 40},
+                        "size": True,
+                    }
+                ],
+            }
+        ],
+    }
+    with pytest.raises(PylockValidationError) as exc_info:
+        Pylock.from_dict(data)
+    assert str(exc_info.value) == (
+        "Unexpected type bool (expected int) in 'packages[0].wheels[0].size'"
+    )
+
+
 def test_pylock_missing_version() -> None:
     data = {
         "created-by": "pip",

--- a/tests/test_pylock.py
+++ b/tests/test_pylock.py
@@ -232,6 +232,51 @@ def test_pylock_packages_with_archive_directory_and_vcs() -> None:
     )
 
 
+def test_pylock_empty_wheels_with_directory() -> None:
+    # An empty wheels array still counts as wheels being specified, so it is
+    # mutually exclusive with vcs, directory, and archive.
+    data = {
+        "lock-version": "1.0",
+        "created-by": "pip",
+        "packages": [
+            {
+                "name": "example",
+                "version": "1.0",
+                "wheels": [],
+                "directory": {
+                    "path": ".",
+                    "editable": False,
+                },
+            }
+        ],
+    }
+    with pytest.raises(PylockValidationError) as exc_info:
+        Pylock.from_dict(data)
+    assert str(exc_info.value) == (
+        "None of vcs, directory, archive must be set "
+        "if sdist or wheels are set "
+        "in 'packages[0]'"
+    )
+
+
+def test_pylock_empty_wheels_without_source() -> None:
+    # An empty wheels array on its own counts as wheels being specified, so no
+    # direct URL source is required and the lock validates.
+    data = {
+        "lock-version": "1.0",
+        "created-by": "pip",
+        "packages": [
+            {
+                "name": "example",
+                "version": "1.0",
+                "wheels": [],
+            }
+        ],
+    }
+    pylock = Pylock.from_dict(data)
+    assert pylock.packages[0].wheels == []
+
+
 def test_pylock_basic_package() -> None:
     data = {
         "lock-version": "1.0",

--- a/tests/test_pylock.py
+++ b/tests/test_pylock.py
@@ -232,51 +232,6 @@ def test_pylock_packages_with_archive_directory_and_vcs() -> None:
     )
 
 
-def test_pylock_empty_wheels_with_directory() -> None:
-    # An empty wheels array still counts as wheels being specified, so it is
-    # mutually exclusive with vcs, directory, and archive.
-    data = {
-        "lock-version": "1.0",
-        "created-by": "pip",
-        "packages": [
-            {
-                "name": "example",
-                "version": "1.0",
-                "wheels": [],
-                "directory": {
-                    "path": ".",
-                    "editable": False,
-                },
-            }
-        ],
-    }
-    with pytest.raises(PylockValidationError) as exc_info:
-        Pylock.from_dict(data)
-    assert str(exc_info.value) == (
-        "None of vcs, directory, archive must be set "
-        "if sdist or wheels are set "
-        "in 'packages[0]'"
-    )
-
-
-def test_pylock_empty_wheels_without_source() -> None:
-    # An empty wheels array on its own counts as wheels being specified, so no
-    # direct URL source is required and the lock validates.
-    data = {
-        "lock-version": "1.0",
-        "created-by": "pip",
-        "packages": [
-            {
-                "name": "example",
-                "version": "1.0",
-                "wheels": [],
-            }
-        ],
-    }
-    pylock = Pylock.from_dict(data)
-    assert pylock.packages[0].wheels == []
-
-
 def test_pylock_basic_package() -> None:
     data = {
         "lock-version": "1.0",


### PR DESCRIPTION
Item 3 has been removed. And Item 2 has been removed.

:robot: _AI text below_ :robot:

Part of #1239.

This fixes three related PEP 751 lockfile validation bugs surfaced in the code review for #1239. Each fix is a separate commit with a regression test, and `src/packaging/pylock.py` stays at 100% coverage.

## 1. Booleans accepted where TOML integers are expected

`_get` used `isinstance(value, expected_type)`, and because `bool` is a subclass of `int`, a boolean passed the integer check. TOML distinguishes the two types, so a lockfile could set an integer field to a boolean:

```python
>>> from packaging.pylock import _get
>>> _get({"size": True}, int, "size")
True   # before: accepted; PackageWheel.size becomes True
```

`_get` now rejects a boolean when the expected type is `int`, raising the usual `PylockValidationError` with field context (following the existing str-vs-`Sequence` special case):

```
Unexpected type bool (expected int) in 'packages[0].wheels[0].size'
```

## 2. Empty `wheels = []` array defeated the mutual-exclusivity check

The check counted distributions with `len(package.wheels or [])`, so an empty `wheels = []` array alongside a direct URL source validated, even though `[[packages.wheels]]` is mutually exclusive with `vcs`/`directory`/`archive`:

```python
>>> from packaging.pylock import Package
>>> Package._from_dict({"name": "foo", "wheels": [], "directory": {"path": "./foo"}})
# before: validated; after: PylockValidationError
```

The check now treats the *presence* of the key (`package.wheels is not None`) as wheels being specified. An empty `wheels = []` on its own is likewise treated as a specified distribution and validates without requiring a direct URL source.

## 3. `select()` raised `KeyError` on partial environments

`Pylock.select()` indexed `environment["python_full_version"]` directly, so a partial environment dict missing that key raised a bare `KeyError`, even though the adjacent code (`dict(environment or {})`) anticipates partial environments and lets `Marker.evaluate` fill defaults:

```python
>>> list(lock.select(environment={"sys_platform": "linux"}))
KeyError: 'python_full_version'   # before
```

The lookup now falls back to `markers.default_environment()["python_full_version"]` when the key is missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
