### PR TITLE
fix(metadata): route multipart payloads to unparsed instead of asserting

### DIFF
--- a/src/packaging/metadata.py
+++ b/src/packaging/metadata.py
@@ -228,13 +228,19 @@ def _get_payload(msg: email.message.Message, source: bytes | str) -> str:
     # and we don't need to deal with it.
     if isinstance(source, str):
         payload = msg.get_payload()
-        assert isinstance(payload, str)
+        # A multipart payload makes get_payload() return a list of messages
+        # rather than a str; treat it as unparsable instead of crashing.
+        if not isinstance(payload, str):
+            raise ValueError("payload is not a string")  # noqa: TRY004
         return payload
     # If our source is a bytes, then we're managing the encoding and we need
     # to deal with it.
     else:
         bpayload = msg.get_payload(decode=True)
-        assert isinstance(bpayload, bytes)
+        # A multipart payload makes get_payload(decode=True) return None;
+        # treat it as unparsable instead of crashing.
+        if not isinstance(bpayload, bytes):
+            raise ValueError("payload in an invalid encoding")  # noqa: TRY004
         try:
             return bpayload.decode("utf8", "strict")
         except UnicodeDecodeError as exc:

--- a/src/packaging/metadata.py
+++ b/src/packaging/metadata.py
@@ -229,7 +229,7 @@ def _get_payload(msg: email.message.Message, source: bytes | str) -> str:
     if isinstance(source, str):
         payload = msg.get_payload()
         # A multipart payload makes get_payload() return a list of messages
-        # rather than a str; treat it as unparsable instead of crashing.
+        # rather than a str; route it to ``unparsed``.
         if not isinstance(payload, str):
             raise ValueError("payload is not a string")  # noqa: TRY004
         return payload
@@ -238,7 +238,7 @@ def _get_payload(msg: email.message.Message, source: bytes | str) -> str:
     else:
         bpayload = msg.get_payload(decode=True)
         # A multipart payload makes get_payload(decode=True) return None;
-        # treat it as unparsable instead of crashing.
+        # route it to ``unparsed``.
         if not isinstance(bpayload, bytes):
             raise ValueError("payload in an invalid encoding")  # noqa: TRY004
         try:

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -177,6 +177,42 @@ class TestRawMetadata:
         assert "description" in unparsed
         assert unparsed["description"] == expected
 
+    @pytest.mark.parametrize("encode", [False, True])
+    def test_description_multipart_payload(self, encode: bool) -> None:
+        # A multipart payload makes email's get_payload() return a list of
+        # message parts (str input) or None (bytes input). Previously this
+        # tripped a bare AssertionError in _get_payload (and silently
+        # corrupted the description under python -O); it must instead be
+        # routed to unparsed, like other unparsable bodies.
+        metadata_text = (
+            "Metadata-Version: 2.1\n"
+            "Name: example\n"
+            "Version: 1.0\n"
+            'Content-Type: multipart/mixed; boundary="BOUND"\n'
+            "\n"
+            "--BOUND\n"
+            "Content-Type: text/plain\n"
+            "\n"
+            "the description\n"
+            "--BOUND--\n"
+        )
+        given: str | bytes = metadata_text.encode("utf8") if encode else metadata_text
+        raw, unparsed = metadata.parse_email(given)
+        # Recognized headers still parse; the multipart body is routed to
+        # unparsed via the existing ValueError path instead of crashing. The
+        # stored value mirrors email's get_payload() for each input kind (the
+        # same lenient handling already used for the non-utf8 bytes path).
+        assert raw["name"] == "example"
+        assert "description" not in raw
+        assert "description" in unparsed
+        if encode:
+            # bytes path: get_payload(decode=True) is None for multipart.
+            assert unparsed["description"] == [None]
+        else:
+            # str path: get_payload() is the list of message parts.
+            (payload,) = unparsed["description"]
+            assert isinstance(payload, list)
+
     def test_lowercase_keys(self) -> None:
         header = "AUTHOR: Tarek Ziadé\nWhatever: Else"
         raw, unparsed = metadata.parse_email(header)

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -179,15 +179,11 @@ class TestRawMetadata:
 
     @pytest.mark.parametrize("encode", [False, True])
     def test_description_multipart_payload(self, encode: bool) -> None:
-        # A multipart payload makes email's get_payload() return a list of
-        # message parts (str input) or None (bytes input). Previously this
-        # tripped a bare AssertionError in _get_payload (and silently
-        # corrupted the description under python -O); it must instead be
-        # routed to unparsed, like other unparsable bodies.
+        # A multipart body makes get_payload() return a non-str; it must route
+        # to unparsed rather than trip the old assert.
         metadata_text = (
             "Metadata-Version: 2.1\n"
             "Name: example\n"
-            "Version: 1.0\n"
             'Content-Type: multipart/mixed; boundary="BOUND"\n'
             "\n"
             "--BOUND\n"
@@ -198,20 +194,9 @@ class TestRawMetadata:
         )
         given: str | bytes = metadata_text.encode("utf8") if encode else metadata_text
         raw, unparsed = metadata.parse_email(given)
-        # Recognized headers still parse; the multipart body is routed to
-        # unparsed via the existing ValueError path instead of crashing. The
-        # stored value mirrors email's get_payload() for each input kind (the
-        # same lenient handling already used for the non-utf8 bytes path).
         assert raw["name"] == "example"
         assert "description" not in raw
         assert "description" in unparsed
-        if encode:
-            # bytes path: get_payload(decode=True) is None for multipart.
-            assert unparsed["description"] == [None]
-        else:
-            # str path: get_payload() is the list of message parts.
-            (payload,) = unparsed["description"]
-            assert isinstance(payload, list)
 
     def test_lowercase_keys(self) -> None:
         header = "AUTHOR: Tarek Ziadé\nWhatever: Else"


### PR DESCRIPTION
`parse_email()` crashes with a bare `AssertionError` on a multipart/mixed METADATA payload: `get_payload()` returns a list (str input) and `get_payload(decode=True)` returns `None` (bytes input), both failing the `isinstance` asserts in `_get_payload`. Under `python -O` the asserts are stripped, so the list/`None` is silently stored as the description instead.

This raises the catchable `ValueError` the caller already handles, so a multipart body falls into `unparsed` like other unparsable data — no contract change. The stored value mirrors `email`'s existing lenient handling (same as the non-utf8 bytes path); a richer serialization is intentionally left out of scope.

Surfaced by the Fable review in #1239.

Verification: `pytest tests/test_metadata.py` (301 pass, incl. new str+bytes regression test), `ruff check`, `ruff format --check`, and `mypy` all green.