### PR TITLE
fix: normalize nested extra marker values

### DIFF
--- a/src/packaging/markers.py
+++ b/src/packaging/markers.py
@@ -156,14 +156,16 @@ class Environment(TypedDict):
 def _normalize_extras(
     result: MarkerList | MarkerAtom | str,
 ) -> MarkerList | MarkerAtom | str:
+    if isinstance(result, list):
+        return [_normalize_extras(r) for r in result]
     if not isinstance(result, tuple):
         return result
 
     lhs, op, rhs = result
-    if isinstance(lhs, Variable) and lhs.value == "extra":
+    if isinstance(lhs, Variable) and lhs.value == "extra" and isinstance(rhs, Value):
         normalized_extra = canonicalize_name(rhs.value)
         rhs = Value(normalized_extra)
-    elif isinstance(rhs, Variable) and rhs.value == "extra":
+    elif isinstance(rhs, Variable) and rhs.value == "extra" and isinstance(lhs, Value):
         normalized_extra = canonicalize_name(lhs.value)
         lhs = Value(normalized_extra)
     return lhs, op, rhs

--- a/tests/test_markers.py
+++ b/tests/test_markers.py
@@ -422,6 +422,17 @@ class TestMarker:
         assert str(Marker(lhs)) == f'"{normalized_name}" == extra'
         assert str(Marker(rhs)) == f'extra == "{normalized_name}"'
 
+    def test_nested_extra_str_normalization(self) -> None:
+        marker = Marker(
+            '(extra == "Foo_Bar" or extra == "Baz") and python_version >= "3"'
+        )
+
+        assert (
+            str(marker)
+            == '(extra == "foo-bar" or extra == "baz") and python_version >= "3"'
+        )
+        assert marker.evaluate({"extra": "foo-bar", "python_version": "3.12"})
+
     def test_python_full_version_untagged_user_provided(self) -> None:
         """A user-provided python_full_version ending with a + is also repaired."""
         assert Marker("python_full_version < '3.12'").evaluate(

--- a/tests/test_markers.py
+++ b/tests/test_markers.py
@@ -422,6 +422,12 @@ class TestMarker:
         assert str(Marker(lhs)) == f'"{normalized_name}" == extra'
         assert str(Marker(rhs)) == f'extra == "{normalized_name}"'
 
+    def test_extra_compared_to_variable_not_normalized(self) -> None:
+        # A variable-vs-variable atom must not be rewritten into a string
+        # literal, even when one side is ``extra``.
+        assert str(Marker("extra == os_name")) == "extra == os_name"
+        assert str(Marker("os_name == extra")) == "os_name == extra"
+
     def test_nested_extra_str_normalization(self) -> None:
         marker = Marker(
             '(extra == "Foo_Bar" or extra == "Baz") and python_version >= "3"'


### PR DESCRIPTION
Fixes one of the `markers.py` issues reported in #1239.

`_normalize_extra_values()` delegates each top-level marker item to `_normalize_extras()`, but `_normalize_extras()` only handled tuples. Parenthesized marker groups are represented as nested lists, so literal `extra` comparisons inside parentheses skipped PEP 685 normalization.

This makes `_normalize_extras()` recurse through nested marker lists and keeps the literal-only guards around `extra` normalization so variable operands are not rewritten by this scoped fix.

Tests:
- `uv run pytest tests/test_markers.py -q`
- `uv run ruff check src/packaging/markers.py tests/test_markers.py`
- `uv run ruff format --check src/packaging/markers.py tests/test_markers.py`

Pre-submit review: Codex approved the final scoped diff after earlier review feedback identified that broader variable-variable marker semantics should be left for a separate, spec-backed patch.
