### PR TITLE
test: make test suite compatible with pytest 9.1.0

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -135,6 +135,11 @@ def downstream(session: nox.Session, project: str) -> None:
 
     pip_cmd = ["uv", "pip"] if session.venv_backend == "uv" else ["pip"]
 
+    # These pinned downstream releases predate pytest 9.1.0, which turns their
+    # parametrize usage into collection errors. Install a compatible pytest
+    # before the project's test deps so it is kept (pip won't upgrade it).
+    session.install("pytest<9.1.0")
+
     if project == "packaging_legacy":
         session.install("-r", "tests/requirements.txt")
         session.install("-e.")

--- a/tests/test_specifiers.py
+++ b/tests/test_specifiers.py
@@ -248,15 +248,17 @@ class TestSpecifier:
 
     @pytest.mark.parametrize(
         ("left", "right", "op"),
-        itertools.chain.from_iterable(
-            # Verify that the equal (==) operator works correctly
-            [[(x, x, operator.eq) for x in SPECIFIERS]]
-            +
-            # Verify that the not equal (!=) operator works correctly
-            [
-                [(x, y, operator.ne) for j, y in enumerate(SPECIFIERS) if i != j]
-                for i, x in enumerate(SPECIFIERS)
-            ]
+        list(
+            itertools.chain.from_iterable(
+                # Verify that the equal (==) operator works correctly
+                [[(x, x, operator.eq) for x in SPECIFIERS]]
+                +
+                # Verify that the not equal (!=) operator works correctly
+                [
+                    [(x, y, operator.ne) for j, y in enumerate(SPECIFIERS) if i != j]
+                    for i, x in enumerate(SPECIFIERS)
+                ]
+            )
         ),
     )
     def test_comparison_true(
@@ -277,15 +279,17 @@ class TestSpecifier:
 
     @pytest.mark.parametrize(
         ("left", "right", "op"),
-        itertools.chain.from_iterable(
-            # Verify that the equal (==) operator works correctly
-            [[(x, x, operator.ne) for x in SPECIFIERS]]
-            +
-            # Verify that the not equal (!=) operator works correctly
-            [
-                [(x, y, operator.eq) for j, y in enumerate(SPECIFIERS) if i != j]
-                for i, x in enumerate(SPECIFIERS)
-            ]
+        list(
+            itertools.chain.from_iterable(
+                # Verify that the equal (==) operator works correctly
+                [[(x, x, operator.ne) for x in SPECIFIERS]]
+                +
+                # Verify that the not equal (!=) operator works correctly
+                [
+                    [(x, y, operator.eq) for j, y in enumerate(SPECIFIERS) if i != j]
+                    for i, x in enumerate(SPECIFIERS)
+                ]
+            )
         ),
     )
     def test_comparison_false(
@@ -2297,15 +2301,17 @@ class TestSpecifierSet:
 
     @pytest.mark.parametrize(
         ("left", "right", "op"),
-        itertools.chain.from_iterable(
-            # Verify that the equal (==) operator works correctly
-            [[(x, x, operator.eq) for x in SPECIFIERS]]
-            +
-            # Verify that the not equal (!=) operator works correctly
-            [
-                [(x, y, operator.ne) for j, y in enumerate(SPECIFIERS) if i != j]
-                for i, x in enumerate(SPECIFIERS)
-            ]
+        list(
+            itertools.chain.from_iterable(
+                # Verify that the equal (==) operator works correctly
+                [[(x, x, operator.eq) for x in SPECIFIERS]]
+                +
+                # Verify that the not equal (!=) operator works correctly
+                [
+                    [(x, y, operator.ne) for j, y in enumerate(SPECIFIERS) if i != j]
+                    for i, x in enumerate(SPECIFIERS)
+                ]
+            )
         ),
     )
     def test_comparison_true(
@@ -2319,15 +2325,17 @@ class TestSpecifierSet:
 
     @pytest.mark.parametrize(
         ("left", "right", "op"),
-        itertools.chain.from_iterable(
-            # Verify that the equal (==) operator works correctly
-            [[(x, x, operator.ne) for x in SPECIFIERS]]
-            +
-            # Verify that the not equal (!=) operator works correctly
-            [
-                [(x, y, operator.eq) for j, y in enumerate(SPECIFIERS) if i != j]
-                for i, x in enumerate(SPECIFIERS)
-            ]
+        list(
+            itertools.chain.from_iterable(
+                # Verify that the equal (==) operator works correctly
+                [[(x, x, operator.ne) for x in SPECIFIERS]]
+                +
+                # Verify that the not equal (!=) operator works correctly
+                [
+                    [(x, y, operator.eq) for j, y in enumerate(SPECIFIERS) if i != j]
+                    for i, x in enumerate(SPECIFIERS)
+                ]
+            )
         ),
     )
     def test_comparison_false(

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -805,39 +805,41 @@ class TestVersion:
         ("left", "right", "op"),
         # Below we'll generate every possible combination of VERSIONS that
         # should be True for the given operator
-        itertools.chain.from_iterable(
-            # Verify that the less than (<) operator works correctly
-            [
-                [(x, y, operator.lt) for y in VERSIONS[i + 1 :]]
-                for i, x in enumerate(VERSIONS)
-            ]
-            +
-            # Verify that the less than equal (<=) operator works correctly
-            [
-                [(x, y, operator.le) for y in VERSIONS[i:]]
-                for i, x in enumerate(VERSIONS)
-            ]
-            +
-            # Verify that the equal (==) operator works correctly
-            [[(x, x, operator.eq) for x in VERSIONS]]
-            +
-            # Verify that the not equal (!=) operator works correctly
-            [
-                [(x, y, operator.ne) for j, y in enumerate(VERSIONS) if i != j]
-                for i, x in enumerate(VERSIONS)
-            ]
-            +
-            # Verify that the greater than equal (>=) operator works correctly
-            [
-                [(x, y, operator.ge) for y in VERSIONS[: i + 1]]
-                for i, x in enumerate(VERSIONS)
-            ]
-            +
-            # Verify that the greater than (>) operator works correctly
-            [
-                [(x, y, operator.gt) for y in VERSIONS[:i]]
-                for i, x in enumerate(VERSIONS)
-            ]
+        list(
+            itertools.chain.from_iterable(
+                # Verify that the less than (<) operator works correctly
+                [
+                    [(x, y, operator.lt) for y in VERSIONS[i + 1 :]]
+                    for i, x in enumerate(VERSIONS)
+                ]
+                +
+                # Verify that the less than equal (<=) operator works correctly
+                [
+                    [(x, y, operator.le) for y in VERSIONS[i:]]
+                    for i, x in enumerate(VERSIONS)
+                ]
+                +
+                # Verify that the equal (==) operator works correctly
+                [[(x, x, operator.eq) for x in VERSIONS]]
+                +
+                # Verify that the not equal (!=) operator works correctly
+                [
+                    [(x, y, operator.ne) for j, y in enumerate(VERSIONS) if i != j]
+                    for i, x in enumerate(VERSIONS)
+                ]
+                +
+                # Verify that the greater than equal (>=) operator works correctly
+                [
+                    [(x, y, operator.ge) for y in VERSIONS[: i + 1]]
+                    for i, x in enumerate(VERSIONS)
+                ]
+                +
+                # Verify that the greater than (>) operator works correctly
+                [
+                    [(x, y, operator.gt) for y in VERSIONS[:i]]
+                    for i, x in enumerate(VERSIONS)
+                ]
+            )
         ),
     )
     def test_comparison_true(
@@ -849,39 +851,41 @@ class TestVersion:
         ("left", "right", "op"),
         # Below we'll generate every possible combination of VERSIONS that
         # should be False for the given operator
-        itertools.chain.from_iterable(
-            # Verify that the less than (<) operator works correctly
-            [
-                [(x, y, operator.lt) for y in VERSIONS[: i + 1]]
-                for i, x in enumerate(VERSIONS)
-            ]
-            +
-            # Verify that the less than equal (<=) operator works correctly
-            [
-                [(x, y, operator.le) for y in VERSIONS[:i]]
-                for i, x in enumerate(VERSIONS)
-            ]
-            +
-            # Verify that the equal (==) operator works correctly
-            [
-                [(x, y, operator.eq) for j, y in enumerate(VERSIONS) if i != j]
-                for i, x in enumerate(VERSIONS)
-            ]
-            +
-            # Verify that the not equal (!=) operator works correctly
-            [[(x, x, operator.ne) for x in VERSIONS]]
-            +
-            # Verify that the greater than equal (>=) operator works correctly
-            [
-                [(x, y, operator.ge) for y in VERSIONS[i + 1 :]]
-                for i, x in enumerate(VERSIONS)
-            ]
-            +
-            # Verify that the greater than (>) operator works correctly
-            [
-                [(x, y, operator.gt) for y in VERSIONS[i:]]
-                for i, x in enumerate(VERSIONS)
-            ]
+        list(
+            itertools.chain.from_iterable(
+                # Verify that the less than (<) operator works correctly
+                [
+                    [(x, y, operator.lt) for y in VERSIONS[: i + 1]]
+                    for i, x in enumerate(VERSIONS)
+                ]
+                +
+                # Verify that the less than equal (<=) operator works correctly
+                [
+                    [(x, y, operator.le) for y in VERSIONS[:i]]
+                    for i, x in enumerate(VERSIONS)
+                ]
+                +
+                # Verify that the equal (==) operator works correctly
+                [
+                    [(x, y, operator.eq) for j, y in enumerate(VERSIONS) if i != j]
+                    for i, x in enumerate(VERSIONS)
+                ]
+                +
+                # Verify that the not equal (!=) operator works correctly
+                [[(x, x, operator.ne) for x in VERSIONS]]
+                +
+                # Verify that the greater than equal (>=) operator works correctly
+                [
+                    [(x, y, operator.ge) for y in VERSIONS[i + 1 :]]
+                    for i, x in enumerate(VERSIONS)
+                ]
+                +
+                # Verify that the greater than (>) operator works correctly
+                [
+                    [(x, y, operator.gt) for y in VERSIONS[i:]]
+                    for i, x in enumerate(VERSIONS)
+                ]
+            )
         ),
     )
     def test_comparison_false(


### PR DESCRIPTION
Our CI is now broken without this.

🤖 _AI text below_ 🤖 

pytest **9.1.0** (released 2026-06-14) tightened `parametrize` collection, and under this repo's `filterwarnings = ["error"]` that turns into hard **collection errors** that took every CI job red across all open PRs and `main`.

Two fixes:

**1. This repo's own tests** — the comparison tests in `test_specifiers.py`/`test_version.py` passed `itertools.chain.from_iterable(...)`, a lazy `chain` iterator, directly as `parametrize` argvalues:

```
pytest.PytestRemovedIn10Warning: Passing a non-Collection iterable to parametrize is deprecated.
  Test: tests/test_specifiers.py::TestSpecifier::test_comparison_true, argvalues type: chain
```

Wrapped each of the six call sites in `list(...)` so a concrete `Collection` is passed. No behavior change; the reindent is from `ruff format`. Verified locally: `test_specifiers.py` + `test_version.py` pass (53199 passed).

**2. Downstream jobs** — the `downstream` nox session runs pinned third-party releases' own suites, which 9.1.0 also breaks (non-Collection iterable in packaging_legacy/setuptools, `duplicate parametrization` in build). These were green on the last pre-9.1.0 run. Pinned `pytest<9.1.0` before each project's test deps so a compatible pytest is kept. Verified locally: packaging_legacy downstream collects and passes on 9.0.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
