### PR TITLE
perf(manylinux): cache _manylinux module lookup process-wide

### DIFF
--- a/src/packaging/_manylinux.py
+++ b/src/packaging/_manylinux.py
@@ -183,22 +183,25 @@ def _get_glibc_version() -> _GLibCVersion:
 
 
 # From PEP 513, PEP 600
+@functools.lru_cache(maxsize=1)
 def _get_manylinux_module() -> types.ModuleType | None:
-    """Return the ``_manylinux`` C extension module, or None if unavailable."""
+    """Return the ``_manylinux`` C extension module, or None if unavailable.
+
+    The result is cached for the lifetime of the process, since the presence
+    of the module does not change while running.
+    """
     try:
-        import _manylinux  # noqa: F401, PLC0415
+        return __import__("_manylinux")
     except ImportError:
         return None
-    return sys.modules["_manylinux"]
 
 
-def _is_compatible(
-    arch: str, version: _GLibCVersion, manylinux_mod: types.ModuleType | None
-) -> bool:
+def _is_compatible(arch: str, version: _GLibCVersion) -> bool:
     sys_glibc = _get_glibc_version()
     if sys_glibc < version:
         return False
     # Check for presence of _manylinux module.
+    manylinux_mod = _get_manylinux_module()
     if manylinux_mod is None:
         return True
     if hasattr(manylinux_mod, "manylinux_compatible"):
@@ -260,9 +263,6 @@ def platform_tags(archs: Sequence[str]) -> Iterator[str]:
     for glibc_major in range(current_glibc.major - 1, 1, -1):
         glibc_minor = _LAST_GLIBC_MINOR[glibc_major]
         glibc_max_list.append(_GLibCVersion(glibc_major, glibc_minor))
-    # Resolve the _manylinux module once for the entire loop rather than
-    # re-running the import machinery on every (arch, glibc-version) pair.
-    manylinux_mod = _get_manylinux_module()
     for arch in archs:
         for glibc_max in glibc_max_list:
             if glibc_max.major == too_old_glibc2.major:
@@ -272,7 +272,7 @@ def platform_tags(archs: Sequence[str]) -> Iterator[str]:
                 min_minor = -1
             for glibc_minor in range(glibc_max.minor, min_minor, -1):
                 glibc_version = _GLibCVersion(glibc_max.major, glibc_minor)
-                if _is_compatible(arch, glibc_version, manylinux_mod):
+                if _is_compatible(arch, glibc_version):
                     yield "manylinux_{}_{}_{}".format(*glibc_version, arch)
 
                     # Handle the legacy manylinux1, manylinux2010, manylinux2014 tags.

--- a/src/packaging/_manylinux.py
+++ b/src/packaging/_manylinux.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, NamedTuple
 from ._elffile import EIClass, EIData, ELFFile, EMachine
 
 if TYPE_CHECKING:
+    import types
     from collections.abc import Generator, Iterator, Sequence
 
 EF_ARM_ABIMASK = 0xFF000000
@@ -182,30 +183,41 @@ def _get_glibc_version() -> _GLibCVersion:
 
 
 # From PEP 513, PEP 600
-def _is_compatible(arch: str, version: _GLibCVersion) -> bool:
+def _get_manylinux_module() -> types.ModuleType | None:
+    """Return the ``_manylinux`` C extension module, or None if unavailable."""
+    try:
+        import _manylinux  # noqa: F401, PLC0415
+    except ImportError:
+        return None
+    return sys.modules["_manylinux"]
+
+
+def _is_compatible(
+    arch: str, version: _GLibCVersion, manylinux_mod: types.ModuleType | None
+) -> bool:
     sys_glibc = _get_glibc_version()
     if sys_glibc < version:
         return False
     # Check for presence of _manylinux module.
-    try:
-        import _manylinux  # noqa: PLC0415
-    except ImportError:
+    if manylinux_mod is None:
         return True
-    if hasattr(_manylinux, "manylinux_compatible"):
-        result = _manylinux.manylinux_compatible(version[0], version[1], arch)
+    if hasattr(manylinux_mod, "manylinux_compatible"):
+        result = manylinux_mod.manylinux_compatible(version[0], version[1], arch)
         if result is not None:
             return bool(result)
         return True
-    if version == _GLibCVersion(2, 5) and hasattr(_manylinux, "manylinux1_compatible"):
-        return bool(_manylinux.manylinux1_compatible)
+    if version == _GLibCVersion(2, 5) and hasattr(
+        manylinux_mod, "manylinux1_compatible"
+    ):
+        return bool(manylinux_mod.manylinux1_compatible)
     if version == _GLibCVersion(2, 12) and hasattr(
-        _manylinux, "manylinux2010_compatible"
+        manylinux_mod, "manylinux2010_compatible"
     ):
-        return bool(_manylinux.manylinux2010_compatible)
+        return bool(manylinux_mod.manylinux2010_compatible)
     if version == _GLibCVersion(2, 17) and hasattr(
-        _manylinux, "manylinux2014_compatible"
+        manylinux_mod, "manylinux2014_compatible"
     ):
-        return bool(_manylinux.manylinux2014_compatible)
+        return bool(manylinux_mod.manylinux2014_compatible)
     return True
 
 
@@ -248,6 +260,9 @@ def platform_tags(archs: Sequence[str]) -> Iterator[str]:
     for glibc_major in range(current_glibc.major - 1, 1, -1):
         glibc_minor = _LAST_GLIBC_MINOR[glibc_major]
         glibc_max_list.append(_GLibCVersion(glibc_major, glibc_minor))
+    # Resolve the _manylinux module once for the entire loop rather than
+    # re-running the import machinery on every (arch, glibc-version) pair.
+    manylinux_mod = _get_manylinux_module()
     for arch in archs:
         for glibc_max in glibc_max_list:
             if glibc_max.major == too_old_glibc2.major:
@@ -257,7 +272,7 @@ def platform_tags(archs: Sequence[str]) -> Iterator[str]:
                 min_minor = -1
             for glibc_minor in range(glibc_max.minor, min_minor, -1):
                 glibc_version = _GLibCVersion(glibc_max.major, glibc_minor)
-                if _is_compatible(arch, glibc_version):
+                if _is_compatible(arch, glibc_version, manylinux_mod):
                     yield "manylinux_{}_{}_{}".format(*glibc_version, arch)
 
                     # Handle the legacy manylinux1, manylinux2010, manylinux2014 tags.

--- a/tests/test_manylinux.py
+++ b/tests/test_manylinux.py
@@ -21,6 +21,7 @@ import pytest
 from packaging import _manylinux
 from packaging._manylinux import (
     _get_glibc_version,
+    _get_manylinux_module,
     _glibc_version_string,
     _glibc_version_string_confstr,
     _glibc_version_string_ctypes,
@@ -60,7 +61,7 @@ def test_module_declaration(
     manylinux = f"manylinux{attribute}_compatible"
     monkeypatch.setattr(manylinux_module, manylinux, tf, raising=False)
     glibc_version = _GLibCVersion(glibc[0], glibc[1])
-    res = _is_compatible("x86_64", glibc_version)
+    res = _is_compatible("x86_64", glibc_version, _get_manylinux_module())
     assert tf is res
 
 
@@ -76,7 +77,7 @@ def test_module_declaration_missing_attribute(
     manylinux = f"manylinux{attribute}_compatible"
     monkeypatch.delattr(manylinux_module, manylinux, raising=False)
     glibc_version = _GLibCVersion(glibc[0], glibc[1])
-    assert _is_compatible("x86_64", glibc_version)
+    assert _is_compatible("x86_64", glibc_version, _get_manylinux_module())
 
 
 @pytest.mark.parametrize(
@@ -88,7 +89,10 @@ def test_is_manylinux_compatible_glibc_support(
     monkeypatch.setitem(sys.modules, "_manylinux", None)
     monkeypatch.setattr(_manylinux, "_get_glibc_version", lambda: (2, 5))
     glibc_version = _GLibCVersion(version[0], version[1])
-    assert bool(_is_compatible("any", glibc_version)) == compatible
+    assert (
+        bool(_is_compatible("any", glibc_version, _get_manylinux_module()))
+        == compatible
+    )
 
 
 @pytest.mark.parametrize("version_str", ["glibc-2.4.5", "2"])
@@ -182,17 +186,17 @@ def test_glibc_version_string_ctypes_raise_oserror(
 def test_is_manylinux_compatible_old() -> None:
     # Assuming no one is running this test with a version of glibc released in
     # 1997.
-    assert _is_compatible("any", _GLibCVersion(2, 0))
+    assert _is_compatible("any", _GLibCVersion(2, 0), _get_manylinux_module())
 
 
 def test_is_manylinux_compatible(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(_manylinux, "_glibc_version_string", lambda: "2.4")
-    assert _is_compatible("any", _GLibCVersion(2, 4))
+    assert _is_compatible("any", _GLibCVersion(2, 4), _get_manylinux_module())
 
 
 def test_glibc_version_string_none(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(_manylinux, "_glibc_version_string", lambda: None)
-    assert not _is_compatible("any", _GLibCVersion(2, 4))
+    assert not _is_compatible("any", _GLibCVersion(2, 4), _get_manylinux_module())
 
 
 @pytest.mark.parametrize(

--- a/tests/test_manylinux.py
+++ b/tests/test_manylinux.py
@@ -36,6 +36,7 @@ from packaging._manylinux import (
 def clear_lru_cache() -> Generator[None, None, None]:
     yield
     _get_glibc_version.cache_clear()
+    _get_manylinux_module.cache_clear()
 
 
 @pytest.fixture
@@ -61,7 +62,7 @@ def test_module_declaration(
     manylinux = f"manylinux{attribute}_compatible"
     monkeypatch.setattr(manylinux_module, manylinux, tf, raising=False)
     glibc_version = _GLibCVersion(glibc[0], glibc[1])
-    res = _is_compatible("x86_64", glibc_version, _get_manylinux_module())
+    res = _is_compatible("x86_64", glibc_version)
     assert tf is res
 
 
@@ -77,7 +78,7 @@ def test_module_declaration_missing_attribute(
     manylinux = f"manylinux{attribute}_compatible"
     monkeypatch.delattr(manylinux_module, manylinux, raising=False)
     glibc_version = _GLibCVersion(glibc[0], glibc[1])
-    assert _is_compatible("x86_64", glibc_version, _get_manylinux_module())
+    assert _is_compatible("x86_64", glibc_version)
 
 
 @pytest.mark.parametrize(
@@ -89,10 +90,7 @@ def test_is_manylinux_compatible_glibc_support(
     monkeypatch.setitem(sys.modules, "_manylinux", None)
     monkeypatch.setattr(_manylinux, "_get_glibc_version", lambda: (2, 5))
     glibc_version = _GLibCVersion(version[0], version[1])
-    assert (
-        bool(_is_compatible("any", glibc_version, _get_manylinux_module()))
-        == compatible
-    )
+    assert bool(_is_compatible("any", glibc_version)) == compatible
 
 
 @pytest.mark.parametrize("version_str", ["glibc-2.4.5", "2"])
@@ -186,17 +184,17 @@ def test_glibc_version_string_ctypes_raise_oserror(
 def test_is_manylinux_compatible_old() -> None:
     # Assuming no one is running this test with a version of glibc released in
     # 1997.
-    assert _is_compatible("any", _GLibCVersion(2, 0), _get_manylinux_module())
+    assert _is_compatible("any", _GLibCVersion(2, 0))
 
 
 def test_is_manylinux_compatible(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(_manylinux, "_glibc_version_string", lambda: "2.4")
-    assert _is_compatible("any", _GLibCVersion(2, 4), _get_manylinux_module())
+    assert _is_compatible("any", _GLibCVersion(2, 4))
 
 
 def test_glibc_version_string_none(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(_manylinux, "_glibc_version_string", lambda: None)
-    assert not _is_compatible("any", _GLibCVersion(2, 4), _get_manylinux_module())
+    assert not _is_compatible("any", _GLibCVersion(2, 4))
 
 
 @pytest.mark.parametrize(

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -655,7 +655,7 @@ class TestManylinuxPlatform:
         monkeypatch.setattr(
             tags._manylinux,  # type: ignore[attr-defined]
             "_is_compatible",
-            lambda _, glibc_version: glibc_version == _GLibCVersion(2, 5),
+            lambda _, glibc_version, __: glibc_version == _GLibCVersion(2, 5),
         )
         monkeypatch.setattr(sysconfig, "get_platform", lambda: "linux_x86_64")
         monkeypatch.setattr(platform, "machine", lambda: "x86_64")
@@ -729,7 +729,7 @@ class TestManylinuxPlatform:
         monkeypatch.setattr(
             tags._manylinux,  # type: ignore[attr-defined]
             "_is_compatible",
-            lambda _, glibc_version: glibc_version == _GLibCVersion(2, 17),
+            lambda _, glibc_version, __: glibc_version == _GLibCVersion(2, 17),
         )
         monkeypatch.setattr(sysconfig, "get_platform", lambda: f"linux_{native_arch}")
         monkeypatch.setattr(
@@ -862,7 +862,7 @@ class TestManylinuxPlatform:
         monkeypatch.setattr(
             tags._manylinux,  # type: ignore[attr-defined]
             "_is_compatible",
-            lambda _, glibc_version: glibc_version == _GLibCVersion(2, 17),
+            lambda _, glibc_version, __: glibc_version == _GLibCVersion(2, 17),
         )
         monkeypatch.setattr(sysconfig, "get_platform", lambda: "linux_armv6l")
         monkeypatch.setattr(os, "confstr", lambda _: "glibc 2.20", raising=False)

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -600,8 +600,9 @@ def _disable_musl_detection(monkeypatch: pytest.MonkeyPatch) -> None:
 @pytest.mark.usefixtures("_disable_musl_detection")
 class TestManylinuxPlatform:
     def teardown_method(self) -> None:
-        # Clear the version cache
+        # Clear the version and module caches
         tags._manylinux._get_glibc_version.cache_clear()  # type: ignore[attr-defined]
+        tags._manylinux._get_manylinux_module.cache_clear()  # type: ignore[attr-defined]
 
     def test_get_config_var_does_not_log(self, monkeypatch: pytest.MonkeyPatch) -> None:
         debug = pretend.call_recorder(lambda *a: None)
@@ -655,7 +656,7 @@ class TestManylinuxPlatform:
         monkeypatch.setattr(
             tags._manylinux,  # type: ignore[attr-defined]
             "_is_compatible",
-            lambda _, glibc_version, __: glibc_version == _GLibCVersion(2, 5),
+            lambda _, glibc_version: glibc_version == _GLibCVersion(2, 5),
         )
         monkeypatch.setattr(sysconfig, "get_platform", lambda: "linux_x86_64")
         monkeypatch.setattr(platform, "machine", lambda: "x86_64")
@@ -729,7 +730,7 @@ class TestManylinuxPlatform:
         monkeypatch.setattr(
             tags._manylinux,  # type: ignore[attr-defined]
             "_is_compatible",
-            lambda _, glibc_version, __: glibc_version == _GLibCVersion(2, 17),
+            lambda _, glibc_version: glibc_version == _GLibCVersion(2, 17),
         )
         monkeypatch.setattr(sysconfig, "get_platform", lambda: f"linux_{native_arch}")
         monkeypatch.setattr(
@@ -862,7 +863,7 @@ class TestManylinuxPlatform:
         monkeypatch.setattr(
             tags._manylinux,  # type: ignore[attr-defined]
             "_is_compatible",
-            lambda _, glibc_version, __: glibc_version == _GLibCVersion(2, 17),
+            lambda _, glibc_version: glibc_version == _GLibCVersion(2, 17),
         )
         monkeypatch.setattr(sysconfig, "get_platform", lambda: "linux_armv6l")
         monkeypatch.setattr(os, "confstr", lambda _: "glibc 2.20", raising=False)
@@ -1577,6 +1578,7 @@ class TestSysTags:
     def teardown_method(self) -> None:
         # Clear the version cache
         tags._glibc_version = []  # type: ignore[attr-defined]
+        tags._manylinux._get_manylinux_module.cache_clear()  # type: ignore[attr-defined]
 
     @pytest.mark.parametrize(
         ("name", "expected"),


### PR DESCRIPTION
:robot: _AI text below_ :robot:

`_is_compatible()` ran `try: import _manylinux` on every call, and it is called once per (arch × glibc version) combination from `platform_tags()`. Successful imports hit `sys.modules`, but *failed* imports are retried by the import machinery every time — and not having a `_manylinux` module is the overwhelmingly common case.

The lookup is now factored into `_get_manylinux_module()`, wrapped in `functools.lru_cache(maxsize=1)`, so `_manylinux` (or `None`) is resolved once and cached for the lifetime of the process — its presence cannot change while running. `_is_compatible()` calls this helper instead of importing inline; the `manylinux_compatible`/`manylinux{1,2010,2014}_compatible` fallback chain is unchanged.

Tests (and tools) that inject `_manylinux` into `sys.modules` still work: the existing teardowns/fixtures that already `cache_clear()` `_get_glibc_version` now also clear `_get_manylinux_module`.

There is no asv benchmark for tags, so `timeit` with `_glibc_version_string` stubbed to `"2.31"` and the ABI check stubbed true, no `_manylinux` module present (Python 3.14, Apple M5 Pro):

| Call | main | this PR |
|---|---|---|
| `list(platform_tags(["x86_64", "i686"]))` (60 tags) | 947 μs | 32 μs |

The repeated failed imports were ~97% of the runtime, which lines up with the ~1ms `sys_tags()` overhead noted in the review.

Part of #1239.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
