### PR TITLE
ci: deselect flaky hatchling test_default_shared_scripts

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -190,7 +190,16 @@ PROJECTS = {
         ),
         install_env={"SETUPTOOLS_SCM_PRETEND_VERSION": "1.30.1"},
         # test_binary downloads a PyApp binary over the network.
-        pytest_args=("tests/backend", "--ignore=tests/backend/builders/test_binary.py"),
+        # test_default_shared_scripts is flaky (~0.4%/run) and unrelated to
+        # packaging: it builds a shared script from os.urandom(1024) and
+        # hatchling's shebang rewriter drops leading blank lines, so when the
+        # random bytes start with a blank line the RECORD hash/length mismatches.
+        # See https://github.com/pypa/hatch/issues/2319.
+        pytest_args=(
+            "tests/backend",
+            "--ignore=tests/backend/builders/test_binary.py",
+            "--deselect=tests/backend/builders/test_wheel.py::TestBuildStandard::test_default_shared_scripts",
+        ),
     ),
     "tox": Project(
         "https://github.com/tox-dev/tox/archive/refs/tags/4.55.1.tar.gz",

--- a/noxfile.py
+++ b/noxfile.py
@@ -190,10 +190,6 @@ PROJECTS = {
         ),
         install_env={"SETUPTOOLS_SCM_PRETEND_VERSION": "1.30.1"},
         # test_binary downloads a PyApp binary over the network.
-        # test_default_shared_scripts is flaky (~0.4%/run) and unrelated to
-        # packaging: it builds a shared script from os.urandom(1024) and
-        # hatchling's shebang rewriter drops leading blank lines, so when the
-        # random bytes start with a blank line the RECORD hash/length mismatches.
         # See https://github.com/pypa/hatch/issues/2319.
         pytest_args=(
             "tests/backend",


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Deselect `tests/backend/builders/test_wheel.py::TestBuildStandard::test_default_shared_scripts` from the downstream hatchling job. It is flaky (~0.4% per run) and the failure is entirely inside hatchling — no packaging code runs in that path.

## Why it's flaky

The test builds a shared script from `os.urandom(1024)`. Hatchling's `add_shared_scripts` (`backend/src/hatchling/builders/wheel.py`) streams each shared-script file line-by-line and drops leading blank lines:

```python
for line in f:
    if not line.strip():   # "Ignore leading blank lines"
        continue
    ...
```

When the random bytes happen to begin with a line that strips to empty (dominated by a leading `\n`), one byte is dropped, so the built artifact is 1023 bytes instead of 1024 and the `RECORD` hash/length no longer matches the expected fixture:

```
-   ...ry,sha256=LQExxMDUOi4Bzn7A52GrgT0E4QhIMbFJOiTLja8gQgQ,1024
+   ...ry,sha256=XQhNDuePv5NPJT6EnAqCBrhy_Xztfu7qAuL6vH2JwcQ,1023
```

A standalone replica of that loop fails on ~800/200000 random inputs, confirming the ~0.4% rate.

## Upstream

Reported at pypa/hatch#2319.
