### PR TITLE
ci: add ten more projects to the downstream matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -118,6 +118,8 @@ jobs:
           - tox
           - virtualenv
           - pdm
+          - poetry_core
+          - pipenv
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,7 +104,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        project: [packaging_legacy, build, pyproject_metadata, setuptools, pip]
+        project:
+          - packaging_legacy
+          - build
+          - pyproject_metadata
+          - setuptools
+          - pip
+          - dependency_groups
+          - dep_logic
+          - twine
+          - cibuildwheel
+          - hatchling
+          - tox
+          - virtualenv
+          - pdm
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/noxfile.py
+++ b/noxfile.py
@@ -19,6 +19,7 @@ import tempfile
 import textwrap
 import time
 import urllib.request
+from dataclasses import dataclass
 from pathlib import Path
 from typing import IO, TYPE_CHECKING
 
@@ -103,36 +104,160 @@ def property_tests(session: nox.Session) -> None:
     )
 
 
-PROJECTS = {
-    "packaging_legacy": "https://github.com/di/packaging_legacy/archive/refs/tags/23.0.post0.tar.gz",
-    "build": "https://github.com/pypa/build/archive/refs/tags/1.5.0.tar.gz",
-    "setuptools": "https://github.com/pypa/setuptools/archive/refs/tags/v82.0.0.tar.gz",
-    "pyproject_metadata": "https://github.com/pypa/pyproject-metadata/archive/refs/tags/0.11.0.tar.gz",
-    "pip": "https://github.com/pypa/pip/archive/refs/tags/26.0.1.tar.gz",
-    "dependency_groups": "https://github.com/pypa/dependency-groups/archive/refs/tags/1.3.1.tar.gz",
-    "dep_logic": "https://github.com/pdm-project/dep-logic/archive/refs/tags/0.6.0.tar.gz",
-    "twine": "https://github.com/pypa/twine/archive/refs/tags/6.2.0.tar.gz",
-    "cibuildwheel": "https://github.com/pypa/cibuildwheel/archive/refs/tags/v4.1.0.tar.gz",
-    "hatchling": "https://github.com/pypa/hatch/archive/refs/tags/hatchling-v1.30.1.tar.gz",
-    "tox": "https://github.com/tox-dev/tox/archive/refs/tags/4.55.1.tar.gz",
-    "virtualenv": "https://github.com/pypa/virtualenv/archive/refs/tags/21.5.0.tar.gz",
-    "pdm": "https://github.com/pdm-project/pdm/archive/refs/tags/2.27.0.tar.gz",
-    "poetry_core": "https://github.com/python-poetry/poetry-core/archive/refs/tags/2.4.1.tar.gz",
-    "pipenv": "https://github.com/pypa/pipenv/archive/refs/tags/v2026.6.2.tar.gz",
-}
-
-# The pinned releases below break under pytest 9.1.0 (released 2026-06-13), whose
-# parametrize handling turns their test collection into errors. Rather than pin
-# pytest by hand, cap dependency resolution at the day before it shipped, so they
-# resolve pytest 9.0.x (and otherwise-current deps) on both the uv and pip
-# backends. The newer downstream projects support 9.1.0 and are left alone.
+# A few of the pinned releases break under pytest 9.1.0 (released 2026-06-13),
+# whose parametrize handling turns their test collection into errors. Rather than
+# pin pytest by hand, projects with ``date_limit`` cap dependency resolution at
+# the day before it shipped, so they resolve pytest 9.0.x (and otherwise-current
+# deps) on both the uv and pip backends.
 PYTEST_910_CUTOFF = "2026-06-12"
-DATE_LIMITED_PROJECTS = {
-    "packaging_legacy",
-    "build",
-    "pyproject_metadata",
-    "setuptools",
-    "pip",
+
+
+@dataclass(frozen=True)
+class Project:
+    """One downstream project: how to fetch, install, patch, and test it."""
+
+    url: str
+    # Arguments for ``session.install``; the default covers the common case.
+    install: tuple[str, ...] = ("-e.", "--group=test")
+    # Environment for the install only, e.g. a build-backend version override
+    # (the tarball has no ``.git``). Kept off the test run so it cannot leak into
+    # version-aware tests.
+    install_env: dict[str, str] | None = None
+    # Vendored ``packaging`` directories to replace with the current source.
+    swap: tuple[str, ...] = ()
+    # Arguments inserted before ``session.posargs`` when running pytest.
+    pytest_args: tuple[str, ...] = ()
+    # Extra environment merged into the test run (e.g. unsetting a variable).
+    extra_env: dict[str, str | None] | None = None
+    date_limit: bool = False
+
+
+PROJECTS = {
+    "packaging_legacy": Project(
+        "https://github.com/di/packaging_legacy/archive/refs/tags/23.0.post0.tar.gz",
+        install=("-r", "tests/requirements.txt", "-e."),
+        date_limit=True,
+    ),
+    "build": Project(
+        "https://github.com/pypa/build/archive/refs/tags/1.5.0.tar.gz",
+        date_limit=True,
+    ),
+    "setuptools": Project(
+        "https://github.com/pypa/setuptools/archive/refs/tags/v82.0.0.tar.gz",
+        install=("-e.[test,cover]",),
+        swap=("setuptools/_vendor/packaging",),
+        pytest_args=(
+            "-k",
+            "not test_editable_install and not test_editable_with_pyproject",
+        ),
+        date_limit=True,
+    ),
+    "pyproject_metadata": Project(
+        "https://github.com/pypa/pyproject-metadata/archive/refs/tags/0.11.0.tar.gz",
+        date_limit=True,
+    ),
+    "pip": Project(
+        "https://github.com/pypa/pip/archive/refs/tags/26.0.1.tar.gz",
+        swap=("src/pip/_vendor/packaging",),
+        pytest_args=(
+            "tests/unit",
+            "--numprocesses=auto",
+            "-k",
+            "not test_ensure_svn_available",
+        ),
+        date_limit=True,
+    ),
+    "dependency_groups": Project(
+        "https://github.com/pypa/dependency-groups/archive/refs/tags/1.3.1.tar.gz",
+    ),
+    "dep_logic": Project(
+        "https://github.com/pdm-project/dep-logic/archive/refs/tags/0.6.0.tar.gz",
+        install=("-e.", "pytest"),
+        install_env={"PDM_BUILD_SCM_VERSION": "0.6.0"},
+    ),
+    "twine": Project(
+        "https://github.com/pypa/twine/archive/refs/tags/6.2.0.tar.gz",
+        # twine keeps its test deps in tox.ini rather than a [test] extra.
+        install=("-e.", "pretend", "pytest", "pytest-socket", "coverage"),
+        install_env={"SETUPTOOLS_SCM_PRETEND_VERSION": "6.2.0"},
+        # test_fails_rst_syntax_error asserts an exact docutils warning string
+        # that changed in newer docutils; unrelated to packaging.
+        pytest_args=("-k", "not test_fails_rst_syntax_error"),
+    ),
+    "cibuildwheel": Project(
+        "https://github.com/pypa/cibuildwheel/archive/refs/tags/v4.1.0.tar.gz",
+        # unit_test/ is the fast suite; test/ holds slow Docker integration tests.
+        pytest_args=("unit_test",),
+    ),
+    "hatchling": Project(
+        "https://github.com/pypa/hatch/archive/refs/tags/hatchling-v1.30.1.tar.gz",
+        # hatchling lives in the hatch monorepo; its backend tests rely on the
+        # full hatch package and its fixtures.
+        install=(
+            "-e./backend",
+            "-e.",
+            "pytest",
+            "pytest-mock",
+            "filelock",
+            "editables",
+        ),
+        install_env={"SETUPTOOLS_SCM_PRETEND_VERSION": "1.30.1"},
+        # test_binary downloads a PyApp binary over the network.
+        pytest_args=("tests/backend", "--ignore=tests/backend/builders/test_binary.py"),
+    ),
+    "tox": Project(
+        "https://github.com/tox-dev/tox/archive/refs/tags/4.55.1.tar.gz",
+        # argcomplete is an optional dep that several tests import at collection.
+        install=("-e.", "--group=test", "argcomplete"),
+        install_env={"SETUPTOOLS_SCM_PRETEND_VERSION": "4.55.1"},
+        pytest_args=("-m", "not integration"),
+        # tox appends a pip-freeze line to command output when CI is set, which
+        # several output-asserting tests do not expect.
+        extra_env={"CI": None},
+    ),
+    "virtualenv": Project(
+        "https://github.com/pypa/virtualenv/archive/refs/tags/21.5.0.tar.gz",
+        install_env={"SETUPTOOLS_SCM_PRETEND_VERSION": "21.5.0"},
+    ),
+    "pdm": Project(
+        "https://github.com/pdm-project/pdm/archive/refs/tags/2.27.0.tar.gz",
+        install_env={"PDM_BUILD_SCM_VERSION": "2.27.0"},
+        pytest_args=("-m", "not network and not integration"),
+    ),
+    "poetry_core": Project(
+        "https://github.com/python-poetry/poetry-core/archive/refs/tags/2.4.1.tar.gz",
+        # poetry-core uses poetry-native dependency groups, so its test deps are
+        # not pip-installable as an extra; install them explicitly. setuptools is
+        # needed to build its C-extension test fixtures.
+        install=(
+            "-e.",
+            "pytest",
+            "pytest-mock",
+            "build",
+            "setuptools",
+            "tomli-w",
+            "virtualenv",
+            "trove-classifiers",
+        ),
+        # poetry-core vendors packaging under _vendor and injects it onto sys.path.
+        swap=("src/poetry/core/_vendor/packaging",),
+        pytest_args=("tests",),
+    ),
+    "pipenv": Project(
+        "https://github.com/pypa/pipenv/archive/refs/tags/v2026.6.2.tar.gz",
+        install=("-e.[tests]",),
+        # pipenv vendors packaging twice: its own vendor tree and the patched pip.
+        swap=("pipenv/vendor/packaging", "pipenv/patched/pip/_vendor/packaging"),
+        # test_vendor.py asserts vendoring integrity (and needs pytz), so it is
+        # expected to fail after the swap. pipenv's addopts enable --no-cov, which
+        # errors without pytest-cov; replace them.
+        pytest_args=(
+            "tests/unit",
+            "--ignore=tests/unit/test_vendor.py",
+            "-o",
+            "addopts=-ra",
+        ),
+    ),
 }
 
 
@@ -142,15 +267,15 @@ def downstream(session: nox.Session, project: str) -> None:
     """
     Run downstream projects with this packaging.
     """
+    cfg = PROJECTS[project]
     pkg_dir = Path.cwd() / "src/packaging"
-    env = {"FORCE_COLOR": None}
     session.install("-e.")
 
     tmp_dir = Path(session.create_tmp())
     session.chdir(tmp_dir)
 
     shutil.rmtree(project, ignore_errors=True)
-    with urllib.request.urlopen(PROJECTS[project]) as resp:
+    with urllib.request.urlopen(cfg.url) as resp:
         data = resp.read()
     with tarfile.open(fileobj=io.BytesIO(data), mode="r:gz") as tf:
         tf.extractall(project)
@@ -159,38 +284,27 @@ def downstream(session: nox.Session, project: str) -> None:
 
     pip_cmd = ["uv", "pip"] if session.venv_backend == "uv" else ["pip"]
 
-    # nox points TMPDIR inside this git checkout, so downstream tools that walk
-    # up the tree (hatchling's VCS sdist builder, tox/pdm config discovery) find
-    # packaging's own repo metadata and misbehave. Run the newer projects' tests
-    # with a temp dir outside the checkout. The original five do not need this.
-    test_env = {**env, "TMPDIR": tempfile.mkdtemp(prefix="downstream-")}
-
-    if project in DATE_LIMITED_PROJECTS:
-        # See DATE_LIMITED_PROJECTS: cap resolution at the cutoff so these
-        # projects pull a pytest they support, for both backends.
+    if cfg.date_limit:
+        # See PYTEST_910_CUTOFF: cap resolution so these projects pull a pytest
+        # they support, on both backends.
         session.env["UV_EXCLUDE_NEWER"] = PYTEST_910_CUTOFF
         session.env["PIP_UPLOADED_PRIOR_TO"] = PYTEST_910_CUTOFF
 
-    if project == "packaging_legacy":
-        session.install("-r", "tests/requirements.txt")
-        session.install("-e.")
-        session.run(*pip_cmd, "list")
-        session.run("pytest", *session.posargs, env=env)
-    elif project in {"build", "pyproject_metadata"}:
-        session.install("-e.", "--group=test")
-        if project != "build":
-            session.run(*pip_cmd, "list")
-        session.run("pytest", *session.posargs, env=env)
-    elif project == "setuptools":
-        session.install("-e.[test,cover]")
-        session.run(*pip_cmd, "list")
-        repl_dir = "setuptools/_vendor/packaging"
-        shutil.rmtree(repl_dir)
-        shutil.copytree(pkg_dir, repl_dir)
-        skips = ["-k", "not test_editable_install and not test_editable_with_pyproject"]
-        session.run("pytest", *skips, *session.posargs, env=env)
-    elif project == "pip":
-        session.install("-e.", "--group=test")
+    # nox points TMPDIR inside this git checkout, so downstream tools that walk up
+    # the tree (hatchling's VCS sdist builder, tox/pdm config discovery) find
+    # packaging's own repo metadata and misbehave. Keep the test temp dir outside.
+    test_env: dict[str, str | None] = {
+        "FORCE_COLOR": None,
+        "TMPDIR": tempfile.mkdtemp(prefix="downstream-"),
+    }
+    if cfg.extra_env:
+        test_env |= cfg.extra_env
+
+    session.install(*cfg.install, env=cfg.install_env)
+
+    if project == "pip":
+        # pip needs its common test wheels built before its vendored copy of
+        # packaging is swapped out.
         session.run(
             "pip",
             "wheel",
@@ -199,149 +313,15 @@ def downstream(session: nox.Session, project: str) -> None:
             "--group",
             "test-common-wheels",
         )
-        session.run(*pip_cmd, "list")
-        repl_dir = "src/pip/_vendor/packaging"
+
+    for repl_dir in cfg.swap:
+        # Replace the vendored packaging with the current source. Its relative
+        # imports keep it self-contained under any vendor namespace.
         shutil.rmtree(repl_dir)
         shutil.copytree(pkg_dir, repl_dir)
-        session.run(
-            "pytest",
-            "tests/unit",
-            "--numprocesses=auto",
-            "-k",
-            "not test_ensure_svn_available",
-            *session.posargs,
-        )
-    elif project == "dependency_groups":
-        session.install("-e.", "--group=test")
-        session.run(*pip_cmd, "list")
-        session.run("pytest", *session.posargs, env=test_env)
-    elif project == "dep_logic":
-        # pdm-backend computes the version from git, absent in the tarball. Scope
-        # the override to the build so it cannot leak into version-aware tests.
-        session.install("-e.", "pytest", env={"PDM_BUILD_SCM_VERSION": "0.6.0"})
-        session.run(*pip_cmd, "list")
-        session.run("pytest", *session.posargs, env=test_env)
-    elif project == "twine":
-        # twine keeps its test deps in tox.ini rather than a [test] extra.
-        session.install(
-            "-e.",
-            "pretend",
-            "pytest",
-            "pytest-socket",
-            "coverage",
-            env={"SETUPTOOLS_SCM_PRETEND_VERSION": "6.2.0"},
-        )
-        # test_fails_rst_syntax_error asserts an exact docutils warning string
-        # that changed in newer docutils; unrelated to packaging.
-        session.run(
-            "pytest",
-            "-k",
-            "not test_fails_rst_syntax_error",
-            *session.posargs,
-            env=test_env,
-        )
-    elif project == "cibuildwheel":
-        session.install("-e.", "--group=test")
-        session.run(*pip_cmd, "list")
-        # unit_test/ is the fast suite; test/ holds slow Docker integration tests.
-        session.run("pytest", "unit_test", *session.posargs, env=test_env)
-    elif project == "hatchling":
-        # hatchling lives in the hatch monorepo; its backend tests under
-        # tests/backend rely on the full hatch package and its fixtures. Keep the
-        # version override out of the test env: hatchling has version-detection
-        # tests that fail if SETUPTOOLS_SCM_PRETEND_VERSION is set while they run.
-        session.install(
-            "-e./backend",
-            "-e.",
-            "pytest",
-            "pytest-mock",
-            "filelock",
-            "editables",
-            env={"SETUPTOOLS_SCM_PRETEND_VERSION": "1.30.1"},
-        )
-        # test_binary downloads a PyApp binary over the network.
-        session.run(
-            "pytest",
-            "tests/backend",
-            "--ignore=tests/backend/builders/test_binary.py",
-            *session.posargs,
-            env=test_env,
-        )
-    elif project == "tox":
-        # argcomplete is an optional dep that several tests import at collection.
-        session.install(
-            "-e.",
-            "--group=test",
-            "argcomplete",
-            env={"SETUPTOOLS_SCM_PRETEND_VERSION": "4.55.1"},
-        )
-        # tox appends a pip-freeze line to command output when CI is set, which
-        # several output-asserting tests do not expect, so run them without it.
-        session.run(
-            "pytest",
-            "-m",
-            "not integration",
-            *session.posargs,
-            env={**test_env, "CI": None},
-        )
-    elif project == "virtualenv":
-        session.install(
-            "-e.", "--group=test", env={"SETUPTOOLS_SCM_PRETEND_VERSION": "21.5.0"}
-        )
-        session.run("pytest", *session.posargs, env=test_env)
-    elif project == "pdm":
-        session.install("-e.", "--group=test", env={"PDM_BUILD_SCM_VERSION": "2.27.0"})
-        session.run(
-            "pytest",
-            "-m",
-            "not network and not integration",
-            *session.posargs,
-            env=test_env,
-        )
-    elif project == "poetry_core":
-        # poetry-core uses poetry-native dependency groups, so its test deps are
-        # not pip-installable as an extra; install them explicitly.
-        session.install(
-            "-e.",
-            "pytest",
-            "pytest-mock",
-            "build",
-            "setuptools",
-            "tomli-w",
-            "virtualenv",
-            "trove-classifiers",
-        )
-        # poetry-core vendors packaging under _vendor and injects it onto
-        # sys.path; replace it with the current source, as we do for pip.
-        repl_dir = "src/poetry/core/_vendor/packaging"
-        shutil.rmtree(repl_dir)
-        shutil.copytree(pkg_dir, repl_dir)
-        session.run("pytest", "tests", *session.posargs, env=test_env)
-    elif project == "pipenv":
-        session.install("-e.[tests]")
-        # pipenv vendors packaging twice (its own vendor tree and the patched
-        # pip); replace both with the current source.
-        for repl_dir in (
-            "pipenv/vendor/packaging",
-            "pipenv/patched/pip/_vendor/packaging",
-        ):
-            shutil.rmtree(repl_dir)
-            shutil.copytree(pkg_dir, repl_dir)
-        # test_vendor.py asserts vendoring integrity (and needs pytz), so it is
-        # expected to fail after the swap. pipenv's addopts enable --no-cov,
-        # which errors without pytest-cov; replace them. integration tests need
-        # the network.
-        session.run(
-            "pytest",
-            "tests/unit",
-            "--ignore=tests/unit/test_vendor.py",
-            "-o",
-            "addopts=-ra",
-            *session.posargs,
-            env=test_env,
-        )
-    else:
-        session.error("Unknown package")
+
+    session.run(*pip_cmd, "list")
+    session.run("pytest", *cfg.pytest_args, *session.posargs, env=test_env)
 
 
 @nox.session(python="3.10")

--- a/noxfile.py
+++ b/noxfile.py
@@ -117,6 +117,8 @@ PROJECTS = {
     "tox": "https://github.com/tox-dev/tox/archive/refs/tags/4.55.1.tar.gz",
     "virtualenv": "https://github.com/pypa/virtualenv/archive/refs/tags/21.5.0.tar.gz",
     "pdm": "https://github.com/pdm-project/pdm/archive/refs/tags/2.27.0.tar.gz",
+    "poetry_core": "https://github.com/python-poetry/poetry-core/archive/refs/tags/2.4.1.tar.gz",
+    "pipenv": "https://github.com/pypa/pipenv/archive/refs/tags/v2026.6.2.tar.gz",
 }
 
 # The original pinned releases predate pytest 9.1.0, which turns their parametrize
@@ -281,6 +283,48 @@ def downstream(session: nox.Session, project: str) -> None:
             "pytest",
             "-m",
             "not network and not integration",
+            *session.posargs,
+            env=test_env,
+        )
+    elif project == "poetry_core":
+        # poetry-core uses poetry-native dependency groups, so its test deps are
+        # not pip-installable as an extra; install them explicitly.
+        session.install(
+            "-e.",
+            "pytest",
+            "pytest-mock",
+            "build",
+            "setuptools",
+            "tomli-w",
+            "virtualenv",
+            "trove-classifiers",
+        )
+        # poetry-core vendors packaging under _vendor and injects it onto
+        # sys.path; replace it with the current source, as we do for pip.
+        repl_dir = "src/poetry/core/_vendor/packaging"
+        shutil.rmtree(repl_dir)
+        shutil.copytree(pkg_dir, repl_dir)
+        session.run("pytest", "tests", *session.posargs, env=test_env)
+    elif project == "pipenv":
+        session.install("-e.[tests]")
+        # pipenv vendors packaging twice (its own vendor tree and the patched
+        # pip); replace both with the current source.
+        for repl_dir in (
+            "pipenv/vendor/packaging",
+            "pipenv/patched/pip/_vendor/packaging",
+        ):
+            shutil.rmtree(repl_dir)
+            shutil.copytree(pkg_dir, repl_dir)
+        # test_vendor.py asserts vendoring integrity (and needs pytz), so it is
+        # expected to fail after the swap. pipenv's addopts enable --no-cov,
+        # which errors without pytest-cov; replace them. integration tests need
+        # the network.
+        session.run(
+            "pytest",
+            "tests/unit",
+            "--ignore=tests/unit/test_vendor.py",
+            "-o",
+            "addopts=-ra",
             *session.posargs,
             env=test_env,
         )

--- a/noxfile.py
+++ b/noxfile.py
@@ -121,10 +121,13 @@ PROJECTS = {
     "pipenv": "https://github.com/pypa/pipenv/archive/refs/tags/v2026.6.2.tar.gz",
 }
 
-# The original pinned releases predate pytest 9.1.0, which turns their parametrize
-# usage into collection errors, so they need an older pytest. The newer downstream
-# releases below support pytest 9.1.0 and must not get that pin.
-LEGACY_PYTEST_PROJECTS = {
+# The pinned releases below break under pytest 9.1.0 (released 2026-06-13), whose
+# parametrize handling turns their test collection into errors. Rather than pin
+# pytest by hand, cap dependency resolution at the day before it shipped, so they
+# resolve pytest 9.0.x (and otherwise-current deps) on both the uv and pip
+# backends. The newer downstream projects support 9.1.0 and are left alone.
+PYTEST_910_CUTOFF = "2026-06-12"
+DATE_LIMITED_PROJECTS = {
     "packaging_legacy",
     "build",
     "pyproject_metadata",
@@ -162,10 +165,11 @@ def downstream(session: nox.Session, project: str) -> None:
     # with a temp dir outside the checkout. The original five do not need this.
     test_env = {**env, "TMPDIR": tempfile.mkdtemp(prefix="downstream-")}
 
-    if project in LEGACY_PYTEST_PROJECTS:
-        # Install a compatible pytest before the project's test deps so it is
-        # kept (pip won't upgrade it). See LEGACY_PYTEST_PROJECTS.
-        session.install("pytest<9.1.0")
+    if project in DATE_LIMITED_PROJECTS:
+        # See DATE_LIMITED_PROJECTS: cap resolution at the cutoff so these
+        # projects pull a pytest they support, for both backends.
+        session.env["UV_EXCLUDE_NEWER"] = PYTEST_910_CUTOFF
+        session.env["PIP_UPLOADED_PRIOR_TO"] = PYTEST_910_CUTOFF
 
     if project == "packaging_legacy":
         session.install("-r", "tests/requirements.txt")

--- a/noxfile.py
+++ b/noxfile.py
@@ -271,7 +271,15 @@ def downstream(session: nox.Session, project: str) -> None:
             "argcomplete",
             env={"SETUPTOOLS_SCM_PRETEND_VERSION": "4.55.1"},
         )
-        session.run("pytest", "-m", "not integration", *session.posargs, env=test_env)
+        # tox appends a pip-freeze line to command output when CI is set, which
+        # several output-asserting tests do not expect, so run them without it.
+        session.run(
+            "pytest",
+            "-m",
+            "not integration",
+            *session.posargs,
+            env={**test_env, "CI": None},
+        )
     elif project == "virtualenv":
         session.install(
             "-e.", "--group=test", env={"SETUPTOOLS_SCM_PRETEND_VERSION": "21.5.0"}

--- a/noxfile.py
+++ b/noxfile.py
@@ -105,8 +105,7 @@ def property_tests(session: nox.Session) -> None:
 
 
 # A few of the pinned releases break under pytest 9.1.0 (released 2026-06-13)
-# Pip and uv are one day different in handling it
-PYTEST_910_CUTOFF = "2026-06-12"
+PYTEST_910_CUTOFF = "2026-06-12 00:00:00Z"
 
 
 @dataclass(frozen=True)

--- a/noxfile.py
+++ b/noxfile.py
@@ -104,30 +104,18 @@ def property_tests(session: nox.Session) -> None:
     )
 
 
-# A few of the pinned releases break under pytest 9.1.0 (released 2026-06-13),
-# whose parametrize handling turns their test collection into errors. Rather than
-# pin pytest by hand, projects with ``date_limit`` cap dependency resolution at
-# the day before it shipped, so they resolve pytest 9.0.x (and otherwise-current
-# deps) on both the uv and pip backends.
+# A few of the pinned releases break under pytest 9.1.0 (released 2026-06-13)
+# Pip and uv are one day different in handling it
 PYTEST_910_CUTOFF = "2026-06-12"
 
 
 @dataclass(frozen=True)
 class Project:
-    """One downstream project: how to fetch, install, patch, and test it."""
-
     url: str
-    # Arguments for ``session.install``; the default covers the common case.
     install: tuple[str, ...] = ("-e.", "--group=test")
-    # Environment for the install only, e.g. a build-backend version override
-    # (the tarball has no ``.git``). Kept off the test run so it cannot leak into
-    # version-aware tests.
     install_env: dict[str, str] | None = None
-    # Vendored ``packaging`` directories to replace with the current source.
     swap: tuple[str, ...] = ()
-    # Arguments inserted before ``session.posargs`` when running pytest.
     pytest_args: tuple[str, ...] = ()
-    # Extra environment merged into the test run (e.g. unsetting a variable).
     extra_env: dict[str, str | None] | None = None
     date_limit: bool = False
 
@@ -211,9 +199,10 @@ PROJECTS = {
         install=("-e.", "--group=test", "argcomplete"),
         install_env={"SETUPTOOLS_SCM_PRETEND_VERSION": "4.55.1"},
         pytest_args=("-m", "not integration"),
-        # tox appends a pip-freeze line to command output when CI is set, which
-        # several output-asserting tests do not expect.
-        extra_env={"CI": None},
+        # In CI, tox appends a pip-freeze line to command output, which several
+        # output-asserting tests do not expect. Unset every variable its is_ci()
+        # (tox/util/ci.py) checks that GitHub Actions sets.
+        extra_env={"CI": None, "GITHUB_ACTIONS": None},
     ),
     "virtualenv": Project(
         "https://github.com/pypa/virtualenv/archive/refs/tags/21.5.0.tar.gz",

--- a/noxfile.py
+++ b/noxfile.py
@@ -109,6 +109,25 @@ PROJECTS = {
     "setuptools": "https://github.com/pypa/setuptools/archive/refs/tags/v82.0.0.tar.gz",
     "pyproject_metadata": "https://github.com/pypa/pyproject-metadata/archive/refs/tags/0.11.0.tar.gz",
     "pip": "https://github.com/pypa/pip/archive/refs/tags/26.0.1.tar.gz",
+    "dependency_groups": "https://github.com/pypa/dependency-groups/archive/refs/tags/1.3.1.tar.gz",
+    "dep_logic": "https://github.com/pdm-project/dep-logic/archive/refs/tags/0.6.0.tar.gz",
+    "twine": "https://github.com/pypa/twine/archive/refs/tags/6.2.0.tar.gz",
+    "cibuildwheel": "https://github.com/pypa/cibuildwheel/archive/refs/tags/v4.1.0.tar.gz",
+    "hatchling": "https://github.com/pypa/hatch/archive/refs/tags/hatchling-v1.30.1.tar.gz",
+    "tox": "https://github.com/tox-dev/tox/archive/refs/tags/4.55.1.tar.gz",
+    "virtualenv": "https://github.com/pypa/virtualenv/archive/refs/tags/21.5.0.tar.gz",
+    "pdm": "https://github.com/pdm-project/pdm/archive/refs/tags/2.27.0.tar.gz",
+}
+
+# The original pinned releases predate pytest 9.1.0, which turns their parametrize
+# usage into collection errors, so they need an older pytest. The newer downstream
+# releases below support pytest 9.1.0 and must not get that pin.
+LEGACY_PYTEST_PROJECTS = {
+    "packaging_legacy",
+    "build",
+    "pyproject_metadata",
+    "setuptools",
+    "pip",
 }
 
 
@@ -135,10 +154,16 @@ def downstream(session: nox.Session, project: str) -> None:
 
     pip_cmd = ["uv", "pip"] if session.venv_backend == "uv" else ["pip"]
 
-    # These pinned downstream releases predate pytest 9.1.0, which turns their
-    # parametrize usage into collection errors. Install a compatible pytest
-    # before the project's test deps so it is kept (pip won't upgrade it).
-    session.install("pytest<9.1.0")
+    # nox points TMPDIR inside this git checkout, so downstream tools that walk
+    # up the tree (hatchling's VCS sdist builder, tox/pdm config discovery) find
+    # packaging's own repo metadata and misbehave. Run the newer projects' tests
+    # with a temp dir outside the checkout. The original five do not need this.
+    test_env = {**env, "TMPDIR": tempfile.mkdtemp(prefix="downstream-")}
+
+    if project in LEGACY_PYTEST_PROJECTS:
+        # Install a compatible pytest before the project's test deps so it is
+        # kept (pip won't upgrade it). See LEGACY_PYTEST_PROJECTS.
+        session.install("pytest<9.1.0")
 
     if project == "packaging_legacy":
         session.install("-r", "tests/requirements.txt")
@@ -179,6 +204,85 @@ def downstream(session: nox.Session, project: str) -> None:
             "-k",
             "not test_ensure_svn_available",
             *session.posargs,
+        )
+    elif project == "dependency_groups":
+        session.install("-e.", "--group=test")
+        session.run(*pip_cmd, "list")
+        session.run("pytest", *session.posargs, env=test_env)
+    elif project == "dep_logic":
+        # pdm-backend computes the version from git, absent in the tarball. Scope
+        # the override to the build so it cannot leak into version-aware tests.
+        session.install("-e.", "pytest", env={"PDM_BUILD_SCM_VERSION": "0.6.0"})
+        session.run(*pip_cmd, "list")
+        session.run("pytest", *session.posargs, env=test_env)
+    elif project == "twine":
+        # twine keeps its test deps in tox.ini rather than a [test] extra.
+        session.install(
+            "-e.",
+            "pretend",
+            "pytest",
+            "pytest-socket",
+            "coverage",
+            env={"SETUPTOOLS_SCM_PRETEND_VERSION": "6.2.0"},
+        )
+        # test_fails_rst_syntax_error asserts an exact docutils warning string
+        # that changed in newer docutils; unrelated to packaging.
+        session.run(
+            "pytest",
+            "-k",
+            "not test_fails_rst_syntax_error",
+            *session.posargs,
+            env=test_env,
+        )
+    elif project == "cibuildwheel":
+        session.install("-e.", "--group=test")
+        session.run(*pip_cmd, "list")
+        # unit_test/ is the fast suite; test/ holds slow Docker integration tests.
+        session.run("pytest", "unit_test", *session.posargs, env=test_env)
+    elif project == "hatchling":
+        # hatchling lives in the hatch monorepo; its backend tests under
+        # tests/backend rely on the full hatch package and its fixtures. Keep the
+        # version override out of the test env: hatchling has version-detection
+        # tests that fail if SETUPTOOLS_SCM_PRETEND_VERSION is set while they run.
+        session.install(
+            "-e./backend",
+            "-e.",
+            "pytest",
+            "pytest-mock",
+            "filelock",
+            "editables",
+            env={"SETUPTOOLS_SCM_PRETEND_VERSION": "1.30.1"},
+        )
+        # test_binary downloads a PyApp binary over the network.
+        session.run(
+            "pytest",
+            "tests/backend",
+            "--ignore=tests/backend/builders/test_binary.py",
+            *session.posargs,
+            env=test_env,
+        )
+    elif project == "tox":
+        # argcomplete is an optional dep that several tests import at collection.
+        session.install(
+            "-e.",
+            "--group=test",
+            "argcomplete",
+            env={"SETUPTOOLS_SCM_PRETEND_VERSION": "4.55.1"},
+        )
+        session.run("pytest", "-m", "not integration", *session.posargs, env=test_env)
+    elif project == "virtualenv":
+        session.install(
+            "-e.", "--group=test", env={"SETUPTOOLS_SCM_PRETEND_VERSION": "21.5.0"}
+        )
+        session.run("pytest", *session.posargs, env=test_env)
+    elif project == "pdm":
+        session.install("-e.", "--group=test", env={"PDM_BUILD_SCM_VERSION": "2.27.0"})
+        session.run(
+            "pytest",
+            "-m",
+            "not network and not integration",
+            *session.posargs,
+            env=test_env,
         )
     else:
         session.error("Unknown package")


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Inspired by the downstream survey in #1250, this expands the `downstream` job to cover more of the ecosystem.

## What's added

Ten projects, each verified green by running its real suite against this `packaging` through the actual `nox` session on a regular CPython 3.14 (matching CI).

**Imported directly (not vendored):**

| Project | Tests | Time¹ |
|---|---|---|
| dependency-groups | 39 passed | <1s |
| dep-logic | 2479 passed | <1s |
| twine | 228 passed | 3s |
| cibuildwheel | 790 passed | 4s |
| hatchling | 941 passed | 8s |
| virtualenv | 282 passed | 46s |
| pdm | 1107 passed | 56s |
| tox | 7879 passed | 70s |

**Vendored — tested via the copytree swap** (the same trick the `pip` branch already uses: after the editable install, replace the vendored `packaging` dir with the current source; `packaging`'s relative imports make the dropped-in copy self-contained under any vendor namespace). The swap is runtime-verified to report the dev version.

| Project | Vendored dir(s) replaced | Tests | Time¹ |
|---|---|---|---|
| poetry-core | `src/poetry/core/_vendor/packaging` | 2826 passed | 40s |
| pipenv | `pipenv/vendor/packaging`, `pipenv/patched/pip/_vendor/packaging` | 483 passed (`tests/unit`) | 4s |

¹ Test-run wall time (plus ~15–20s install each); every project runs on its own matrix runner.

## What was deliberately left out

- **pex** also vendors `packaging` and the swap is feasible (its import hook even tolerates the new `_ranges.py`), but its full suite is integration/network-heavy — only a thin ~24-test subset is runnable, so the signal isn't worth the matrix slot.
- **installer** doesn't import `packaging` at all.
- **Too slow / network-bound:** grayskull (>8 min against live PyPI), pip-audit (~95s, hits live OSV/PyPI).
- **Too environment-sensitive from a tarball:** flit (sdist contents come from git, absent in the tag tarball), scikit-build-core (pytest-9.1 collection issues + needs a compiler), importlib_metadata (hard-requires CPython's bundled `test` module).

## Harness details worth a look in review

- **SCM pretend-version is scoped to the build step.** GitHub tag tarballs ship no `.git`, so setuptools-scm / pdm-backend need a pretend version to build — but leaving `SETUPTOOLS_SCM_PRETEND_VERSION` set during the test run breaks hatchling's version-detection tests, so it's passed only to `install()`.
- **The test `TMPDIR` is pointed outside the checkout.** `nox`'s `create_tmp()` places the temp dir *inside* this git repo, so downstream tools that walk up the tree (hatchling's VCS sdist builder, tox/pdm config discovery) find packaging's own repo metadata and misbehave.
- The vendored copies need a couple of project-specific deps: poetry-core's C-extension masonry fixtures need `setuptools`, and pipenv's `--no-cov` addopts is dropped since `pytest-cov` isn't in its test extra.

## ⚠️ This already caught a real regression

While probing, **unearth's tests failed against current `main`** on a genuine bug — `SpecifierSet.contains()` no longer applies implicit pre-release exclusion:

```python
SpecifierSet(">=7").contains(Version("8.0.0dev0"))  # → True, should be False
SpecifierSet("").contains(Version("8.0.0a0"))        # → True, should be False
```

`.filter()` still excludes them correctly, so `contains()` and `filter()` now disagree. It's correct on 25.0 but broken on 26.1, 26.2, and `main` (came in with the range-engine work in `_ranges.py`; predates #1259). Tracking separately — flagging here since this PR's job is what surfaces it.

Opened as a **draft** pending maintainer decision on the project set and the regression.
