### PR TITLE
Fix dependency group malformed parse caching

### DIFF
--- a/src/packaging/dependency_groups.py
+++ b/src/packaging/dependency_groups.py
@@ -267,7 +267,7 @@ class DependencyGroupResolver:
                 errors.error(TypeError(f"Invalid dependency group item: {item!r}"))
 
         if errors.errors:
-            return tuple(elements)
+            return ()
 
         self._parsed_groups[group] = tuple(elements)
         return self._parsed_groups[group]

--- a/src/packaging/dependency_groups.py
+++ b/src/packaging/dependency_groups.py
@@ -253,9 +253,20 @@ class DependencyGroupResolver:
                     )
                 else:
                     include_group = item["include-group"]
-                    elements.append(DependencyGroupInclude(include_group=include_group))
+                    if not isinstance(include_group, str):
+                        errors.error(
+                            TypeError(
+                                "Dependency group include-group value is not a string: "
+                                f"{item!r}"
+                            )
+                        )
+                    else:
+                        elements.append(DependencyGroupInclude(include_group=include_group))
             else:
                 errors.error(TypeError(f"Invalid dependency group item: {item!r}"))
+
+        if errors.errors:
+            return tuple(elements)
 
         self._parsed_groups[group] = tuple(elements)
         return self._parsed_groups[group]

--- a/src/packaging/dependency_groups.py
+++ b/src/packaging/dependency_groups.py
@@ -254,12 +254,11 @@ class DependencyGroupResolver:
                 else:
                     include_group = item["include-group"]
                     if not isinstance(include_group, str):
-                        errors.error(
-                            TypeError(
-                                "Dependency group include-group value is not a string: "
-                                f"{item!r}"
-                            )
+                        msg = (
+                            "Dependency group include-group value is not a string: "
+                            f"{item!r}"
                         )
+                        errors.error(TypeError(msg))
                     else:
                         elements.append(
                             DependencyGroupInclude(include_group=include_group)

--- a/src/packaging/dependency_groups.py
+++ b/src/packaging/dependency_groups.py
@@ -261,7 +261,9 @@ class DependencyGroupResolver:
                             )
                         )
                     else:
-                        elements.append(DependencyGroupInclude(include_group=include_group))
+                        elements.append(
+                            DependencyGroupInclude(include_group=include_group)
+                        )
             else:
                 errors.error(TypeError(f"Invalid dependency group item: {item!r}"))
 

--- a/tests/test_dependency_groups.py
+++ b/tests/test_dependency_groups.py
@@ -425,6 +425,29 @@ def test_unknown_object_shape(item: dict[str, str] | object) -> None:
     )
 
 
+@pytest.mark.parametrize(
+    ("item", "exc_type", "match"),
+    [
+        ({}, InvalidDependencyGroupObject, "Invalid dependency group item:"),
+        ({"include-group": 5}, TypeError, "include-group value is not a string"),
+    ],
+)
+def test_malformed_group_entries_are_not_cached_on_resolver_instance(
+    item: object,
+    exc_type: type[BaseException],
+    match: str,
+) -> None:
+    groups: Any = {"test": [item]}
+    resolver = DependencyGroupResolver(groups)
+
+    for _ in range(2):
+        with pytest.raises(
+            ExceptionGroup, match=r"\[dependency-groups\] data for 'test' was malformed"
+        ) as excinfo:
+            resolver.lookup("test")
+        assert _group_contains(excinfo, exc_type, match=match)
+
+
 def test_non_unexpected_item_type() -> None:
     groups: Any = {"test": [object()]}
     with pytest.raises(


### PR DESCRIPTION
Refs #1239

## Summary
- reject non-string `include-group` values before constructing a dependency-group include
- avoid storing parsed dependency groups when parsing collected errors, so repeated lookups keep reporting malformed data
- add regression coverage for repeated malformed lookup on the same resolver

## Tests
- `uv run pytest tests/test_dependency_groups.py -q`
- `uv run ruff check src/packaging/dependency_groups.py tests/test_dependency_groups.py`
