### PR TITLE
fix(markers): raise UndefinedComparison for set-valued variables used outside the membership form

### DIFF
--- a/src/packaging/markers.py
+++ b/src/packaging/markers.py
@@ -288,7 +288,21 @@ def _evaluate_markers(
                 environment_key = rhs.value
                 rhs_value = _lookup_environment(environment, environment_key)
 
-            assert isinstance(lhs_value, str), "lhs must be a string"
+            if not isinstance(lhs_value, str):
+                # Set-valued marker variables (``extras`` / ``dependency_groups``
+                # in the ``lock_file`` context) are only defined in the
+                # membership form ``"<name>" in <variable>``. Using one on the
+                # left-hand side of a comparison has no defined meaning, so
+                # surface the public, documented ``UndefinedComparison`` instead
+                # of leaking an internal ``AssertionError`` (which is also
+                # stripped under ``python -O``, leaving a set to flow into
+                # ``canonicalize_name``).
+                raise UndefinedComparison(
+                    f"Set-valued marker {environment_key!r} can only be used "
+                    f'with the membership form (e.g. "<name>" in '
+                    f"{environment_key}); it cannot appear on the left-hand "
+                    f"side of {op.serialize()!r}."
+                )
             lhs_value, rhs_value = _normalize(lhs_value, rhs_value, key=environment_key)
             groups[-1].append(_eval_op(lhs_value, op, rhs_value, key=environment_key))
         elif marker == "or":

--- a/src/packaging/markers.py
+++ b/src/packaging/markers.py
@@ -289,14 +289,6 @@ def _evaluate_markers(
                 rhs_value = _lookup_environment(environment, environment_key)
 
             if not isinstance(lhs_value, str):
-                # Set-valued marker variables (``extras`` / ``dependency_groups``
-                # in the ``lock_file`` context) are only defined in the
-                # membership form ``"<name>" in <variable>``. Using one on the
-                # left-hand side of a comparison has no defined meaning, so
-                # surface the public, documented ``UndefinedComparison`` instead
-                # of leaking an internal ``AssertionError`` (which is also
-                # stripped under ``python -O``, leaving a set to flow into
-                # ``canonicalize_name``).
                 raise UndefinedComparison(
                     f"Set-valued marker {environment_key!r} can only be used "
                     f'with the membership form (e.g. "<name>" in '

--- a/tests/test_markers.py
+++ b/tests/test_markers.py
@@ -525,11 +525,8 @@ class TestMarker:
     def test_set_valued_marker_on_lhs_raises_undefined_comparison(
         self, variable: str, op: str
     ) -> None:
-        # A set-valued marker variable is only defined in the membership form
-        # (``"name" in <variable>``); using it on the left-hand side of a
-        # comparison has no defined meaning and must raise the public,
-        # documented UndefinedComparison rather than leak an internal
-        # AssertionError (which ``python -O`` strips entirely).
+        """Set-valued markers are only defined in the membership form, so using
+        one on the left-hand side of a comparison raises ``UndefinedComparison``."""
         marker = Marker(f"{variable} {op} 'foo'")
         with pytest.raises(UndefinedComparison):
             marker.evaluate(context="lock_file")

--- a/tests/test_markers.py
+++ b/tests/test_markers.py
@@ -520,6 +520,20 @@ class TestMarker:
         with pytest.raises(KeyError):
             marker.evaluate()
 
+    @pytest.mark.parametrize("variable", ["extras", "dependency_groups"])
+    @pytest.mark.parametrize("op", ["==", "!=", ">=", "<="])
+    def test_set_valued_marker_on_lhs_raises_undefined_comparison(
+        self, variable: str, op: str
+    ) -> None:
+        # A set-valued marker variable is only defined in the membership form
+        # (``"name" in <variable>``); using it on the left-hand side of a
+        # comparison has no defined meaning and must raise the public,
+        # documented UndefinedComparison rather than leak an internal
+        # AssertionError (which ``python -O`` strips entirely).
+        marker = Marker(f"{variable} {op} 'foo'")
+        with pytest.raises(UndefinedComparison):
+            marker.evaluate(context="lock_file")
+
     @pytest.mark.parametrize(
         ("marker_string", "environment", "expected"),
         [


### PR DESCRIPTION
Another #1239 review item. In the `lock_file` context, `extras` and `dependency_groups` are set-valued, so a set-valued variable on the left-hand side of a comparison — e.g. `Marker("dependency_groups == 'foo'").evaluate(context="lock_file")` — hits `assert isinstance(lhs_value, str)` in `_evaluate_markers`. That leaks a bare `AssertionError` out of the public `Marker.evaluate`, and under `python -O` the assert is stripped entirely, so a `frozenset` flows into `canonicalize_name()`.

These variables are only defined in the membership form (`"name" in extras`). This replaces the internal assertion with the public, already-documented `UndefinedComparison`, so lock-file tooling gets a catchable diagnostic instead of an internal crash (or `-O`-dependent garbage). The supported membership form is unaffected (its LHS is a string literal). Added a parametrized regression test over both variables and several operators.

Refs #1239.