### PR TITLE
perf(markers): cache the default environment

### DIFF
--- a/src/packaging/markers.py
+++ b/src/packaging/markers.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import functools
 import operator
 import os
 import platform
@@ -337,6 +338,21 @@ def default_environment() -> Environment:
     }
 
 
+@functools.lru_cache(maxsize=1)
+def _cached_default_environment() -> Environment:
+    """Return a cached copy of :func:`default_environment`.
+
+    The values returned by :func:`default_environment` are derived from
+    process-constant data (the running interpreter and the host platform), so
+    rebuilding them on every :meth:`Marker.evaluate` call is wasteful. This
+    helper is used only by :meth:`Marker.evaluate`.
+
+    The returned dictionary is shared between callers and must never be mutated;
+    :meth:`Marker.evaluate` copies it before applying overrides.
+    """
+    return default_environment()
+
+
 class Marker:
     """Represents a parsed dependency marker expression.
 
@@ -486,8 +502,11 @@ class Marker:
         :returns: ``True`` if the marker matches, otherwise ``False``.
 
         """
+        # Copy the cached environment before mutating it below: the cached dict
+        # is shared between calls and must not be modified. A shallow copy is
+        # enough because every value is an immutable string.
         current_environment = cast(
-            "dict[str, str | AbstractSet[str]]", default_environment()
+            "dict[str, str | AbstractSet[str]]", dict(_cached_default_environment())
         )
         if context == "lock_file":
             current_environment |= {

--- a/src/packaging/markers.py
+++ b/src/packaging/markers.py
@@ -316,10 +316,14 @@ def _format_full_version(info: sys._version_info) -> str:
     return version
 
 
-def default_environment() -> Environment:
-    """Return the default marker environment for the current Python process.
+@functools.cache
+def _cached_default_environment() -> Environment:
+    """Build the default marker environment for the current Python process.
 
-    This is the base environment used by :meth:`Marker.evaluate`.
+    The values are derived from process-constant data (the running interpreter
+    and the host platform), so this is cached and built only once. The result is
+    shared between callers and must never be mutated; :func:`default_environment`
+    returns a fresh copy.
     """
     iver = _format_full_version(sys.implementation.version)
     implementation_name = sys.implementation.name
@@ -338,19 +342,14 @@ def default_environment() -> Environment:
     }
 
 
-@functools.lru_cache(maxsize=1)
-def _cached_default_environment() -> Environment:
-    """Return a cached copy of :func:`default_environment`.
+def default_environment() -> Environment:
+    """Return the default marker environment for the current Python process.
 
-    The values returned by :func:`default_environment` are derived from
-    process-constant data (the running interpreter and the host platform), so
-    rebuilding them on every :meth:`Marker.evaluate` call is wasteful. This
-    helper is used only by :meth:`Marker.evaluate`.
-
-    The returned dictionary is shared between callers and must never be mutated;
-    :meth:`Marker.evaluate` copies it before applying overrides.
+    This is the base environment used by :meth:`Marker.evaluate`. A fresh copy
+    is returned on every call so callers may freely mutate the result; a shallow
+    copy suffices because all values are immutable strings.
     """
-    return default_environment()
+    return cast("Environment", dict(_cached_default_environment()))
 
 
 class Marker:
@@ -502,11 +501,8 @@ class Marker:
         :returns: ``True`` if the marker matches, otherwise ``False``.
 
         """
-        # Copy the cached environment before mutating it below: the cached dict
-        # is shared between calls and must not be modified. A shallow copy is
-        # enough because every value is an immutable string.
         current_environment = cast(
-            "dict[str, str | AbstractSet[str]]", dict(_cached_default_environment())
+            "dict[str, str | AbstractSet[str]]", default_environment()
         )
         if context == "lock_file":
             current_environment |= {

--- a/src/packaging/markers.py
+++ b/src/packaging/markers.py
@@ -348,6 +348,12 @@ def default_environment() -> Environment:
     This is the base environment used by :meth:`Marker.evaluate`. A fresh copy
     is returned on every call so callers may freely mutate the result; a shallow
     copy suffices because all values are immutable strings.
+
+    .. versionchanged:: 26.3
+        The environment is computed once per process and cached, since it is
+        derived from process-constant data. Patching ``platform``/``sys``/``os``
+        after the first call has no effect; pass an explicit ``environment`` to
+        :meth:`Marker.evaluate` to evaluate against different values.
     """
     return cast("Environment", dict(_cached_default_environment()))
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,23 @@
 from __future__ import annotations
 
 import sysconfig
+import typing
+
+import pytest
+
+from packaging.markers import _cached_default_environment
+
+if typing.TYPE_CHECKING:
+    from collections.abc import Generator
+
+
+@pytest.fixture(autouse=True)
+def _clear_default_environment_cache() -> Generator[None, None, None]:
+    # default_environment() is cached, so tests that patch platform/sys must run
+    # against a fresh cache and must not leak their patched values to later tests.
+    _cached_default_environment.cache_clear()
+    yield
+    _cached_default_environment.cache_clear()
 
 
 def pytest_report_header() -> str:

--- a/tests/test_markers.py
+++ b/tests/test_markers.py
@@ -20,6 +20,7 @@ from packaging.markers import (
     Marker,
     UndefinedComparison,
     UndefinedEnvironmentName,
+    _cached_default_environment,
     _format_full_version,
     default_environment,
 )
@@ -472,8 +473,29 @@ class TestMarker:
         )
 
     def test_python_full_version_untagged(self) -> None:
-        with mock.patch("platform.python_version", return_value="3.11.1+"):
-            assert Marker("python_full_version < '3.12'").evaluate()
+        # Marker.evaluate() reads from a cached environment, so clear the cache
+        # around the patched platform.python_version to make the patch visible.
+        _cached_default_environment.cache_clear()
+        try:
+            with mock.patch("platform.python_version", return_value="3.11.1+"):
+                assert Marker("python_full_version < '3.12'").evaluate()
+        finally:
+            _cached_default_environment.cache_clear()
+
+    def test_evaluate_does_not_mutate_cached_environment(self) -> None:
+        # An evaluate() call that overrides values (and adds "extra") must not
+        # leak those overrides into the cached environment used by later calls.
+        _cached_default_environment.cache_clear()
+        marker = Marker("os_name == 'magic'")
+        assert marker.evaluate({"os_name": "magic"})
+
+        cached = _cached_default_environment()
+        assert cached["os_name"] == os.name
+        assert "extra" not in cached
+
+        # A second evaluate with no overrides must not see the first call's
+        # overrides, confirming the cache was copied rather than mutated.
+        assert not marker.evaluate()
 
     @pytest.mark.parametrize("variable", ["extras", "dependency_groups"])
     @pytest.mark.parametrize(

--- a/tests/test_markers.py
+++ b/tests/test_markers.py
@@ -48,14 +48,6 @@ PEP_345_VARIABLES = [
     "platform.python_implementation",
 ]
 
-
-@pytest.fixture(autouse=True)
-def _clear_default_environment_cache() -> None:
-    # default_environment() is cached, so tests that patch platform/sys must run
-    # against a fresh cache and must not leak their patched values to later tests.
-    _cached_default_environment.cache_clear()
-
-
 SETUPTOOLS_VARIABLES = ["python_implementation"]
 
 OPERATORS = ["===", "==", ">=", "<=", "!=", "~=", ">", "<", "in", "not in"]

--- a/tests/test_markers.py
+++ b/tests/test_markers.py
@@ -48,6 +48,14 @@ PEP_345_VARIABLES = [
     "platform.python_implementation",
 ]
 
+
+@pytest.fixture(autouse=True)
+def _clear_default_environment_cache() -> None:
+    # default_environment() is cached, so tests that patch platform/sys must run
+    # against a fresh cache and must not leak their patched values to later tests.
+    _cached_default_environment.cache_clear()
+
+
 SETUPTOOLS_VARIABLES = ["python_implementation"]
 
 OPERATORS = ["===", "==", ">=", "<=", "!=", "~=", ">", "<", "in", "not in"]
@@ -473,19 +481,12 @@ class TestMarker:
         )
 
     def test_python_full_version_untagged(self) -> None:
-        # Marker.evaluate() reads from a cached environment, so clear the cache
-        # around the patched platform.python_version to make the patch visible.
-        _cached_default_environment.cache_clear()
-        try:
-            with mock.patch("platform.python_version", return_value="3.11.1+"):
-                assert Marker("python_full_version < '3.12'").evaluate()
-        finally:
-            _cached_default_environment.cache_clear()
+        with mock.patch("platform.python_version", return_value="3.11.1+"):
+            assert Marker("python_full_version < '3.12'").evaluate()
 
     def test_evaluate_does_not_mutate_cached_environment(self) -> None:
         # An evaluate() call that overrides values (and adds "extra") must not
         # leak those overrides into the cached environment used by later calls.
-        _cached_default_environment.cache_clear()
         marker = Marker("os_name == 'magic'")
         assert marker.evaluate({"os_name": "magic"})
 


### PR DESCRIPTION
Reworked this to cache default_environment, so downstream users that patch out default_environment for test or cross-compiling still work. This is a very nice 2x speed up on the evaluation, which has been hard to speed up in the past.

:robot: _AI text below_ :robot:

`Marker.evaluate()` called `default_environment()` on every invocation, re-querying `platform`/`os`/`sys` each time even though the values are process-constant.

This moves the build behind a private `functools.cache` helper, `_cached_default_environment()`. The public `default_environment()` now returns a shallow copy of the cached dict on every call, so it still hands back a fresh, freely-mutable result (a shallow copy is safe because every value is an immutable `str`). `Marker.evaluate()` goes back to calling `default_environment()` directly, so every caller benefits from the cache, not just `evaluate()`. An unbounded `functools.cache` is used over `lru_cache(maxsize=1)`: it's faster and never holds more than one entry.

`asv continuous` (Python 3.14, Apple M5 Pro):

| Benchmark | main | this PR | Ratio |
|---|---|---|---|
| `markers.TimeMarkerSuite.time_evaluate` | 425±9μs | 219±7μs | **0.51** |

One behavior note for reviewers: code that monkeypatches `platform`/`os`/`sys` functions and expects `default_environment()` (or `Marker.evaluate()`) to reflect the patched values will now see the cached environment instead. The repo's own tests handle this with an autouse fixture that clears `_cached_default_environment` before each test; downstream test suites doing the same would need to clear the cache (or pass an explicit `environment=`).

Combined with #1251 (the `_eval_op` specifier cache), `time_evaluate` goes to 190μs (0.46× of main).

Part of #1239.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
