### PR TITLE
fix: reject more invalid license expression forms

### DIFF
--- a/src/packaging/licenses/__init__.py
+++ b/src/packaging/licenses/__init__.py
@@ -48,7 +48,7 @@ def __dir__() -> list[str]:
     return __all__
 
 
-license_ref_allowed = re.compile("^[A-Za-z0-9.-]*$")
+license_ref_allowed = re.compile("^[A-Za-z0-9.-]+$")
 
 NormalizedLicenseExpression = NewType("NormalizedLicenseExpression", str)
 """
@@ -148,9 +148,18 @@ def canonicalize_license_expression(
 
     # Take a final pass to check for unknown licenses/exceptions.
     normalized_tokens = []
-    for token in tokens:
+    last_license_start = False
+    for index, token in enumerate(tokens):
         if token in {"or", "and", "with", "(", ")"}:
+            if token == "with" and (
+                not last_license_start
+                or index + 1 == len(tokens)
+                or tokens[index + 1] in {"or", "and", "with", "(", ")"}
+            ):
+                message = f"Invalid license expression: {raw_license_expression!r}"
+                raise InvalidLicenseExpression(message)
             normalized_tokens.append(token.upper())
+            last_license_start = False
             continue
 
         if normalized_tokens and normalized_tokens[-1] == "WITH":
@@ -159,6 +168,7 @@ def canonicalize_license_expression(
                 raise InvalidLicenseExpression(message)
 
             normalized_tokens.append(EXCEPTIONS[token]["id"])
+            last_license_start = False
         else:
             if token.endswith("+"):
                 final_token = token[:-1]
@@ -168,7 +178,8 @@ def canonicalize_license_expression(
                 suffix = ""
 
             if final_token.startswith("licenseref-"):
-                if suffix or not license_ref_allowed.match(final_token):
+                license_ref_id = final_token[len("licenseref-") :]
+                if suffix or not license_ref_allowed.match(license_ref_id):
                     message = f"Invalid licenseref: {token!r}"
                     raise InvalidLicenseExpression(message)
                 normalized_tokens.append(license_refs[final_token])
@@ -177,6 +188,7 @@ def canonicalize_license_expression(
                     message = f"Unknown license: {final_token!r}"
                     raise InvalidLicenseExpression(message)
                 normalized_tokens.append(LICENSES[final_token]["id"] + suffix)
+            last_license_start = True
 
     normalized_expression = " ".join(normalized_tokens)
 

--- a/tests/test_licenses.py
+++ b/tests/test_licenses.py
@@ -20,3 +20,17 @@ def test_exceptions() -> None:
 def test_licenseref_plus_suffix_is_invalid() -> None:
     with pytest.raises(InvalidLicenseExpression, match="Invalid licenseref"):
         canonicalize_license_expression("LicenseRef-Foo+")
+
+
+@pytest.mark.parametrize(
+    "license_expression",
+    [
+        "MIT WITH Classpath-exception-2.0 WITH GCC-exception-3.1",
+        "(MIT) WITH Classpath-exception-2.0",
+        "(MIT OR Apache-2.0) WITH Classpath-exception-2.0",
+        "LicenseRef-",
+    ],
+)
+def test_invalid_spdx_with_or_licenseref_forms(license_expression: str) -> None:
+    with pytest.raises(InvalidLicenseExpression):
+        canonicalize_license_expression(license_expression)

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -808,6 +808,7 @@ class TestMetadata:
             "LicenseRef-License with spaces",
             "LicenseRef-License_with_underscores",
             "LicenseRef-Foo+",
+            "LicenseRef-",
             "or",
             "and",
             "with",
@@ -833,6 +834,9 @@ class TestMetadata:
             "( ) or mit and ( )",
             "( ) with ( ) or mit",
             "mit with ( ) with ( ) or mit",
+            "mit WITH Classpath-exception-2.0 WITH GCC-exception-3.1",
+            "(mit) WITH Classpath-exception-2.0",
+            "(mit OR Apache-2.0) WITH Classpath-exception-2.0",
         ],
     )
     def test_invalid_license_expression(self, license_expression: str) -> None:


### PR DESCRIPTION
## Summary

This fixes three invalid `License-Expression` forms from the licenses section of #1239:

- chained `WITH` operators, such as `MIT WITH Classpath-exception-2.0 WITH GCC-exception-3.1`
- `WITH` applied to grouped expressions, such as `(MIT OR Apache-2.0) WITH Classpath-exception-2.0`
- empty `LicenseRef-` identifiers

The parser already raises `InvalidLicenseExpression` for most invalid license-expression syntax; this keeps these remaining forms on the same error path, including the `Metadata.license_expression` wrapper.

## Tests

- `PYTHONPATH=src python3 -m pytest tests/test_licenses.py tests/test_metadata.py::TestMetadata::test_valid_license_expression tests/test_metadata.py::TestMetadata::test_invalid_license_expression -q`

Note: running the full `tests/test_metadata.py` file in this local worktree currently fails before these cases on a missing fixture file, `tests/metadata/everything.metadata`; the focused metadata license-expression tests pass.

Fixes part of #1239.
