### PR TITLE
fix(tags): forward warn to generic_tags() in sys_tags

### DIFF
--- a/src/packaging/tags.py
+++ b/src/packaging/tags.py
@@ -897,7 +897,7 @@ def sys_tags(*, warn: bool = False) -> Iterator[Tag]:
     if interp_name == "cp":
         yield from cpython_tags(warn=warn)
     else:
-        yield from generic_tags()
+        yield from generic_tags(warn=warn)
 
     if interp_name == "pp":
         interp = "pp3"

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -1687,6 +1687,27 @@ class TestSysTags:
         )
         assert result[-1] == expected
 
+    def test_warn_forwarded_to_generic_tags(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # On non-CPython interpreters ``generic_tags()`` is the primary tag
+        # source, so ``sys_tags(warn=...)`` must forward the flag to it.
+        class MockGenericTags:
+            def __init__(self) -> None:
+                self.warn: bool | None = None
+
+            def __call__(
+                self, *, warn: bool = False
+            ) -> collections.abc.Iterator[tags.Tag]:
+                self.warn = warn
+                return iter(())
+
+        mock_generic_tags = MockGenericTags()
+        monkeypatch.setattr(tags, "interpreter_name", lambda: "generic")
+        monkeypatch.setattr(tags, "generic_tags", mock_generic_tags)
+        list(tags.sys_tags(warn=True))
+        assert mock_generic_tags.warn
+
     @pytest.mark.usefixtures("manylinux_module")
     def test_linux_platforms_manylinux2014_armv6l(
         self, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
While going through the #1239 review items, I noticed `sys_tags(warn=True)` forwards `warn` to `cpython_tags()` and `interpreter_version()` but calls `generic_tags()` with no arguments. On non-CPython interpreters (PyPy, GraalPy) `generic_tags()` is the primary tag source, so config-variable warnings are silently dropped even when the caller explicitly asked for them.

One-line fix: forward the flag (`generic_tags(warn=warn)`); `generic_tags` already accepts a keyword-only `warn` parameter, so default behavior is unchanged (`warn` still defaults to `False`). Added a regression test asserting the flag reaches `generic_tags` on the non-CPython path.

Refs #1239.