### PR TITLE
fix: duplicate explicit abi3t tags

### DIFF
--- a/src/packaging/tags.py
+++ b/src/packaging/tags.py
@@ -381,8 +381,10 @@ def cpython_tags(
     if abis is None:
         abis = _cpython_abis(python_version, warn) if len(python_version) > 1 else []
     abis = list(abis)
-    # 'abi3' and 'none' are explicitly handled later.
-    for explicit_abi in ("abi3", "none"):
+    threading = _is_threaded_cpython(abis)
+    # Stable ABIs and 'none' are explicitly handled later.
+    explicit_abis = ("abi3", "abi3t", "none") if threading else ("abi3", "none")
+    for explicit_abi in explicit_abis:
         try:
             abis.remove(explicit_abi)
         except ValueError:  # noqa: PERF203
@@ -393,10 +395,8 @@ def cpython_tags(
         for platform_ in platforms:
             yield Tag(interpreter, abi, platform_)
 
-    threading = _is_threaded_cpython(abis)
     use_abi3 = _abi3_applies(python_version, threading)
     use_abi3t = _abi3t_applies(python_version, threading)
-
     if use_abi3:
         yield from (Tag(interpreter, "abi3", platform_) for platform_ in platforms)
     if use_abi3t:

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -1146,19 +1146,8 @@ class TestCPythonTags:
             tags.Tag("cp315", "cp315t", "platform"),
             tags.Tag("cp315", "abi3t", "platform"),
             tags.Tag("cp315", "none", "platform"),
-            tags.Tag("cp314", "abi3t", "platform"),
-            tags.Tag("cp313", "abi3t", "platform"),
-            tags.Tag("cp312", "abi3t", "platform"),
-            tags.Tag("cp311", "abi3t", "platform"),
-            tags.Tag("cp310", "abi3t", "platform"),
-            tags.Tag("cp39", "abi3t", "platform"),
-            tags.Tag("cp38", "abi3t", "platform"),
-            tags.Tag("cp37", "abi3t", "platform"),
-            tags.Tag("cp36", "abi3t", "platform"),
-            tags.Tag("cp35", "abi3t", "platform"),
-            tags.Tag("cp34", "abi3t", "platform"),
-            tags.Tag("cp33", "abi3t", "platform"),
-            tags.Tag("cp32", "abi3t", "platform"),
+        ] + [
+            tags.Tag(f"cp3{minor}", "abi3t", "platform") for minor in range(14, 1, -1)
         ]
 
         result = list(tags.cpython_tags((3, 16), ["cp316t"], ["platform"]))

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -1141,6 +1141,26 @@ class TestCPythonTags:
             tags.Tag("cp32", "abi3t", "platform"),
         ]
 
+        result = list(tags.cpython_tags((3, 15), ["cp315t", "abi3t"], ["platform"]))
+        assert result == [
+            tags.Tag("cp315", "cp315t", "platform"),
+            tags.Tag("cp315", "abi3t", "platform"),
+            tags.Tag("cp315", "none", "platform"),
+            tags.Tag("cp314", "abi3t", "platform"),
+            tags.Tag("cp313", "abi3t", "platform"),
+            tags.Tag("cp312", "abi3t", "platform"),
+            tags.Tag("cp311", "abi3t", "platform"),
+            tags.Tag("cp310", "abi3t", "platform"),
+            tags.Tag("cp39", "abi3t", "platform"),
+            tags.Tag("cp38", "abi3t", "platform"),
+            tags.Tag("cp37", "abi3t", "platform"),
+            tags.Tag("cp36", "abi3t", "platform"),
+            tags.Tag("cp35", "abi3t", "platform"),
+            tags.Tag("cp34", "abi3t", "platform"),
+            tags.Tag("cp33", "abi3t", "platform"),
+            tags.Tag("cp32", "abi3t", "platform"),
+        ]
+
         result = list(tags.cpython_tags((3, 16), ["cp316t"], ["platform"]))
         assert result == [
             tags.Tag("cp316", "cp316t", "platform"),

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -1146,9 +1146,7 @@ class TestCPythonTags:
             tags.Tag("cp315", "cp315t", "platform"),
             tags.Tag("cp315", "abi3t", "platform"),
             tags.Tag("cp315", "none", "platform"),
-        ] + [
-            tags.Tag(f"cp3{minor}", "abi3t", "platform") for minor in range(14, 1, -1)
-        ]
+        ] + [tags.Tag(f"cp3{minor}", "abi3t", "platform") for minor in range(14, 1, -1)]
 
         result = list(tags.cpython_tags((3, 16), ["cp316t"], ["platform"]))
         assert result == [


### PR DESCRIPTION
Fixes one of the `tags.py` issues reported in #1239.

When callers pass an explicit threaded CPython ABI list that already includes `abi3t`, `cpython_tags()` currently emits the current-version `abi3t` tag twice: once from the explicit ABI list and once from the generated stable ABI path.

This removes `abi3t` from the explicit ABI list only when the ABI list identifies a threaded CPython build, matching the existing handling for `abi3` and `none` while leaving the broader standalone `abi3t` policy unchanged.

Tests:
- `uv run pytest tests/test_tags.py -q`
- `uv run ruff check src/packaging/tags.py tests/test_tags.py`
- `uv run ruff format --check src/packaging/tags.py tests/test_tags.py`

Pre-submit review: Codex approved the final narrowed diff after earlier review feedback led to reducing the scope to explicit threaded ABI deduplication.
