### PR TITLE
perf(markers): cache Specifier parsing in _eval_op

### DIFF
--- a/src/packaging/markers.py
+++ b/src/packaging/markers.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import functools
 import operator
 import os
 import platform
@@ -217,14 +218,32 @@ _operators: dict[str, Operator] = {
 }
 
 
+# Cache bound at 64 entries: there are at most 8 version comparison operators
+# and real-world markers use a small, stable set of version strings, so 64
+# slots comfortably covers typical resolver workloads without growing without
+# limit in long-running processes.
+@functools.lru_cache(maxsize=64)
+def _get_specifier(spec_str: str) -> Specifier | None:
+    """Return a cached :class:`Specifier` for *spec_str*, or ``None`` on parse failure.
+
+    The result is cached so that repeated marker evaluations with the same
+    operator/version pair avoid re-parsing the specifier string each time.
+    ``None`` is returned (rather than raising) because
+    :func:`functools.lru_cache` does not cache raised exceptions, which would
+    defeat the purpose of the cache on invalid inputs.
+    """
+    try:
+        return Specifier(spec_str)
+    except InvalidSpecifier:
+        return None
+
+
 def _eval_op(lhs: str, op: Op, rhs: str | AbstractSet[str], *, key: str) -> bool:
     op_str = op.serialize()
     if key in MARKERS_REQUIRING_VERSION:
-        try:
-            spec = Specifier(f"{op_str}{rhs}")
-        except InvalidSpecifier:
-            pass
-        else:
+        assert isinstance(rhs, str), "version marker rhs must be a string"
+        spec = _get_specifier(f"{op_str}{rhs}")
+        if spec is not None:
             return spec.contains(lhs, prereleases=True)
 
     oper: Operator | None = _operators.get(op_str)


### PR DESCRIPTION
:robot: _AI text below_ :robot:

For version-like marker keys, `_eval_op` constructed `Specifier(f"{op}{rhs}")` on every evaluation, so the same handful of specifier strings get re-parsed on each `Marker.evaluate()` call on resolver hot paths. This routes construction through a module-private `lru_cache(maxsize=64)` helper that returns `Specifier | None` (`InvalidSpecifier` is caught inside the helper so the failure case is cached too, since `lru_cache` does not cache exceptions). Sharing instances is safe: nothing mutates them and `contains()` passes `prereleases=True` explicitly.

`asv continuous` (Python 3.14, Apple M5 Pro):

| Benchmark | main | this PR | Ratio |
|---|---|---|---|
| `markers.TimeMarkerSuite.time_evaluate` | 407±5μs | 382±5μs | **0.94** |

The win is modest on its own because the `default_environment()` rebuild dominates `evaluate()` on main; combined with #1250 the benchmark drops to 190μs (0.46× of main).

Part of #1239.

🤖 Generated with [Claude Code](https://claude.com/claude-code)