### PR TITLE
fix(markers): wrap malformed quoted strings as public parse errors

### DIFF
--- a/src/packaging/_parser.py
+++ b/src/packaging/_parser.py
@@ -10,7 +10,7 @@ import ast
 from collections.abc import Sequence
 from typing import Literal, NamedTuple, Union
 
-from ._tokenizer import DEFAULT_RULES, Tokenizer
+from ._tokenizer import DEFAULT_RULES, ParserSyntaxError, Tokenizer
 
 
 class Node:
@@ -355,7 +355,15 @@ def _parse_marker_var(tokenizer: Tokenizer) -> MarkerVar:  # noqa: RET503
     if tokenizer.check("VARIABLE"):
         return process_env_var(tokenizer.read().text.replace(".", "_"))
     elif tokenizer.check("QUOTED_STRING"):
-        return process_python_str(tokenizer.read().text)
+        token = tokenizer.read()
+        try:
+            return process_python_str(token.text)
+        except (SyntaxError, ValueError) as exc:
+            raise ParserSyntaxError(
+                "Invalid quoted string",
+                source=tokenizer.source,
+                span=(token.position, token.position + len(token.text)),
+            ) from exc
     else:
         tokenizer.raise_syntax_error(
             message="Expected a marker variable or quoted string"

--- a/tests/test_markers.py
+++ b/tests/test_markers.py
@@ -201,6 +201,31 @@ class TestMarker:
     @pytest.mark.parametrize(
         ("marker_string", "expected"),
         [
+            (
+                'os_name == "C:\\"',
+                "packaging.markers.InvalidMarker: Invalid quoted string\n"
+                '    os_name == "C:\\"\n'
+                "               ~~~~~^",
+            ),
+            (
+                r'os_name == "\x"',
+                "packaging.markers.InvalidMarker: Invalid quoted string\n"
+                r'    os_name == "\x"'
+                "\n"
+                "               ~~~~^",
+            ),
+        ],
+    )
+    def test_parses_invalid_malformed_quoted_string(
+        self, marker_string: str, expected: str
+    ) -> None:
+        with pytest.raises(InvalidMarker) as ctx:
+            Marker(marker_string)
+        assert ctx.exconly() == expected
+
+    @pytest.mark.parametrize(
+        ("marker_string", "expected"),
+        [
             # Test the different quoting rules
             ("python_version == '2.7'", 'python_version == "2.7"'),
             ('python_version == "2.7"', 'python_version == "2.7"'),

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -463,6 +463,34 @@ class TestRequirementParsing:
             "                   ^"
         )
 
+    @pytest.mark.parametrize(
+        ("to_parse", "expected"),
+        [
+            (
+                'name; os_name == "C:\\"',
+                "packaging.requirements.InvalidRequirement: Invalid quoted string\n"
+                '    name; os_name == "C:\\"\n'
+                "                     ~~~~~^",
+            ),
+            (
+                r'name; os_name == "\x"',
+                "packaging.requirements.InvalidRequirement: Invalid quoted string\n"
+                r'    name; os_name == "\x"'
+                "\n"
+                "                     ~~~~^",
+            ),
+        ],
+    )
+    def test_error_invalid_marker_malformed_quoted_string(
+        self, to_parse: str, expected: str
+    ) -> None:
+        # WHEN
+        with pytest.raises(InvalidRequirement) as ctx:
+            Requirement(to_parse)
+
+        # THEN
+        assert ctx.exconly() == expected
+
     def test_error_invalid_marker_notin_without_whitespace(self) -> None:
         # GIVEN
         to_parse = "name; '3.7' notin python_version"


### PR DESCRIPTION
## Summary

Malformed quoted marker strings can currently leak a raw `SyntaxError` from `ast.literal_eval()` instead of the public parser exceptions callers expect. For example, `Marker('os_name == "C:\"')` and `Requirement('pkg; os_name == "C:\"')` bypass `InvalidMarker` / `InvalidRequirement`.

This converts literal-eval failures in the quoted-string parser path into `ParserSyntaxError`, preserving the existing public wrappers and full source/caret diagnostics.

This addresses one malformed-literal item from #1239.

## Verification

- `uv run pytest tests/test_markers.py tests/test_requirements.py -q`
- `uv run ruff check src/packaging/_parser.py tests/test_markers.py tests/test_requirements.py`
- `uv run ruff format --check src/packaging/_parser.py tests/test_markers.py tests/test_requirements.py`
- Codex adversarial review: reworked tests to pin exact diagnostics, final `VERDICT: approve`

Known scope: this does not change marker grammar; it only maps malformed quoted literals that already reach the quoted-string parser branch onto the existing public exception contract.