### PR TITLE
perf(specifiers): keep range caches across canonicalization

### DIFF
--- a/src/packaging/specifiers.py
+++ b/src/packaging/specifiers.py
@@ -827,8 +827,12 @@ class SpecifierSet(BaseSpecifier):
         if not self._canonicalized:
             self._specs = tuple(dict.fromkeys(sorted(self._specs, key=str)))
             self._canonicalized = True
-            self._is_unsatisfiable = None
-            self._ranges = None
+            # Canonicalization only reorders and removes duplicate specs; it
+            # does not change the set of constraints. Both ``_ranges`` (the
+            # intersection of every spec's ranges) and ``_is_unsatisfiable``
+            # depend only on that set, since range intersection is
+            # commutative, associative, and idempotent. The caches therefore
+            # stay valid and are deliberately left intact here.
         return self._specs
 
     @property

--- a/src/packaging/specifiers.py
+++ b/src/packaging/specifiers.py
@@ -827,12 +827,6 @@ class SpecifierSet(BaseSpecifier):
         if not self._canonicalized:
             self._specs = tuple(dict.fromkeys(sorted(self._specs, key=str)))
             self._canonicalized = True
-            # Canonicalization only reorders and removes duplicate specs; it
-            # does not change the set of constraints. Both ``_ranges`` (the
-            # intersection of every spec's ranges) and ``_is_unsatisfiable``
-            # depend only on that set, since range intersection is
-            # commutative, associative, and idempotent. The caches therefore
-            # stay valid and are deliberately left intact here.
         return self._specs
 
     @property

--- a/tests/test_specifiers.py
+++ b/tests/test_specifiers.py
@@ -2890,6 +2890,60 @@ class TestIsUnsatisfiable:
         combined = s1 & s2
         assert not combined.is_unsatisfiable()
 
+    def test_canonicalization_keeps_range_cache(self) -> None:
+        """Canonicalization must not discard the computed range cache.
+
+        ``_canonical_specs`` only reorders and dedupes specs, which leaves
+        the intersected ranges unchanged, so the expensive ``_ranges`` cache
+        must survive a canonicalizing operation such as ``str()``.
+        """
+        ss = SpecifierSet(">=1.0,<2.0,!=1.5")
+        # filter() builds and caches the intersected ranges, the same cache
+        # the range path of contains() reuses.
+        assert list(ss.filter(["1.2"])) == ["1.2"]
+        assert ss._ranges is not None
+        cached_ranges = ss._ranges
+        # str() forces canonicalization (sort + dedup of the spec tuple).
+        str(ss)
+        # The range cache must still be present and unchanged.
+        assert ss._ranges is cached_ranges
+        # A subsequent contains() now reuses the surviving cache.
+        assert ss.contains("1.2")
+        assert ss._ranges is cached_ranges
+
+    def test_canonicalization_keeps_unsatisfiable_cache(self) -> None:
+        """Canonicalization must not discard the unsatisfiability cache."""
+        ss = SpecifierSet(">=2.0,<1.0")
+        assert ss.is_unsatisfiable()
+        assert ss._is_unsatisfiable is True
+        # Force canonicalization; the cached verdict must remain.
+        str(ss)
+        assert ss._is_unsatisfiable is True
+
+    @pytest.mark.parametrize(
+        ("spec", "versions"),
+        [
+            # Duplicate specifiers.
+            (">=1.0,>=1.0,<2.0", ["0.5", "1.0", "1.5", "2.0", "2.5"]),
+            # Unsorted order.
+            ("<2.0,!=1.5,>=1.0", ["0.5", "1.0", "1.5", "1.9", "2.0"]),
+            # != plus post-release edge cases.
+            ("!=1.0,>=1.0", ["1.0", "1.0.post1", "1.1"]),
+            (">1.0,!=1.0.post1", ["1.0", "1.0.post1", "1.0.post2", "1.1"]),
+        ],
+    )
+    def test_contains_identical_across_canonicalization(
+        self, spec: str, versions: list[str]
+    ) -> None:
+        """contains() results are stable before and after canonicalization."""
+        before = {v: SpecifierSet(spec).contains(v) for v in versions}
+        ss = SpecifierSet(spec)
+        # Populate the range cache, then canonicalize via str().
+        _ = {v: ss.contains(v) for v in versions}
+        str(ss)
+        after = {v: ss.contains(v) for v in versions}
+        assert after == before
+
     def test_range_bounds_hashable_and_equal(self) -> None:
         """Range bounds are hashable and support equality."""
         a = Specifier(">1.0")._to_ranges()


### PR DESCRIPTION
:robot: _AI text below_ :robot:

`SpecifierSet._canonical_specs()` reset `_is_unsatisfiable` and `_ranges` whenever it canonicalized, so calling `filter()`/`is_unsatisfiable()` (which compute the range intersection) followed by `str()`/`hash()`/`==` (which canonicalize) threw the expensive intersection away, and the next range-based call recomputed it.

Canonicalization is just `dict.fromkeys(sorted(specs, key=str))` — a reorder plus exact-duplicate dedup. Both caches depend only on the *set* of constraints: each `Specifier._to_ranges()` is a pure function of that one spec, and `intersect_ranges` is mathematical set intersection (commutative, associative, idempotent), so reordering or deduplicating specs cannot change the result. `_is_unsatisfiable` derives from the ranges plus symmetric checks over the `===` specs. The reset in the `prereleases` setter stays, since prereleases genuinely affects satisfiability.

The existing asv suite never interleaves the two operation families, so it shows no change (and no regressions). A targeted microbenchmark of `is_unsatisfiable()` → `str()` → `is_unsatisfiable()` on an 8-spec set (Python 3.14, Apple M5 Pro): 67.4μs → 42.0μs per round (**1.6×**). The cost on main is bounded — one extra range computation per object lifetime — so this mostly matters for many short-lived sets, e.g. resolvers hashing or printing specifier sets they also evaluate.

Regression tests pin that the cache object survives canonicalization and that `contains()` results are identical before/after for duplicate, unsorted, and post-release-`!=` sets.

Part of #1239.

🤖 Generated with [Claude Code](https://claude.com/claude-code)