### PR TITLE
feat: add public PEP 440 compliance `VersionRange` class

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,14 @@ Changelog
 *unreleased*
 ~~~~~~~~~~~~
 
+Features:
+
+* Add a public :class:`~packaging.ranges.VersionRange` API and
+  :meth:`SpecifierSet.to_range() <packaging.specifiers.SpecifierSet.to_range>`,
+  representing the versions a specifier set accepts as an interval set that
+  supports intersection, union, complement, membership tests, and filtering.
+  (:pull:`1182`)
+
 Behavior adaptations:
 
 * Prefer native ``linux_*`` platform tags over ``manylinux`` and ``musllinux``

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,7 @@ Features:
   :meth:`SpecifierSet.to_range() <packaging.specifiers.SpecifierSet.to_range>`,
   representing the versions a specifier set accepts as an interval set that
   supports intersection, union, complement, membership tests, and filtering.
-  (:pull:`1182`)
+  (:pull:`1267`)
 
 Behavior adaptations:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,6 +25,7 @@ The ``packaging`` library uses calendar-based versioning (``YY.N``).
 
     version
     specifiers
+    ranges
     markers
     licenses
     requirements

--- a/docs/ranges.rst
+++ b/docs/ranges.rst
@@ -1,0 +1,73 @@
+Version Ranges
+==============
+
+.. currentmodule:: packaging.ranges
+
+A :class:`VersionRange` is the set of :class:`~packaging.version.Version`
+values accepted by a :class:`~packaging.specifiers.SpecifierSet`, viewed as
+intervals on the PEP 440 ordering. It supports intersection, union, and
+complement, so tooling that combines many requirements, such as a resolver,
+can work on the intervals directly.
+
+Usage
+-----
+
+.. doctest::
+
+    >>> from packaging.ranges import VersionRange
+    >>> from packaging.specifiers import SpecifierSet
+    >>> from packaging.version import Version
+    >>> # Build a range from a specifier set
+    >>> r = SpecifierSet(">=1.0,<2.0").to_range()
+    >>> r
+    <VersionRange '[1.0, 2.0.dev0)'>
+    >>> Version("1.5") in r
+    True
+    >>> Version("2.0") in r
+    False
+    >>> # Combine ranges with set algebra
+    >>> a = SpecifierSet(">=1.0").to_range()
+    >>> b = SpecifierSet("<2.0").to_range()
+    >>> a & b == r
+    True
+    >>> # The complement is every other version
+    >>> Version("0.5") in ~r
+    True
+    >>> # Filter an iterable of versions
+    >>> list(r.filter(["0.9", "1.5", "2.0"]))
+    ['1.5']
+    >>> # An unsatisfiable set produces the empty range
+    >>> SpecifierSet(">=2.0,<1.0").to_range().is_empty
+    True
+
+Comparing ranges
+----------------
+
+Equality on a :class:`VersionRange` is structural: two ranges are equal only
+when they behave the same under :meth:`VersionRange.contains` and
+:meth:`VersionRange.filter`. Equality covers the pre-release policy and any
+``===`` admission, not only the versions matched. Intersection can change one
+of those without changing the version set, so the textbook subset test
+``a & b == a`` can report a false negative. Use the algebra and
+:attr:`VersionRange.is_empty` for set relations:
+
+.. doctest::
+
+    >>> from packaging.specifiers import SpecifierSet
+    >>> a = SpecifierSet(">=1.0").to_range()
+    >>> b = SpecifierSet(">=1.0a1").to_range()
+    >>> # a is a subset of b (every version >=1.0 is also >=1.0a1), but b
+    >>> # admits pre-releases, so ``a & b`` and ``a`` differ only in policy:
+    >>> a & b == a
+    False
+    >>> (a & ~b).is_empty       # subset: a has no version outside b
+    True
+    >>> (a & b).is_empty        # disjoint: a and b share no version
+    False
+
+Reference
+---------
+
+.. automodule:: packaging.ranges
+    :members:
+    :special-members:

--- a/docs/ranges.rst
+++ b/docs/ranges.rst
@@ -65,6 +65,25 @@ of those without changing the version set, so the textbook subset test
     >>> (a & b).is_empty        # disjoint: a and b share no version
     False
 
+Different specifiers for the same set of versions canonicalize to one form, so
+they compare equal. ``>1.0a1`` excludes ``1.0a1``'s post-releases per PEP 440,
+so its smallest member is ``1.0a2.dev0``, exactly the set of ``>=1.0a2.dev0``:
+
+.. doctest::
+
+    >>> SpecifierSet(">1.0a1").to_range() == SpecifierSet(">=1.0a2.dev0").to_range()
+    True
+
+The pre-release policy is still part of equality. ``<1.0.post0.dev0`` and
+``<=1.0`` cover the same versions, but the first admits pre-releases by default
+(its bound is a ``.dev`` release) while the second does not, so they are not
+substitutable and compare unequal:
+
+.. doctest::
+
+    >>> SpecifierSet("<1.0.post0.dev0").to_range() == SpecifierSet("<=1.0").to_range()
+    False
+
 Reference
 ---------
 

--- a/docs/specifiers.rst
+++ b/docs/specifiers.rst
@@ -59,6 +59,14 @@ Usage
     False
     >>> (SpecifierSet(">=3.13,<4.0") & SpecifierSet("==3.12.*")).is_unsatisfiable()
     True
+    >>> # We can convert a specifier set into a set-algebra VersionRange
+    >>> SpecifierSet(">=1.0,<2.0").to_range()
+    <VersionRange '[1.0, 2.0.dev0)'>
+
+The :meth:`~packaging.specifiers.SpecifierSet.to_range` method returns a
+:class:`~packaging.ranges.VersionRange`, a set-algebra view of the accepted
+versions that supports intersection, union, and complement. See :doc:`ranges`
+for details.
 
 
 Reference

--- a/src/packaging/_ranges.py
+++ b/src/packaging/_ranges.py
@@ -39,14 +39,14 @@ __all__ = [
 ]
 
 #: The smallest possible PEP 440 version. No valid version is less than this.
-_MIN_VERSION: Final[Version] = Version("0.dev0")
+MIN_VERSION: Final[Version] = Version("0.dev0")
 
 #: Sorts above any real post number and any local label, so a boundary can be
 #: ordered above the version family it covers when two boundaries are compared.
 _BOUNDARY_INF: Final[float] = float("inf")
 
 
-class _BoundaryKind(enum.Enum):
+class BoundaryKind(enum.Enum):
     """Where a boundary marker sits in the version ordering."""
 
     AFTER_LOCALS = enum.auto()  # after V+local, before V.post0
@@ -54,7 +54,7 @@ class _BoundaryKind(enum.Enum):
 
 
 @functools.total_ordering
-class _BoundaryVersion:
+class BoundaryVersion:
     """A point on the version line between two real PEP 440 versions.
 
     Relative to a base version V::
@@ -73,13 +73,13 @@ class _BoundaryVersion:
         "_cached_post",
         "_cached_pre",
         "_cached_trimmed_release",
-        "_kind",
+        "kind",
         "version",
     )
 
-    def __init__(self, version: Version, kind: _BoundaryKind) -> None:
+    def __init__(self, version: Version, kind: BoundaryKind) -> None:
         self.version = version
-        self._kind = kind
+        self.kind = kind
         self._cached_trimmed_release = trim_release(version.release)
         self._cached_epoch = version.epoch
         self._cached_pre = version.pre
@@ -105,7 +105,7 @@ class _BoundaryVersion:
                 return False
         if other.pre != self._cached_pre:
             return False
-        if self._kind == _BoundaryKind.AFTER_LOCALS:
+        if self.kind == BoundaryKind.AFTER_LOCALS:
             # Local family: same public version, any local label.
             return other.post == self._cached_post and other.dev == self._cached_dev
         # Post family: V itself + any post-release of V.
@@ -127,18 +127,20 @@ class _BoundaryVersion:
         version_key = self.version._key
         suffix: _BoundaryOrderSuffix = version_key[2]
 
-        if self._kind == _BoundaryKind.AFTER_POSTS:
+        if self.kind == BoundaryKind.AFTER_POSTS:
             suffix = (suffix[0], suffix[1], 1, _BOUNDARY_INF, 1, 0)
 
         return version_key[0], version_key[1], suffix, _BOUNDARY_INF
 
     def __eq__(self, other: object) -> bool:
-        if isinstance(other, _BoundaryVersion):
-            return self.version == other.version and self._kind == other._kind
+        # Key off the order key so equality matches the ``<`` / ``>`` order:
+        # ``AFTER_POSTS(1.0)`` and ``AFTER_POSTS(1.0.post1)`` are the same point.
+        if isinstance(other, BoundaryVersion):
+            return self._order_key() == other._order_key()
         return NotImplemented
 
-    def __lt__(self, other: _BoundaryVersion | Version) -> bool:
-        if isinstance(other, _BoundaryVersion):
+    def __lt__(self, other: BoundaryVersion | Version) -> bool:
+        if isinstance(other, BoundaryVersion):
             return self._order_key() < other._order_key()
         # boundary < other_version iff V < other AND other not in family.
         # The cheap V >= other path short-circuits before the family check.
@@ -146,28 +148,29 @@ class _BoundaryVersion:
             return False
         return not self._is_family(other)
 
-    def __gt__(self, other: _BoundaryVersion | Version) -> bool:
+    def __gt__(self, other: BoundaryVersion | Version) -> bool:
         # Defined directly to bypass functools.total_ordering's
         # NotImplemented round-trip on reflected ``Version < boundary``.
-        if isinstance(other, _BoundaryVersion):
+        if isinstance(other, BoundaryVersion):
             return self._order_key() > other._order_key()
         if self.version >= other:
             return True
         return self._is_family(other)
 
     def __hash__(self) -> int:
-        return hash((self.version, self._kind))
+        # Keyed to ``__eq__`` (the order key), so equal boundaries hash equal.
+        return hash(self._order_key())
 
     def __repr__(self) -> str:
-        return f"{self.__class__.__name__}({self.version!r}, {self._kind.name})"
+        return f"{self.__class__.__name__}({self.version!r}, {self.kind.name})"
 
 
 if TYPE_CHECKING:
-    _VersionOrBoundary = Union[Version, _BoundaryVersion, None]
+    _VersionOrBoundary = Union[Version, BoundaryVersion, None]
 
 
 @functools.total_ordering
-class _LowerBound:
+class LowerBound:
     """Lower bound of a version range.
 
     A version *v* of ``None`` means unbounded below (-inf).
@@ -185,10 +188,10 @@ class _LowerBound:
         # call per check, no operator-dispatch chain.
         if version is None:
             self._above: Callable[[Version], bool] | None = None
-        elif isinstance(version, _BoundaryVersion):
+        elif isinstance(version, BoundaryVersion):
             # >V produces an AFTER_POSTS lower bound; the upper-side
             # range of !=V produces an AFTER_LOCALS lower bound.
-            if version._kind == _BoundaryKind.AFTER_POSTS:
+            if version.kind == BoundaryKind.AFTER_POSTS:
                 self._above = _make_above_after_posts(version.version)
             else:
                 self._above = _make_above_after_locals(version.version)
@@ -198,12 +201,12 @@ class _LowerBound:
             self._above = version.__lt__
 
     def __eq__(self, other: object) -> bool:
-        if not isinstance(other, _LowerBound):
-            return NotImplemented  # pragma: no cover
+        if not isinstance(other, LowerBound):
+            return NotImplemented
         return self.version == other.version and self.inclusive == other.inclusive
 
-    def __lt__(self, other: _LowerBound) -> bool:
-        if not isinstance(other, _LowerBound):  # pragma: no cover
+    def __lt__(self, other: LowerBound) -> bool:
+        if not isinstance(other, LowerBound):
             return NotImplemented
         # -inf < anything (except -inf itself).
         if self.version is None:
@@ -224,7 +227,7 @@ class _LowerBound:
 
 
 @functools.total_ordering
-class _UpperBound:
+class UpperBound:
     """Upper bound of a version range.
 
     A version *v* of ``None`` means unbounded above (+inf).
@@ -238,15 +241,18 @@ class _UpperBound:
         self.version = version
         self.inclusive = inclusive
         # Pre-bind a predicate "is parsed at or below this upper
-        # bound?". See _LowerBound for the rationale.
+        # bound?". See LowerBound for the rationale.
         if version is None:
             self._below: Callable[[Version], bool] | None = None
-        elif isinstance(version, _BoundaryVersion):
+        elif isinstance(version, BoundaryVersion):
             # Standard specifiers only ever produce AFTER_LOCALS upper
             # bounds (from <=V / ==V / !=V with no local).
-            if version._kind == _BoundaryKind.AFTER_LOCALS:
+            if version.kind == BoundaryKind.AFTER_LOCALS:
                 self._below = _make_below_after_locals(version.version)
-            else:  # pragma: no cover (AFTER_POSTS upper not produced by specifiers)
+            else:
+                # An AFTER_POSTS upper is not produced by any specifier, but
+                # range algebra reaches it: complementing ``>V`` flips the
+                # ``AFTER_POSTS(V)`` lower into this upper bound.
                 self._below = version.__ge__
         elif inclusive:
             self._below = version.__ge__
@@ -254,12 +260,12 @@ class _UpperBound:
             self._below = version.__gt__
 
     def __eq__(self, other: object) -> bool:
-        if not isinstance(other, _UpperBound):
-            return NotImplemented  # pragma: no cover
+        if not isinstance(other, UpperBound):
+            return NotImplemented
         return self.version == other.version and self.inclusive == other.inclusive
 
-    def __lt__(self, other: _UpperBound) -> bool:
-        if not isinstance(other, _UpperBound):  # pragma: no cover
+    def __lt__(self, other: UpperBound) -> bool:
+        if not isinstance(other, UpperBound):
             return NotImplemented
         # Nothing < +inf (except +inf itself).
         if self.version is None:
@@ -281,12 +287,12 @@ class _UpperBound:
 
 if TYPE_CHECKING:
     #: A single contiguous version range, as a (lower, upper) pair.
-    VersionRange = tuple[_LowerBound, _UpperBound]
+    VersionRange = tuple[LowerBound, UpperBound]
 
 
-_NEG_INF: Final[_LowerBound] = _LowerBound(None, False)
-_POS_INF: Final[_UpperBound] = _UpperBound(None, False)
-FULL_RANGE: Final[tuple[VersionRange]] = ((_NEG_INF, _POS_INF),)
+NEG_INF: Final[LowerBound] = LowerBound(None, False)
+POS_INF: Final[UpperBound] = UpperBound(None, False)
+FULL_RANGE: Final[tuple[VersionRange]] = ((NEG_INF, POS_INF),)
 
 
 def trim_release(release: tuple[int, ...]) -> tuple[int, ...]:
@@ -327,7 +333,6 @@ def _make_above_after_posts(version: Version) -> Callable[[Version], bool]:
     version_ge = version.__ge__
     version_epoch = version.epoch
     version_pre = version.pre
-    version_dev = version.dev
     version_release_trimmed = trim_release(version.release)
     trimmed_length = len(version_release_trimmed)
 
@@ -348,13 +353,12 @@ def _make_above_after_posts(version: Version) -> Callable[[Version], bool]:
                 return True
         if parsed.pre != version_pre:
             return True
-        # In post family iff: same dev as V (covers V itself + V+local),
-        # or any post-release (covers V.postN + V.postN+local).
-        if parsed.dev == version_dev or parsed.post is not None:
-            return False
-        # Different dev with no post means parsed sorts before V
-        # cmpkey-wise, in which case version_ge returned True already.
-        return False  # pragma: no cover
+
+        # Same release and pre as V: parsed is in V's post family (V itself,
+        # V+local, or V.postN), which the boundary sits above. A V.devN
+        # (different dev, no post) sorts before V and was already caught by
+        # ``version_ge`` above, so the answer here is always "not above".
+        return False
 
     return above
 
@@ -437,7 +441,7 @@ def _make_below_after_locals(version: Version) -> Callable[[Version], bool]:
     return below
 
 
-def _range_is_empty(lower: _LowerBound, upper: _UpperBound) -> bool:
+def _range_is_empty(lower: LowerBound, upper: UpperBound) -> bool:
     """True when the range defined by *lower* and *upper* contains no versions."""
     if lower.version is None or upper.version is None:
         return False
@@ -575,7 +579,7 @@ def _lowest_release_at_or_above(
     """Smallest non-pre-release version at or above *value*, or None."""
     if value is None:
         return None
-    if isinstance(value, _BoundaryVersion):
+    if isinstance(value, BoundaryVersion):
         inner_version = value.version
         if inner_version.is_prerelease:
             # AFTER_LOCALS(1.0a1) -> nearest non-pre is 1.0
@@ -615,11 +619,11 @@ def wildcard_ranges(op: str, base: Version) -> list[VersionRange]:
     lower = _base_dev0(base)
     upper = _next_prefix_dev0(base)
     if op == "==":
-        return [(_LowerBound(lower, True), _UpperBound(upper, False))]
+        return [(LowerBound(lower, True), UpperBound(upper, False))]
     # !=
     return [
-        (_NEG_INF, _UpperBound(lower, False)),
-        (_LowerBound(upper, True), _POS_INF),
+        (NEG_INF, UpperBound(lower, False)),
+        (LowerBound(upper, True), POS_INF),
     ]
 
 
@@ -631,15 +635,13 @@ def standard_ranges(op: str, version: Version, has_local: bool) -> list[VersionR
     upper bound includes V's local family.
     """
     if op == ">=":
-        return [(_LowerBound(version, True), _POS_INF)]
+        return [(LowerBound(version, True), POS_INF)]
 
     if op == "<=":
         return [
             (
-                _NEG_INF,
-                _UpperBound(
-                    _BoundaryVersion(version, _BoundaryKind.AFTER_LOCALS), True
-                ),
+                NEG_INF,
+                UpperBound(BoundaryVersion(version, BoundaryKind.AFTER_LOCALS), True),
             )
         ]
 
@@ -648,19 +650,17 @@ def standard_ranges(op: str, version: Version, has_local: bool) -> list[VersionR
             # >V.devN: dev versions have no post-releases, so the
             # next real version is V.dev(N+1).
             lower_bound = version.__replace__(dev=version.dev + 1, local=None)
-            return [(_LowerBound(lower_bound, True), _POS_INF)]
+            return [(LowerBound(lower_bound, True), POS_INF)]
         if version.post is not None:
             # >V.postN: next real version is V.post(N+1).dev0.
             lower_bound = version.__replace__(post=version.post + 1, dev=0, local=None)
-            return [(_LowerBound(lower_bound, True), _POS_INF)]
+            return [(LowerBound(lower_bound, True), POS_INF)]
         # >V (final or pre-release V): exclude V itself, V+local, and
         # every V.postN per PEP 440.
         return [
             (
-                _LowerBound(
-                    _BoundaryVersion(version, _BoundaryKind.AFTER_POSTS), False
-                ),
-                _POS_INF,
+                LowerBound(BoundaryVersion(version, BoundaryKind.AFTER_POSTS), False),
+                POS_INF,
             )
         ]
 
@@ -670,27 +670,27 @@ def standard_ranges(op: str, version: Version, has_local: bool) -> list[VersionR
         bound = (
             version if version.is_prerelease else version.__replace__(dev=0, local=None)
         )
-        if bound <= _MIN_VERSION:
+        if bound <= MIN_VERSION:
             return []
-        return [(_NEG_INF, _UpperBound(bound, False))]
+        return [(NEG_INF, UpperBound(bound, False))]
 
     # ==, !=: local versions of V match when the spec has no local segment.
-    after_locals = _BoundaryVersion(version, _BoundaryKind.AFTER_LOCALS)
+    after_locals = BoundaryVersion(version, BoundaryKind.AFTER_LOCALS)
     upper = version if has_local else after_locals
 
     if op == "==":
-        return [(_LowerBound(version, True), _UpperBound(upper, True))]
+        return [(LowerBound(version, True), UpperBound(upper, True))]
 
     if op == "!=":
         return [
-            (_NEG_INF, _UpperBound(version, False)),
-            (_LowerBound(upper, False), _POS_INF),
+            (NEG_INF, UpperBound(version, False)),
+            (LowerBound(upper, False), POS_INF),
         ]
 
     if op == "~=":
         prefix = version.__replace__(release=version.release[:-1])
         return [
-            (_LowerBound(version, True), _UpperBound(_next_prefix_dev0(prefix), False))
+            (LowerBound(version, True), UpperBound(_next_prefix_dev0(prefix), False))
         ]
 
     raise ValueError(f"Unknown operator: {op!r}")  # pragma: no cover

--- a/src/packaging/_ranges.py
+++ b/src/packaging/_ranges.py
@@ -43,6 +43,10 @@ __all__ = [
 #: The smallest possible PEP 440 version. No valid version is less than this.
 MIN_VERSION: Final[Version] = Version("0.dev0")
 
+#: The smallest non-pre-release version, i.e. the nearest non-pre-release at or
+#: above the ``-inf`` floor.
+MIN_RELEASE: Final[Version] = Version("0")
+
 #: Sorts above any real post number and any local label, so a boundary can be
 #: ordered above the version family it covers when two boundaries are compared.
 _BOUNDARY_INF: Final[float] = float("inf")
@@ -631,8 +635,14 @@ def _nearest_release_above_prerelease(version: Version) -> Version:
     return version.__replace__(dev=None, local=None)
 
 
-def _lowest_release_at_or_above(value: Version | BoundaryVersion) -> Version:
-    """Smallest non-pre-release version at or above *value*."""
+def _lowest_release_at_or_above(value: Version | BoundaryVersion | None) -> Version:
+    """Smallest non-pre-release version at or above *value*.
+
+    ``None`` is the ``-inf`` floor, whose nearest non-pre-release is
+    :data:`MIN_RELEASE`.
+    """
+    if value is None:
+        return MIN_RELEASE
     if isinstance(value, BoundaryVersion):
         inner_version = value.version
         if inner_version.is_prerelease:
@@ -655,12 +665,7 @@ def ranges_are_prerelease_only(ranges: Sequence[VersionRange]) -> bool:
     if every range is pre-release-only, every contained version is excluded.
     """
     for lower, upper in ranges:
-        # An unbounded lower reaches the PEP 440 floor; its nearest non-pre is 0.
-        if lower.version is None:
-            nearest = Version("0")
-        else:
-            nearest = _lowest_release_at_or_above(lower.version)
-
+        nearest = _lowest_release_at_or_above(lower.version)
         if upper.version is None or nearest < upper.version:
             return False
         if nearest == upper.version and upper.inclusive:

--- a/src/packaging/_ranges.py
+++ b/src/packaging/_ranges.py
@@ -31,7 +31,9 @@ __all__ = [
     "filter_by_ranges",
     "intersect_ranges",
     "intersect_specifier_bounds",
+    "least_version_above",
     "matches_bounds_only",
+    "range_is_empty",
     "ranges_are_prerelease_only",
     "resolve_prereleases",
     "standard_ranges",
@@ -441,12 +443,56 @@ def _make_below_after_locals(version: Version) -> Callable[[Version], bool]:
     return below
 
 
-def _range_is_empty(lower: LowerBound, upper: UpperBound) -> bool:
-    """True when the range defined by *lower* and *upper* contains no versions."""
-    if lower.version is None or upper.version is None:
+def least_version_above(boundary: BoundaryVersion) -> Version | None:
+    """Smallest real version strictly above *boundary*, or ``None`` if none exists."""
+    base = boundary.version
+
+    if boundary.kind == BoundaryKind.AFTER_LOCALS:
+        # AFTER_LOCALS(V) sits just below V.post0, so its least successor is
+        # V.post0.dev0 (V.dev(N+1) if V has a dev, V.post(N+1).dev0 if a post).
+        if base.dev is not None:
+            return base.__replace__(dev=base.dev + 1, local=None)
+        next_post = (base.post + 1) if base.post is not None else 0
+        return base.__replace__(post=next_post, dev=0, local=None)
+
+    # AFTER_POSTS(V): a pre-release V steps to the next pre-release's .dev0;
+    # a final-release AFTER_POSTS has no least successor.
+    if base.pre is not None:
+        kind, number = base.pre
+        return base.__replace__(pre=(kind, number + 1), post=None, dev=0, local=None)
+
+    return None
+
+
+def range_is_empty(lower: LowerBound, upper: UpperBound) -> bool:
+    """True when the range defined by *lower* and *upper* contains no versions.
+
+    A boundary lower sits just below the next real version, so an ordered pair
+    is still empty when the upper excludes that least successor:
+    ``(AFTER_POSTS(1.0a1), 1.0a2.dev0)`` holds no version.
+    """
+    if upper.version is None:
         return False
+
+    if lower.version is None:
+        # Nothing sorts below MIN_VERSION, so an exclusive upper at or below it
+        # leaves an empty floor interval such as ``(-inf, 0.dev0)``.
+        return (
+            not upper.inclusive
+            and isinstance(upper.version, Version)
+            and upper.version <= MIN_VERSION
+        )
+
+    if isinstance(lower.version, BoundaryVersion):
+        successor = least_version_above(lower.version)
+        if successor is not None:
+            if upper.version == successor:
+                return not upper.inclusive
+            return upper.version < successor
+
     if lower.version == upper.version:
         return not (lower.inclusive and upper.inclusive)
+
     return lower.version > upper.version
 
 
@@ -464,7 +510,7 @@ def intersect_ranges(
         lower = max(left_lower, right_lower)
         upper = min(left_upper, right_upper)
 
-        if not _range_is_empty(lower, upper):
+        if not range_is_empty(lower, upper):
             result.append((lower, upper))
 
         # Advance whichever side has the smaller upper bound.
@@ -573,25 +619,33 @@ def filter_by_ranges(
                 break
 
 
-def _lowest_release_at_or_above(
-    value: _VersionOrBoundary,
-) -> Version | None:
-    """Smallest non-pre-release version at or above *value*, or None."""
-    if value is None:
-        return None
+def _nearest_release_above_prerelease(version: Version) -> Version:
+    """Smallest non-pre-release at or above a pre-release *version*."""
+    if version.pre is not None:
+        # An a/b/rc pre-release drops to its final release, which outranks
+        # every post-release of that pre-release (1.0a1.post0 -> 1.0).
+        return version.__replace__(pre=None, post=None, dev=None, local=None)
+
+    # A dev-only release keeps its post-release (1.0.post0.dev0 -> 1.0.post0,
+    # whose final 1.0 sorts below it).
+    return version.__replace__(dev=None, local=None)
+
+
+def _lowest_release_at_or_above(value: Version | BoundaryVersion) -> Version:
+    """Smallest non-pre-release version at or above *value*."""
     if isinstance(value, BoundaryVersion):
         inner_version = value.version
         if inner_version.is_prerelease:
-            # AFTER_LOCALS(1.0a1) -> nearest non-pre is 1.0
-            return inner_version.__replace__(pre=None, dev=None, local=None)
+            return _nearest_release_above_prerelease(inner_version)
         # AFTER_LOCALS(1.0) -> nearest non-pre is 1.0.post0
         # AFTER_LOCALS(1.0.post0) -> nearest non-pre is 1.0.post1
         next_post = (inner_version.post + 1) if inner_version.post is not None else 0
         return inner_version.__replace__(post=next_post, local=None)
+
     if not value.is_prerelease:
         return value
-    # Strip pre/dev to get the final or post-release form.
-    return value.__replace__(pre=None, dev=None, local=None)
+
+    return _nearest_release_above_prerelease(value)
 
 
 def ranges_are_prerelease_only(ranges: Sequence[VersionRange]) -> bool:
@@ -601,9 +655,12 @@ def ranges_are_prerelease_only(ranges: Sequence[VersionRange]) -> bool:
     if every range is pre-release-only, every contained version is excluded.
     """
     for lower, upper in ranges:
-        nearest = _lowest_release_at_or_above(lower.version)
-        if nearest is None:
-            return False
+        # An unbounded lower reaches the PEP 440 floor; its nearest non-pre is 0.
+        if lower.version is None:
+            nearest = Version("0")
+        else:
+            nearest = _lowest_release_at_or_above(lower.version)
+
         if upper.version is None or nearest < upper.version:
             return False
         if nearest == upper.version and upper.inclusive:

--- a/src/packaging/ranges.py
+++ b/src/packaging/ranges.py
@@ -37,7 +37,10 @@ from ._ranges import (
     coerce_version,
     filter_by_ranges,
     intersect_ranges,
+    least_version_above,
     matches_bounds_only,
+    range_is_empty,
+    ranges_are_prerelease_only,
 )
 from .version import Version
 
@@ -61,45 +64,9 @@ def __dir__() -> list[str]:
     return __all__
 
 
-# Range algebra: intersection lives in the engine (``intersect_ranges``);
-# union and complement are only needed here, so they live in this module.
-
-
-def _after_locals_successor(version: Version) -> Version:
-    """Smallest real version strictly above ``AFTER_LOCALS(version)``.
-
-    When V has a dev segment, the next real version is V with ``dev + 1``.
-    Otherwise AFTER_LOCALS(V) sits just below V.post0, so its successor is
-    V.post0.dev0 (V.post(N+1).dev0 when V is itself a post-release).
-    """
-    if version.dev is not None:
-        return version.__replace__(dev=version.dev + 1, local=None)
-
-    next_post = (version.post + 1) if version.post is not None else 0
-    return version.__replace__(post=next_post, dev=0, local=None)
-
-
-def _range_is_empty(lower: LowerBound, upper: UpperBound) -> bool:
-    """True when the union gap ``(lower, upper)`` holds no version.
-
-    Union calls this only for a strictly-ordered gap between two intervals,
-    so an ordinary version gap always holds a version. The one empty case is
-    a flipped ``AFTER_LOCALS(V)`` lower whose smallest real successor,
-    ``V.post0.dev0``, sits at or above the upper.
-    """
-    lower_version = lower.version
-    upper_version = upper.version
-
-    if (
-        isinstance(lower_version, BoundaryVersion)
-        and lower_version.kind == BoundaryKind.AFTER_LOCALS
-        and isinstance(upper_version, Version)
-    ):
-        successor = _after_locals_successor(lower_version.version)
-        if upper_version == successor:
-            return not upper.inclusive
-        return upper_version < successor
-    return False
+# Range algebra: intersection and the empty-interval test live in the engine
+# (``intersect_ranges`` / ``range_is_empty``); union and complement are only
+# needed here, so they live in this module.
 
 
 def _union_ranges(
@@ -147,7 +114,7 @@ def _union_ranges(
             # stay canonical.
             gap_lower = LowerBound(prev_upper.version, not prev_upper.inclusive)
             gap_upper = UpperBound(lower.version, not lower.inclusive)
-            overlaps = _range_is_empty(gap_lower, gap_upper)
+            overlaps = range_is_empty(gap_lower, gap_upper)
 
         if overlaps:
             merged[-1] = (prev_lower, max(prev_upper, upper))
@@ -172,16 +139,12 @@ def _complement_ranges(ranges: Sequence[_Interval]) -> list[_Interval]:
 
     for lower, upper in ranges:
         if prev_upper is None:
-            # A leading gap that ends at or below the PEP 440 floor holds no
-            # version, so it is dropped to keep ``is_empty`` correct. The live
-            # trigger is ``~singleton("0.dev0")`` (a strict ``[0.dev0, 0.dev0]``
-            # built outside ``_canonical_floor``); specifier-derived floor
-            # ranges are already collapsed to ``-inf`` before complement.
-            if lower.version is not None and not (
-                lower.inclusive
-                and isinstance(lower.version, Version)
-                and lower.version <= MIN_VERSION
-            ):
+            # Leading gap below the first interval. Every range reaching here is
+            # floor-canonical: ``_canonical_floor`` has already folded an
+            # inclusive lower at or below ``0.dev0`` into ``-inf``. So a finite
+            # first lower always leaves a non-empty gap down to ``-inf``, while a
+            # ``-inf`` lower leaves no leading gap at all.
+            if lower.version is not None:
                 gap_upper = UpperBound(lower.version, not lower.inclusive)
                 result.append((NEG_INF, gap_upper))
         else:
@@ -213,11 +176,7 @@ def _canonical_floor(bounds: tuple[_Interval, ...]) -> tuple[_Interval, ...]:
         return bounds
 
     lower, upper = bounds[0]
-    if (
-        not upper.inclusive
-        and isinstance(upper.version, Version)
-        and upper.version <= MIN_VERSION
-    ):
+    if range_is_empty(NEG_INF, upper):
         return bounds[1:]
 
     if (
@@ -228,6 +187,74 @@ def _canonical_floor(bounds: tuple[_Interval, ...]) -> tuple[_Interval, ...]:
         return ((NEG_INF, upper), *bounds[1:])
 
     return bounds
+
+
+def _predecessor_boundary(version: Version) -> BoundaryVersion | None:
+    """The boundary whose least successor is *version*, or ``None``.
+
+    Inverse of :func:`~packaging._ranges.least_version_above`. A plain version
+    that is exactly such a successor (``1.0a2.dev0`` sits just above
+    ``AFTER_POSTS(1.0a1)``) folds back to that boundary, so ``>=1.0a2.dev0`` and
+    ``>1.0a1`` share one form. The proposed boundary is confirmed by
+    round-tripping through ``least_version_above``.
+    """
+    # Only a least successor carries a dev segment, so nothing else can fold.
+    if version.dev is None:
+        return None
+
+    candidate: BoundaryVersion | None = None
+    if version.pre is not None and version.dev == 0 and version.post is None:
+        # 1.0a2.dev0 -> AFTER_POSTS(1.0a1)
+        kind, number = version.pre
+        if number >= 1:
+            candidate = BoundaryVersion(
+                version.__replace__(pre=(kind, number - 1), dev=None),
+                BoundaryKind.AFTER_POSTS,
+            )
+    elif version.dev >= 1:
+        # 1.0.dev3 -> AFTER_LOCALS(1.0.dev2)
+        candidate = BoundaryVersion(
+            version.__replace__(dev=version.dev - 1), BoundaryKind.AFTER_LOCALS
+        )
+    elif version.dev == 0 and version.post is not None:
+        # 1.0.post1.dev0 -> AFTER_LOCALS(1.0.post0); 1.0.post0.dev0 -> AFTER_LOCALS(1.0)
+        base = (
+            version.__replace__(post=None, dev=None)
+            if version.post == 0
+            else version.__replace__(post=version.post - 1, dev=None)
+        )
+        candidate = BoundaryVersion(base, BoundaryKind.AFTER_LOCALS)
+
+    if candidate is not None and least_version_above(candidate) == version:
+        return candidate
+    return None
+
+
+def _canonicalize(bounds: tuple[_Interval, ...]) -> tuple[_Interval, ...]:
+    """Fold least-successor bounds to their boundary form.
+
+    ``>=1.0a2.dev0`` and ``>1.0a1`` denote the same set, so both must reduce to
+    one representation for ``==`` and ``hash`` to agree. An inclusive lower or
+    exclusive upper sitting on a boundary's least successor becomes that
+    boundary; the engine's emptiness check has already dropped the synthetic
+    gaps such intervals would otherwise leave.
+    """
+    result: list[_Interval] = []
+    for lower, upper in bounds:
+        new_lower, new_upper = lower, upper
+
+        if isinstance(lower.version, Version) and lower.inclusive:
+            boundary = _predecessor_boundary(lower.version)
+            if boundary is not None:
+                new_lower = LowerBound(boundary, inclusive=False)
+
+        if isinstance(upper.version, Version) and not upper.inclusive:
+            boundary = _predecessor_boundary(upper.version)
+            if boundary is not None:
+                new_upper = UpperBound(boundary, inclusive=True)
+
+        result.append((new_lower, new_upper))
+    return tuple(result)
 
 
 def _struct_admits(
@@ -352,9 +379,11 @@ class VersionRange:
     ) -> VersionRange:
         """Internal factory; bypasses :meth:`__new__`.
 
-        Drops admit literals the bounds already admit, and reject literals the
-        bounds do not match anyway. Reject wins over admit on overlap.
+        Canonicalizes the bounds so equal version sets share one representation,
+        then drops admit literals the bounds already admit and reject literals
+        the bounds do not match anyway. Reject wins over admit on overlap.
         """
+        bounds = _canonicalize(bounds)
         if admit and reject:
             admit = admit - reject
         if admit:
@@ -796,12 +825,33 @@ class VersionRange:
     def is_empty(self) -> bool:
         """``True`` if no version or string satisfies this range.
 
+        Agrees with :meth:`~packaging.specifiers.SpecifierSet.is_unsatisfiable`,
+        including the pre-release policy: a range whose only members are
+        pre-releases is empty when that policy excludes them.
+
         >>> SpecifierSet(">=2,<1").to_range().is_empty
         True
         >>> SpecifierSet(">=1,<2").to_range().is_empty
         False
+        >>> SpecifierSet("==1.0a1", prereleases=False).to_range().is_empty
+        True
         """
-        return not self._bounds and not self._admit
+        # An arbitrary-string admission or a surviving ``===`` literal is a
+        # member; a literal that is a pre-release is dropped when the policy is.
+        if self._arbitrary_active():
+            return False
+
+        for literal in self._admit:
+            if self._prereleases is False:
+                parsed = coerce_version(literal)
+                if parsed is not None and parsed.is_prerelease:
+                    continue
+            return False
+
+        if not self._bounds:
+            return True
+
+        return self._prereleases is False and ranges_are_prerelease_only(self._bounds)
 
     def contains(
         self,
@@ -885,6 +935,20 @@ class VersionRange:
         :meth:`filter` agrees: the bounds, the ``===`` admit/reject literals,
         the arbitrary-string flag, and both the configured and resolved
         pre-release policies. Equal ranges therefore filter identically.
+
+        Different specifiers for the same set fold to one canonical bound form,
+        so they compare equal. ``>1.0a1`` excludes ``1.0a1``'s post-releases, so
+        its smallest member is ``1.0a2.dev0``, the same set as ``>=1.0a2.dev0``:
+
+        >>> SpecifierSet(">1.0a1").to_range() == SpecifierSet(">=1.0a2.dev0").to_range()
+        True
+
+        The pre-release policy is still part of equality, so two ranges with the
+        same versions but different policies stay unequal:
+
+        >>> le, lt = SpecifierSet("<=1.0"), SpecifierSet("<1.0.post0.dev0")
+        >>> le.to_range() == lt.to_range()
+        False
 
         >>> r = SpecifierSet(">=1.0,<2.0").to_range()
         >>> r == SpecifierSet(">=1.0,<2.0").to_range()

--- a/src/packaging/ranges.py
+++ b/src/packaging/ranges.py
@@ -376,12 +376,17 @@ class VersionRange:
         admit: frozenset[str] = frozenset(),
         reject: frozenset[str] = frozenset(),
         admit_arbitrary: bool = False,
+        *,
+        prereleases: bool | None = None,
+        prereleases_configured: bool | None = None,
     ) -> VersionRange:
         """Internal factory; bypasses :meth:`__new__`.
 
         Canonicalizes the bounds so equal version sets share one representation,
         then drops admit literals the bounds already admit and reject literals
-        the bounds do not match anyway. Reject wins over admit on overlap.
+        the bounds do not match anyway. Reject wins over admit on overlap. The
+        pre-release policy is set here, so a built range never has its policy
+        reassigned afterwards.
         """
         bounds = _canonicalize(bounds)
         if admit and reject:
@@ -404,8 +409,8 @@ class VersionRange:
         instance._admit = admit
         instance._reject = reject
         instance._admit_arbitrary = admit_arbitrary
-        instance._prereleases = None
-        instance._prereleases_configured = None
+        instance._prereleases = prereleases
+        instance._prereleases_configured = prereleases_configured
 
         return instance
 
@@ -431,20 +436,34 @@ class VersionRange:
                 f"and {other._prereleases_configured!r}"
             )
 
-    def _propagate_prereleases(self, other: VersionRange, result: VersionRange) -> None:
-        """Carry the shared pre-release policy onto a freshly built result."""
-        result._prereleases_configured = self._prereleases_configured
-        if self._prereleases_configured is not None:
-            result._prereleases = self._prereleases_configured
-        elif self._prereleases is True or other._prereleases is True:
-            result._prereleases = True
-        else:
-            result._prereleases = None
+    def _combined_policy(self, other: VersionRange) -> tuple[bool | None, bool | None]:
+        """The ``(resolved, configured)`` pre-release policy for ``self`` combined
+        with ``other``, ready to feed into :meth:`_build`.
 
-    def _restamp(self, *, resolved: bool | None, configured: bool | None) -> None:
-        """Set the pre-release policy slots on a freshly built range."""
-        self._prereleases = resolved
-        self._prereleases_configured = configured
+        Both operands share a configured policy by the time this is called (see
+        :meth:`_check_policy_compat`).
+        """
+        configured = self._prereleases_configured
+        if configured is not None:
+            resolved: bool | None = configured
+        elif self._prereleases is True or other._prereleases is True:
+            resolved = True
+        else:
+            resolved = None
+        return resolved, configured
+
+    def _with_policy(
+        self, *, resolved: bool | None, configured: bool | None
+    ) -> VersionRange:
+        """A structural copy of this range carrying the given pre-release policy."""
+        return self._build(
+            self._bounds,
+            admit=self._admit,
+            reject=self._reject,
+            admit_arbitrary=self._admit_arbitrary,
+            prereleases=resolved,
+            prereleases_configured=configured,
+        )
 
     @classmethod
     def empty(cls, *, prereleases: bool | None = None) -> VersionRange:
@@ -455,11 +474,9 @@ class VersionRange:
         >>> "1.0" in VersionRange.empty()
         False
         """
-        result = cls._build(())
-        if prereleases is not None:
-            result._restamp(resolved=prereleases, configured=prereleases)
-
-        return result
+        return cls._build(
+            (), prereleases=prereleases, prereleases_configured=prereleases
+        )
 
     @classmethod
     def full(
@@ -480,11 +497,12 @@ class VersionRange:
         >>> "garbage" in VersionRange.full(admit_arbitrary=False)
         False
         """
-        result = cls._build(FULL_RANGE, admit_arbitrary=admit_arbitrary)
-        if prereleases is not None:
-            result._restamp(resolved=prereleases, configured=prereleases)
-
-        return result
+        return cls._build(
+            FULL_RANGE,
+            admit_arbitrary=admit_arbitrary,
+            prereleases=prereleases,
+            prereleases_configured=prereleases,
+        )
 
     @classmethod
     def singleton(
@@ -512,11 +530,11 @@ class VersionRange:
 
         # Collapse the floor: nothing sorts below ``MIN_VERSION``, so the
         # ``0.dev0`` singleton is ``(-inf, 0.dev0]`` in canonical form.
-        result = cls._build(_canonical_floor(((lower, upper),)))
-        if prereleases is not None:
-            result._restamp(resolved=prereleases, configured=prereleases)
-
-        return result
+        return cls._build(
+            _canonical_floor(((lower, upper),)),
+            prereleases=prereleases,
+            prereleases_configured=prereleases,
+        )
 
     def intersection(self, other: VersionRange) -> VersionRange:
         """Range containing exactly the versions in both self and other.
@@ -531,17 +549,25 @@ class VersionRange:
         """
         self._check_policy_compat(other)
 
+        resolved, configured = self._combined_policy(other)
         new_bounds = tuple(intersect_ranges(self._bounds, other._bounds))
         combined_arb = self._admit_arbitrary and other._admit_arbitrary
         if not self._has_literals() and not other._has_literals():
-            result = self._build(new_bounds, admit_arbitrary=combined_arb)
-        else:
-            result = self._combine_literals(
-                other, new_bounds, intersect=True, admit_arbitrary=combined_arb
+            return self._build(
+                new_bounds,
+                admit_arbitrary=combined_arb,
+                prereleases=resolved,
+                prereleases_configured=configured,
             )
 
-        self._propagate_prereleases(other, result)
-        return result
+        return self._combine_literals(
+            other,
+            new_bounds,
+            intersect=True,
+            admit_arbitrary=combined_arb,
+            prereleases=resolved,
+            prereleases_configured=configured,
+        )
 
     def union(self, other: VersionRange) -> VersionRange:
         """Range containing every version in self or other.
@@ -558,13 +584,24 @@ class VersionRange:
         """
         self._check_policy_compat(other)
 
+        resolved, configured = self._combined_policy(other)
         new_bounds = tuple(_union_ranges(self._bounds, other._bounds))
         combined_arb = self._admit_arbitrary or other._admit_arbitrary
         if not self._has_literals() and not other._has_literals():
-            result = self._build(new_bounds, admit_arbitrary=combined_arb)
+            result = self._build(
+                new_bounds,
+                admit_arbitrary=combined_arb,
+                prereleases=resolved,
+                prereleases_configured=configured,
+            )
         else:
             result = self._combine_literals(
-                other, new_bounds, intersect=False, admit_arbitrary=combined_arb
+                other,
+                new_bounds,
+                intersect=False,
+                admit_arbitrary=combined_arb,
+                prereleases=resolved,
+                prereleases_configured=configured,
             )
 
         # ``r | full()`` collapses to the canonical universal range only when
@@ -575,11 +612,8 @@ class VersionRange:
             and not result._has_literals()
             and self._prereleases_configured is None
         ):
-            result._prereleases_configured = None
-            result._prereleases = None
-            return result
+            return self.full()
 
-        self._propagate_prereleases(other, result)
         return result
 
     def complement(self) -> VersionRange:
@@ -597,22 +631,16 @@ class VersionRange:
         >>> r.complement().complement() == r
         True
         """
-        if not self._has_literals():
-            result = self._build(
-                tuple(_complement_ranges(self._bounds)),
-                admit_arbitrary=self._admit_arbitrary,
-            )
-        else:
-            result = self._build(
-                tuple(_complement_ranges(self._bounds)),
-                admit=self._reject,
-                reject=self._admit,
-                admit_arbitrary=self._admit_arbitrary,
-            )
-
-        result._prereleases = self._prereleases
-        result._prereleases_configured = self._prereleases_configured
-        return result
+        # Complement swaps literal admission: what the range rejects, its
+        # complement admits, and vice versa.
+        return self._build(
+            tuple(_complement_ranges(self._bounds)),
+            admit=self._reject,
+            reject=self._admit,
+            admit_arbitrary=self._admit_arbitrary,
+            prereleases=self._prereleases,
+            prereleases_configured=self._prereleases_configured,
+        )
 
     def _combine_literals(
         self,
@@ -621,6 +649,8 @@ class VersionRange:
         *,
         intersect: bool,
         admit_arbitrary: bool,
+        prereleases: bool | None,
+        prereleases_configured: bool | None,
     ) -> VersionRange:
         """Resolve admit/reject for ``self & other`` or ``self | other``."""
         admits: set[str] = set()
@@ -639,6 +669,8 @@ class VersionRange:
             admit=frozenset(admits),
             reject=frozenset(rejects),
             admit_arbitrary=admit_arbitrary,
+            prereleases=prereleases,
+            prereleases_configured=prereleases_configured,
         )
 
     def _matches_literal(self, literal: str) -> bool:
@@ -814,12 +846,10 @@ class VersionRange:
                     )
                 result = result.intersection(operand)
 
-        result._restamp(
+        return result._with_policy(
             resolved=specifier_set.prereleases,
             configured=specifier_set._prereleases,
         )
-
-        return result
 
     @property
     def is_empty(self) -> bool:

--- a/src/packaging/ranges.py
+++ b/src/packaging/ranges.py
@@ -1,0 +1,946 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+"""Public :class:`VersionRange` API.
+
+A set-algebra view of the versions accepted by a
+:class:`~packaging.specifiers.SpecifierSet`. Ranges support intersection,
+union, and complement; membership and filtering match the originating
+specifier set.
+
+.. testsetup::
+
+    from packaging.ranges import VersionRange
+    from packaging.specifiers import SpecifierSet
+    from packaging.version import Version
+"""
+
+from __future__ import annotations
+
+import typing
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    TypeVar,
+    Union,
+)
+
+from ._ranges import (
+    FULL_RANGE,
+    MIN_VERSION,
+    NEG_INF,
+    POS_INF,
+    BoundaryKind,
+    BoundaryVersion,
+    LowerBound,
+    UpperBound,
+    coerce_version,
+    filter_by_ranges,
+    intersect_ranges,
+    matches_bounds_only,
+)
+from .version import Version
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable, Iterator, Sequence
+
+    from .specifiers import SpecifierSet
+
+    #: A single contiguous interval as a (lower, upper) bound pair.
+    _Interval = tuple[LowerBound, UpperBound]
+
+
+__all__ = ["VersionRange"]
+
+T = TypeVar("T")
+UnparsedVersion = Union[Version, str]
+UnparsedVersionVar = TypeVar("UnparsedVersionVar", bound=UnparsedVersion)
+
+
+def __dir__() -> list[str]:
+    return __all__
+
+
+# Range algebra: intersection lives in the engine (``intersect_ranges``);
+# union and complement are only needed here, so they live in this module.
+
+
+def _after_locals_successor(version: Version) -> Version:
+    """Smallest real version strictly above ``AFTER_LOCALS(version)``.
+
+    When V has a dev segment, the next real version is V with ``dev + 1``.
+    Otherwise AFTER_LOCALS(V) sits just below V.post0, so its successor is
+    V.post0.dev0 (V.post(N+1).dev0 when V is itself a post-release).
+    """
+    if version.dev is not None:
+        return version.__replace__(dev=version.dev + 1, local=None)
+
+    next_post = (version.post + 1) if version.post is not None else 0
+    return version.__replace__(post=next_post, dev=0, local=None)
+
+
+def _range_is_empty(lower: LowerBound, upper: UpperBound) -> bool:
+    """True when the union gap ``(lower, upper)`` holds no version.
+
+    Union calls this only for a strictly-ordered gap between two intervals,
+    so an ordinary version gap always holds a version. The one empty case is
+    a flipped ``AFTER_LOCALS(V)`` lower whose smallest real successor,
+    ``V.post0.dev0``, sits at or above the upper.
+    """
+    lower_version = lower.version
+    upper_version = upper.version
+
+    if (
+        isinstance(lower_version, BoundaryVersion)
+        and lower_version.kind == BoundaryKind.AFTER_LOCALS
+        and isinstance(upper_version, Version)
+    ):
+        successor = _after_locals_successor(lower_version.version)
+        if upper_version == successor:
+            return not upper.inclusive
+        return upper_version < successor
+    return False
+
+
+def _union_ranges(
+    left: Sequence[_Interval],
+    right: Sequence[_Interval],
+) -> list[_Interval]:
+    """Union two sorted, non-overlapping interval lists.
+
+    A linear merge over the two pre-sorted inputs followed by a single
+    coalescing pass: adjacent or overlapping intervals collapse so the result
+    is itself sorted and non-overlapping.
+    """
+    if not left:
+        return list(right)
+    if not right:
+        return list(left)
+
+    merged_input: list[_Interval] = []
+    left_index = right_index = 0
+    while left_index < len(left) and right_index < len(right):
+        if left[left_index][0] <= right[right_index][0]:
+            merged_input.append(left[left_index])
+            left_index += 1
+        else:
+            merged_input.append(right[right_index])
+            right_index += 1
+    merged_input.extend(left[left_index:])
+    merged_input.extend(right[right_index:])
+
+    merged: list[_Interval] = [merged_input[0]]
+    for lower, upper in merged_input[1:]:
+        prev_lower, prev_upper = merged[-1]
+
+        if (
+            prev_upper.version is None
+            or lower.version is None
+            or prev_upper.version > lower.version
+        ):
+            overlaps = True
+        elif prev_upper.version == lower.version:
+            overlaps = prev_upper.inclusive or lower.inclusive
+        else:
+            # An ordering gap may still hold no version when the two bounds
+            # straddle a synthetic boundary; merge across an empty gap to
+            # stay canonical.
+            gap_lower = LowerBound(prev_upper.version, not prev_upper.inclusive)
+            gap_upper = UpperBound(lower.version, not lower.inclusive)
+            overlaps = _range_is_empty(gap_lower, gap_upper)
+
+        if overlaps:
+            merged[-1] = (prev_lower, max(prev_upper, upper))
+        else:
+            merged.append((lower, upper))
+
+    return merged
+
+
+def _complement_ranges(ranges: Sequence[_Interval]) -> list[_Interval]:
+    """Complement a sorted, non-overlapping interval list.
+
+    Yields the gaps between intervals plus a leading gap before the first and
+    a trailing gap after the last. Bound inclusivity flips so that
+    complement-of-complement round-trips back to the input.
+    """
+    if not ranges:
+        return list(FULL_RANGE)
+
+    result: list[_Interval] = []
+    prev_upper: UpperBound | None = None
+
+    for lower, upper in ranges:
+        if prev_upper is None:
+            # A leading gap that ends at or below the PEP 440 floor holds no
+            # version, so it is dropped to keep ``is_empty`` correct. The live
+            # trigger is ``~singleton("0.dev0")`` (a strict ``[0.dev0, 0.dev0]``
+            # built outside ``_canonical_floor``); specifier-derived floor
+            # ranges are already collapsed to ``-inf`` before complement.
+            if lower.version is not None and not (
+                lower.inclusive
+                and isinstance(lower.version, Version)
+                and lower.version <= MIN_VERSION
+            ):
+                gap_upper = UpperBound(lower.version, not lower.inclusive)
+                result.append((NEG_INF, gap_upper))
+        else:
+            gap_lower = LowerBound(prev_upper.version, not prev_upper.inclusive)
+            gap_upper = UpperBound(lower.version, not lower.inclusive)
+            # Input intervals are canonical (sorted, disjoint, non-touching),
+            # so the gap between two of them always holds at least one version.
+            result.append((gap_lower, gap_upper))
+        prev_upper = upper
+
+    # The empty-input early return guarantees the loop ran.
+    assert prev_upper is not None
+    if prev_upper.version is not None:
+        gap_lower = LowerBound(prev_upper.version, not prev_upper.inclusive)
+        result.append((gap_lower, POS_INF))
+
+    return result
+
+
+def _canonical_floor(bounds: tuple[_Interval, ...]) -> tuple[_Interval, ...]:
+    """Collapse the PEP 440 floor in a sorted interval list.
+
+    Only the first interval can touch ``0.dev0`` (the minimum version). An
+    inclusive lower at or below it admits everything below, the same as
+    ``-inf``, so ``>=0.dev0`` becomes the one canonical full range. An
+    exclusive upper at or below it leaves the interval empty, so it is dropped.
+    """
+    if not bounds:
+        return bounds
+
+    lower, upper = bounds[0]
+    if (
+        not upper.inclusive
+        and isinstance(upper.version, Version)
+        and upper.version <= MIN_VERSION
+    ):
+        return bounds[1:]
+
+    if (
+        lower.inclusive
+        and isinstance(lower.version, Version)
+        and lower.version <= MIN_VERSION
+    ):
+        return ((NEG_INF, upper), *bounds[1:])
+
+    return bounds
+
+
+def _struct_admits(
+    bounds: tuple[_Interval, ...], admit_arbitrary: bool, literal: str
+) -> bool:
+    """True when the bounds (plus arbitrary admission) admit ``literal``.
+
+    Skips the explicit admit/reject sets, which the caller layers on top. A
+    non-version string matches via ``admit_arbitrary`` only on full bounds;
+    on narrower bounds the flag is metadata only.
+    """
+    parsed = coerce_version(literal)
+    if parsed is None:
+        return admit_arbitrary and bounds == FULL_RANGE
+
+    return matches_bounds_only(bounds, parsed)
+
+
+# Repr helpers:
+
+
+def _bound_version_str(value: BoundaryVersion | Version) -> str:
+    """Printout for a bound's inner value, kind-tagged for boundaries."""
+    if isinstance(value, BoundaryVersion):
+        return f"{value.version}[{value.kind.name}]"
+    return str(value)
+
+
+def _format_lower(bound: LowerBound) -> str:
+    if bound.version is None:
+        return "(-inf"
+    bracket = "[" if bound.inclusive else "("
+    return f"{bracket}{_bound_version_str(bound.version)}"
+
+
+def _format_upper(bound: UpperBound) -> str:
+    if bound.version is None:
+        return "+inf)"
+    bracket = "]" if bound.inclusive else ")"
+    return f"{_bound_version_str(bound.version)}{bracket}"
+
+
+class VersionRange:
+    """A set of :class:`~packaging.version.Version` values accepted by a
+    :class:`~packaging.specifiers.SpecifierSet`.
+
+    Construct via :meth:`~packaging.specifiers.SpecifierSet.to_range`, or with
+    the :meth:`full`, :meth:`empty`, and :meth:`singleton` class methods.
+    Compose with :meth:`intersection`, :meth:`union`, and :meth:`complement`
+    (or the ``&`` / ``|`` / ``~`` operators). Test membership with ``in`` or
+    :meth:`contains`, filter an iterable with :meth:`filter`.
+
+    The configured pre-release policy of the originating specifier set carries
+    onto the range and controls whether pre-releases are admitted under ``in``,
+    :meth:`contains`, and :meth:`filter`. :meth:`intersection` and
+    :meth:`union` require both operands to share the same policy.
+
+    >>> r = SpecifierSet(">=1.0,<2.0").to_range()
+    >>> "1.5" in r
+    True
+    >>> "2.0" in r
+    False
+    >>> SpecifierSet(">=2.0,<1.0").to_range().is_empty
+    True
+
+    PEP 440's ``===`` operator matches a candidate string verbatim
+    (case-insensitive) rather than a set of versions. Ranges built from
+    ``===`` specifiers still support membership and set operations; matching
+    follows the literal-equality rule.
+    """
+
+    __slots__ = (
+        "_admit",
+        "_admit_arbitrary",
+        "_bounds",
+        "_prereleases",
+        "_prereleases_configured",
+        "_reject",
+    )
+
+    #: The disjoint, sorted, non-overlapping interval list.
+    _bounds: tuple[_Interval, ...]
+
+    #: Whether this range matches non-version strings as well as versions.
+    #: True only by construction on ``SpecifierSet("")`` / :meth:`full`. Set
+    #: algebra ANDs on intersection, ORs on union, and preserves on complement.
+    #: Part of equality, since membership reads it.
+    _admit_arbitrary: bool
+
+    #: Case-folded strings the range admits in addition to its bounds.
+    #: ``===wat`` produces ``_admit = {"wat"}``.
+    _admit: frozenset[str]
+
+    #: Case-folded strings the range rejects (overrides ``_admit`` and the
+    #: bounds). Populated only by :meth:`complement` of an admit-bearing range.
+    _reject: frozenset[str]
+
+    #: Resolved pre-release policy used by :meth:`filter` and :meth:`contains`
+    #: when their ``prereleases`` argument is ``None``. Part of equality, so
+    #: two ranges that compare equal always filter the same versions.
+    _prereleases: bool | None
+
+    #: Raw configured pre-release override of the originating specifier set.
+    #: Distinguishes autodetect-True from explicit-True. :meth:`intersection`
+    #: and :meth:`union` require it to match on both operands. Part of equality.
+    _prereleases_configured: bool | None
+
+    def __new__(cls, *args: object, **kwargs: object) -> VersionRange:  # noqa: PYI034
+        raise TypeError(
+            "cannot create 'VersionRange' instances directly; use "
+            "SpecifierSet.to_range(), VersionRange.full(), "
+            "VersionRange.empty(), or VersionRange.singleton() instead"
+        )
+
+    @classmethod
+    def _build(
+        cls,
+        bounds: tuple[_Interval, ...],
+        admit: frozenset[str] = frozenset(),
+        reject: frozenset[str] = frozenset(),
+        admit_arbitrary: bool = False,
+    ) -> VersionRange:
+        """Internal factory; bypasses :meth:`__new__`.
+
+        Drops admit literals the bounds already admit, and reject literals the
+        bounds do not match anyway. Reject wins over admit on overlap.
+        """
+        if admit and reject:
+            admit = admit - reject
+        if admit:
+            admit = frozenset(
+                literal
+                for literal in admit
+                if not _struct_admits(bounds, admit_arbitrary, literal)
+            )
+        if reject:
+            reject = frozenset(
+                literal
+                for literal in reject
+                if _struct_admits(bounds, admit_arbitrary, literal)
+            )
+
+        instance = object.__new__(cls)
+        instance._bounds = bounds
+        instance._admit = admit
+        instance._reject = reject
+        instance._admit_arbitrary = admit_arbitrary
+        instance._prereleases = None
+        instance._prereleases_configured = None
+
+        return instance
+
+    def _has_literals(self) -> bool:
+        return bool(self._admit) or bool(self._reject)
+
+    def _arbitrary_active(self) -> bool:
+        """True when ``_admit_arbitrary`` actually admits non-version strings.
+
+        The flag rides through set algebra but only fires admission on full
+        bounds; on narrower bounds it is metadata awaiting a later widening.
+        """
+        return self._admit_arbitrary and self._bounds == FULL_RANGE
+
+    def _check_policy_compat(self, other: VersionRange) -> None:
+        """Refuse combining ranges with different pre-release policies."""
+        if not isinstance(other, VersionRange):
+            raise TypeError(f"expected VersionRange, got {type(other).__name__}")
+        if self._prereleases_configured != other._prereleases_configured:
+            raise ValueError(
+                "Cannot combine VersionRange operands with different "
+                f"pre-release policies: {self._prereleases_configured!r} "
+                f"and {other._prereleases_configured!r}"
+            )
+
+    def _propagate_prereleases(self, other: VersionRange, result: VersionRange) -> None:
+        """Carry the shared pre-release policy onto a freshly built result."""
+        result._prereleases_configured = self._prereleases_configured
+        if self._prereleases_configured is not None:
+            result._prereleases = self._prereleases_configured
+        elif self._prereleases is True or other._prereleases is True:
+            result._prereleases = True
+        else:
+            result._prereleases = None
+
+    def _restamp(self, *, resolved: bool | None, configured: bool | None) -> None:
+        """Set the pre-release policy slots on a freshly built range."""
+        self._prereleases = resolved
+        self._prereleases_configured = configured
+
+    @classmethod
+    def empty(cls, *, prereleases: bool | None = None) -> VersionRange:
+        """Return the empty range. No version satisfies it.
+
+        >>> VersionRange.empty().is_empty
+        True
+        >>> "1.0" in VersionRange.empty()
+        False
+        """
+        result = cls._build(())
+        if prereleases is not None:
+            result._restamp(resolved=prereleases, configured=prereleases)
+
+        return result
+
+    @classmethod
+    def full(
+        cls, *, admit_arbitrary: bool = True, prereleases: bool | None = None
+    ) -> VersionRange:
+        """Return the full range. Every PEP 440 version satisfies it.
+
+        ``admit_arbitrary=False`` restricts the range to PEP 440 versions only
+        (matching the same versions as ``SpecifierSet(">=0.dev0").to_range()``);
+        its complement is :meth:`empty`. The flag propagates through set algebra
+        and is part of equality. Default ``True`` so that ``r & full()``
+        preserves ``r``'s own flag structurally.
+
+        >>> "1.0" in VersionRange.full()
+        True
+        >>> "garbage" in VersionRange.full()
+        True
+        >>> "garbage" in VersionRange.full(admit_arbitrary=False)
+        False
+        """
+        result = cls._build(FULL_RANGE, admit_arbitrary=admit_arbitrary)
+        if prereleases is not None:
+            result._restamp(resolved=prereleases, configured=prereleases)
+
+        return result
+
+    @classmethod
+    def singleton(
+        cls, version: Version | str, *, prereleases: bool | None = None
+    ) -> VersionRange:
+        """Return the strict singleton range ``{version}``.
+
+        Built as the closed interval ``[version, version]`` with strict
+        equality. ``Specifier("==V")`` matches ``V+local`` too, so the strict
+        singleton is narrower:
+
+        >>> "1.0+local" in VersionRange.singleton("1.0")
+        False
+        >>> "1.0+local" in SpecifierSet("==1.0").to_range()
+        True
+
+        :raises packaging.version.InvalidVersion: if version is a string that
+            does not parse as a PEP 440 version.
+        """
+        if not isinstance(version, Version):
+            version = Version(version)
+
+        lower = LowerBound(version, True)
+        upper = UpperBound(version, True)
+
+        # Collapse the floor: nothing sorts below ``MIN_VERSION``, so the
+        # ``0.dev0`` singleton is ``(-inf, 0.dev0]`` in canonical form.
+        result = cls._build(_canonical_floor(((lower, upper),)))
+        if prereleases is not None:
+            result._restamp(resolved=prereleases, configured=prereleases)
+
+        return result
+
+    def intersection(self, other: VersionRange) -> VersionRange:
+        """Range containing exactly the versions in both self and other.
+
+        Both operands must share the same configured pre-release policy;
+        otherwise :exc:`ValueError` is raised.
+
+        >>> a = SpecifierSet(">=1.0").to_range()
+        >>> b = SpecifierSet("<2.0").to_range()
+        >>> a.intersection(b) == SpecifierSet(">=1.0,<2.0").to_range()
+        True
+        """
+        self._check_policy_compat(other)
+
+        new_bounds = tuple(intersect_ranges(self._bounds, other._bounds))
+        combined_arb = self._admit_arbitrary and other._admit_arbitrary
+        if not self._has_literals() and not other._has_literals():
+            result = self._build(new_bounds, admit_arbitrary=combined_arb)
+        else:
+            result = self._combine_literals(
+                other, new_bounds, intersect=True, admit_arbitrary=combined_arb
+            )
+
+        self._propagate_prereleases(other, result)
+        return result
+
+    def union(self, other: VersionRange) -> VersionRange:
+        """Range containing every version in self or other.
+
+        Both operands must share the same configured pre-release policy;
+        otherwise :exc:`ValueError` is raised.
+
+        >>> a = VersionRange.singleton("1.0")
+        >>> b = VersionRange.singleton("2.0")
+        >>> "1.0" in a.union(b) and "2.0" in a.union(b)
+        True
+        >>> "1.5" in a.union(b)
+        False
+        """
+        self._check_policy_compat(other)
+
+        new_bounds = tuple(_union_ranges(self._bounds, other._bounds))
+        combined_arb = self._admit_arbitrary or other._admit_arbitrary
+        if not self._has_literals() and not other._has_literals():
+            result = self._build(new_bounds, admit_arbitrary=combined_arb)
+        else:
+            result = self._combine_literals(
+                other, new_bounds, intersect=False, admit_arbitrary=combined_arb
+            )
+
+        # ``r | full()`` collapses to the canonical universal range only when
+        # both sides carry the autodetect default; an explicit policy survives.
+        if (
+            result._bounds == FULL_RANGE
+            and result._admit_arbitrary
+            and not result._has_literals()
+            and self._prereleases_configured is None
+        ):
+            result._prereleases_configured = None
+            result._prereleases = None
+            return result
+
+        self._propagate_prereleases(other, result)
+        return result
+
+    def complement(self) -> VersionRange:
+        """Range containing every version not in self.
+
+        Preserves the configured pre-release policy. Within the PEP 440
+        universe (no ``===`` literals and no arbitrary admission) double
+        negation holds; for ``===`` ranges complement is one-way.
+
+        >>> r = SpecifierSet(">=1.0").to_range()
+        >>> "0.5" in r.complement()
+        True
+        >>> "1.5" in r.complement()
+        False
+        >>> r.complement().complement() == r
+        True
+        """
+        if not self._has_literals():
+            result = self._build(
+                tuple(_complement_ranges(self._bounds)),
+                admit_arbitrary=self._admit_arbitrary,
+            )
+        else:
+            result = self._build(
+                tuple(_complement_ranges(self._bounds)),
+                admit=self._reject,
+                reject=self._admit,
+                admit_arbitrary=self._admit_arbitrary,
+            )
+
+        result._prereleases = self._prereleases
+        result._prereleases_configured = self._prereleases_configured
+        return result
+
+    def _combine_literals(
+        self,
+        other: VersionRange,
+        new_bounds: tuple[_Interval, ...],
+        *,
+        intersect: bool,
+        admit_arbitrary: bool,
+    ) -> VersionRange:
+        """Resolve admit/reject for ``self & other`` or ``self | other``."""
+        admits: set[str] = set()
+        rejects: set[str] = set()
+        for literal in self._admit | self._reject | other._admit | other._reject:
+            self_in = self._matches_literal(literal)
+            other_in = other._matches_literal(literal)
+            want = (self_in and other_in) if intersect else (self_in or other_in)
+            if want:
+                admits.add(literal)
+            else:
+                rejects.add(literal)
+
+        return self._build(
+            new_bounds,
+            admit=frozenset(admits),
+            reject=frozenset(rejects),
+            admit_arbitrary=admit_arbitrary,
+        )
+
+    def _matches_literal(self, literal: str) -> bool:
+        """Whether literal (case-folded) matches this range's predicate."""
+        if literal in self._reject:
+            return False
+        if literal in self._admit:
+            return True
+
+        parsed = coerce_version(literal)
+        if parsed is None:
+            return self._arbitrary_active()
+        return matches_bounds_only(self._bounds, parsed)
+
+    def __and__(self, other: object) -> VersionRange:
+        """Operator alias for :meth:`intersection`."""
+        if not isinstance(other, VersionRange):
+            return NotImplemented
+        return self.intersection(other)
+
+    def __or__(self, other: object) -> VersionRange:
+        """Operator alias for :meth:`union`."""
+        if not isinstance(other, VersionRange):
+            return NotImplemented
+        return self.union(other)
+
+    def __invert__(self) -> VersionRange:
+        """Operator alias for :meth:`complement`."""
+        return self.complement()
+
+    @typing.overload
+    def filter(
+        self,
+        iterable: Iterable[UnparsedVersionVar],
+        prereleases: bool | None = None,
+        key: None = ...,
+    ) -> Iterator[UnparsedVersionVar]: ...
+
+    @typing.overload
+    def filter(
+        self,
+        iterable: Iterable[T],
+        prereleases: bool | None = None,
+        key: Callable[[T], UnparsedVersion] = ...,
+    ) -> Iterator[T]: ...
+
+    def filter(
+        self,
+        iterable: Iterable[Any],
+        prereleases: bool | None = None,
+        key: Callable[[Any], Version | str] | None = None,
+    ) -> Iterator[Any]:
+        """Yield items from iterable whose version falls inside the range.
+
+        With prereleases ``None`` the PEP 440 default applies: pre-releases are
+        buffered and only emitted if no final release in iterable is in range.
+
+        The signature mirrors
+        :meth:`~packaging.specifiers.SpecifierSet.filter`.
+
+        >>> r = SpecifierSet(">=1.0,<2.0").to_range()
+        >>> list(r.filter(["0.9", "1.5", "2.0"]))
+        ['1.5']
+        """
+        if prereleases is None:
+            prereleases = self._prereleases
+
+        arbitrary_active = self._arbitrary_active()
+        if not self._admit and not self._reject and not arbitrary_active:
+            return filter_by_ranges(self._bounds, iterable, key, prereleases)
+        return self._filter_with_admission(iterable, key, prereleases, arbitrary_active)
+
+    def _filter_with_admission(
+        self,
+        iterable: Iterable[Any],
+        key: Callable[[Any], Version | str] | None,
+        prereleases: bool | None,
+        arbitrary_active: bool,
+    ) -> Iterator[Any]:
+        """Filter for ranges with admit/reject literals or live arbitrary
+        admission (including the universal ``SpecifierSet("")`` range)."""
+        admit_set = self._admit
+        reject_set = self._reject
+
+        def admit(item: Any) -> tuple[bool, Version | None]:  # noqa: ANN401
+            raw: Version | str = item if key is None else key(item)
+            raw_lower = str(raw).lower()
+
+            if reject_set and raw_lower in reject_set:
+                return False, None
+            if admit_set and raw_lower in admit_set:
+                return True, coerce_version(raw)
+
+            parsed = coerce_version(raw)
+            if parsed is None:
+                return arbitrary_active, None
+            if not matches_bounds_only(self._bounds, parsed):
+                return False, None
+            return True, parsed
+
+        if prereleases is True:
+            for item in iterable:
+                ok, _ = admit(item)
+                if ok:
+                    yield item
+            return
+
+        if prereleases is False:
+            for item in iterable:
+                ok, parsed = admit(item)
+                if not ok:
+                    continue
+                if parsed is not None and parsed.is_prerelease:
+                    continue
+                yield item
+            return
+
+        all_nonfinal: list[Any] = []
+        arbitrary_strings: list[Any] = []
+        found_final = False
+        for item in iterable:
+            ok, parsed = admit(item)
+            if not ok:
+                continue
+
+            if parsed is None:
+                if found_final:
+                    yield item
+                else:
+                    arbitrary_strings.append(item)
+                    all_nonfinal.append(item)
+                continue
+
+            if not parsed.is_prerelease:
+                if not found_final:
+                    yield from arbitrary_strings
+                    arbitrary_strings.clear()
+                    found_final = True
+                yield item
+                continue
+
+            if not found_final:
+                all_nonfinal.append(item)
+
+        if not found_final:
+            yield from all_nonfinal
+
+    @classmethod
+    def _from_specifier_set(cls, specifier_set: SpecifierSet) -> VersionRange:
+        """Build the range accepted by ``specifier_set``.
+
+        Friend constructor for :meth:`~packaging.specifiers.SpecifierSet.to_range`.
+        The intersection of every specifier in the set: an empty set yields the
+        full range, an unsatisfiable set yields the empty range, and ``===``
+        specifiers contribute literal-string admission.
+        """
+        if not specifier_set:
+            result = cls.full()
+        elif not specifier_set._has_arbitrary:
+            result = cls._build(
+                bounds=_canonical_floor(tuple(specifier_set._get_ranges()))
+            )
+        else:
+            result = cls.full()
+            for spec in specifier_set:
+                if spec.operator == "===":
+                    operand = cls._build(
+                        bounds=(), admit=frozenset({spec.version.lower()})
+                    )
+                else:
+                    operand = cls._build(
+                        bounds=_canonical_floor(tuple(spec._to_ranges()))
+                    )
+                result = result.intersection(operand)
+
+        result._restamp(
+            resolved=specifier_set.prereleases,
+            configured=specifier_set._prereleases,
+        )
+
+        return result
+
+    @property
+    def is_empty(self) -> bool:
+        """``True`` if no version or string satisfies this range.
+
+        >>> SpecifierSet(">=2,<1").to_range().is_empty
+        True
+        >>> SpecifierSet(">=1,<2").to_range().is_empty
+        False
+        """
+        return not self._bounds and not self._admit
+
+    def contains(
+        self,
+        item: Version | str,
+        prereleases: bool | None = None,
+        installed: bool | None = None,
+    ) -> bool:
+        """Return whether item is contained in this range.
+
+        :param item: a version string or :class:`~packaging.version.Version`.
+        :param prereleases: whether to match pre-releases. ``None`` (default)
+            uses the range's own policy.
+        :param installed: when ``True``, accept a pre-release item even if the
+            range would not otherwise allow it.
+
+        Unparsable strings do not match, except where the full
+        ``SpecifierSet`` would also match: the full range admits any string,
+        and a ``===`` range admits items equal to the literal
+        case-insensitively.
+
+        >>> r = SpecifierSet(">=1.0,<2.0").to_range()
+        >>> r.contains("1.5")
+        True
+        >>> r.contains("2.0")
+        False
+
+        :raises TypeError: if item is not a str or Version.
+        """
+        if not isinstance(item, (str, Version)):
+            raise TypeError(
+                f"VersionRange.contains() expected str or Version, "
+                f"got {type(item).__name__}"
+            )
+
+        parsed: Version | None = item if isinstance(item, Version) else None
+        if installed and parsed is None:
+            parsed = coerce_version(item)
+        if installed and parsed is not None and parsed.is_prerelease:
+            prereleases = True
+
+        effective_pre = (
+            self._prereleases_configured if prereleases is None else prereleases
+        )
+
+        if self._admit or self._reject:
+            item_str = str(item).lower()
+            if item_str in self._reject:
+                return False
+            if item_str in self._admit:
+                if effective_pre is False:
+                    literal_parsed = coerce_version(item_str)
+                    if literal_parsed is not None and literal_parsed.is_prerelease:
+                        return False
+                return True
+
+        if not isinstance(item, Version):
+            if parsed is None:
+                parsed = coerce_version(item)
+            if parsed is None:
+                return self._arbitrary_active()
+            item = parsed
+
+        if effective_pre is False and item.is_prerelease:
+            return False
+        return matches_bounds_only(self._bounds, item)
+
+    def __contains__(self, item: Version | str) -> bool:
+        """Return whether item is contained in this range.
+
+        Forwards to :meth:`contains` with default arguments.
+
+        >>> "1.5" in SpecifierSet(">=1.0,<2.0").to_range()
+        True
+        """
+        return self.contains(item)
+
+    def __eq__(self, other: object) -> bool:
+        """Structural equality.
+
+        Two ranges compare equal when every input to :meth:`contains` and
+        :meth:`filter` agrees: the bounds, the ``===`` admit/reject literals,
+        the arbitrary-string flag, and both the configured and resolved
+        pre-release policies. Equal ranges therefore filter identically.
+
+        >>> r = SpecifierSet(">=1.0,<2.0").to_range()
+        >>> r == SpecifierSet(">=1.0,<2.0").to_range()
+        True
+        """
+        if not isinstance(other, VersionRange):
+            return NotImplemented
+        return (
+            self._bounds == other._bounds
+            and self._admit == other._admit
+            and self._reject == other._reject
+            and self._admit_arbitrary == other._admit_arbitrary
+            and self._prereleases_configured == other._prereleases_configured
+            and self._prereleases == other._prereleases
+        )
+
+    def __hash__(self) -> int:
+        return hash(
+            (
+                self._bounds,
+                self._admit,
+                self._reject,
+                self._admit_arbitrary,
+                self._prereleases_configured,
+                self._prereleases,
+            )
+        )
+
+    def __repr__(self) -> str:
+        """Human-readable representation for debugging.
+
+        >>> SpecifierSet(">=1.0,<2.0").to_range()
+        <VersionRange '[1.0, 2.0.dev0)'>
+        >>> SpecifierSet("").to_range()
+        <VersionRange '(-inf, +inf)' arbitrary>
+        >>> SpecifierSet(">=2.0,<1.0").to_range()
+        <VersionRange '(empty)'>
+        """
+        parts: list[str] = []
+        if self._bounds:
+            parts.append(
+                " | ".join(
+                    f"{_format_lower(lower)}, {_format_upper(upper)}"
+                    for lower, upper in self._bounds
+                )
+            )
+        if self._admit:
+            parts.append("{" + ", ".join(sorted(self._admit)) + "}")
+
+        body = " | ".join(parts) if parts else "(empty)"
+        if self._reject:
+            body = f"{body} \\ {{{', '.join(sorted(self._reject))}}}"
+
+        tail = ""
+        if self._admit_arbitrary:
+            tail += " arbitrary"
+        if self._prereleases_configured is not None:
+            tail += f" pre={self._prereleases_configured}"
+        return f"<{self.__class__.__name__} {body!r}{tail}>"

--- a/src/packaging/specifiers.py
+++ b/src/packaging/specifiers.py
@@ -45,6 +45,7 @@ if TYPE_CHECKING:
     else:
         from typing_extensions import TypeGuard
 
+    from . import ranges
     from ._ranges import VersionRange
 
 
@@ -1111,6 +1112,21 @@ class SpecifierSet(BaseSpecifier):
             return True
 
         return not all(s.contains(candidate) for s in standard)
+
+    def to_range(self) -> ranges.VersionRange:
+        """Return the :class:`~packaging.ranges.VersionRange` this set accepts.
+
+        An empty set yields the full range; an unsatisfiable set yields the
+        empty range. ``===`` specifiers contribute literal-string admission.
+
+        >>> SpecifierSet(">=1.0,<2.0").to_range()
+        <VersionRange '[1.0, 2.0.dev0)'>
+
+        .. versionadded:: 26.3
+        """
+        from .ranges import VersionRange  # noqa: PLC0415
+
+        return VersionRange._from_specifier_set(self)
 
     def __contains__(self, item: UnparsedVersion) -> bool:
         """Return whether or not the item is contained in this specifier.

--- a/tests/property/strategies.py
+++ b/tests/property/strategies.py
@@ -4,11 +4,31 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from hypothesis import settings
 from hypothesis import strategies as st
 
 from packaging.specifiers import SpecifierSet
 from packaging.version import Version
+
+if TYPE_CHECKING:
+    from packaging.ranges import VersionRange
+
+
+def eq_versions_only(a: VersionRange, b: VersionRange) -> bool:
+    """Compare two ranges ignoring the arbitrary-string and pre-release
+    policy slots.
+
+    Complement preserves ``_admit_arbitrary`` (only the universal range
+    admits non-version strings, never algebra), so ``r | ~r`` is never
+    structurally equal to ``VersionRange.full()`` when neither ``r`` nor
+    ``~r`` is empty. The pre-release configured override mirrors
+    ``SpecifierSet.__and__`` rather than pure Boolean algebra. Use this
+    helper when the property is "same set of versions accepted".
+    """
+    return a._bounds == b._bounds and a._admit == b._admit and a._reject == b._reject
+
 
 SETTINGS = settings(max_examples=300, deadline=None)
 
@@ -65,7 +85,7 @@ def pep440_versions(
     min_segments: int = 1,
 ) -> Version:
     """Generate a random PEP 440 version."""
-    epoch = draw(st.sampled_from([None, 0, 1]))
+    epoch = draw(st.sampled_from([None, 0, 1, 2, 3]))
     num_segments = draw(st.integers(min_value=min_segments, max_value=4))
     release = tuple(draw(small_ints) for _ in range(num_segments))
 
@@ -109,11 +129,19 @@ def nonlocal_versions(draw: st.DrawFn) -> Version:
 
 
 @st.composite
-def release_versions(draw: st.DrawFn, *, min_segments: int = 1) -> Version:
-    """Generate a final release version (no pre/post/dev/local)."""
+def release_versions(
+    draw: st.DrawFn, *, min_segments: int = 1, allow_epoch: bool = False
+) -> Version:
+    """Generate a final release version (no pre/post/dev/local).
+
+    With ``allow_epoch=True`` the release may carry a non-zero epoch, so a
+    zero release becomes a non-zero-epoch zero family (e.g. ``1!0``).
+    """
     num_segments = draw(st.integers(min_value=min_segments, max_value=4))
     release = tuple(draw(small_ints) for _ in range(num_segments))
-    return Version(".".join(str(s) for s in release))
+    epoch = draw(st.sampled_from([None, 1, 2])) if allow_epoch else None
+    prefix = f"{epoch}!" if epoch else ""
+    return Version(prefix + ".".join(str(s) for s in release))
 
 
 @st.composite
@@ -132,8 +160,20 @@ def versions_with_local(draw: st.DrawFn) -> Version:
 
 
 @st.composite
-def specifier_sets(draw: st.DrawFn) -> SpecifierSet:
-    """Generate a random SpecifierSet from common operator/version pairs."""
+def specifier_sets(
+    draw: st.DrawFn,
+    *,
+    vary_prereleases: bool = False,
+) -> SpecifierSet:
+    """Random SpecifierSet over ``>= <= > < == !=`` and ``major.minor``.
+
+    Narrow on purpose. Tests that need wildcards, locals, pre/post/dev
+    on the RHS, epochs, or ``===`` should use :func:`rich_specifier_sets`.
+
+    With ``vary_prereleases=True`` the configured pre-release policy is
+    drawn from ``(None, True, False)``; otherwise it is left as ``None``
+    (autodetect).
+    """
     num = draw(st.integers(min_value=1, max_value=3))
     parts: list[str] = []
     for _ in range(num):
@@ -141,6 +181,69 @@ def specifier_sets(draw: st.DrawFn) -> SpecifierSet:
         major = draw(small_ints)
         minor = draw(small_ints)
         parts.append(f"{op}{major}.{minor}")
+
+    prereleases = (
+        draw(st.sampled_from([None, True, False])) if vary_prereleases else None
+    )
+
+    return SpecifierSet(",".join(parts), prereleases=prereleases)
+
+
+_ordered_ops = st.sampled_from([">=", "<=", ">", "<"])
+_equality_ops = st.sampled_from(["==", "!="])
+
+
+@st.composite
+def pep440_specifier_strings(
+    draw: st.DrawFn,
+    *,
+    include_arbitrary: bool = False,
+) -> str:
+    """One specifier string covering the full PEP 440 surface.
+
+    Includes pre/post/dev/local-bearing RHS versions, epochs, multi-
+    segment release tuples, ``==V.*`` / ``!=V.*`` wildcards, and
+    optionally ``===L``.
+    """
+    shape = draw(st.sampled_from(["ordered", "equality", "wildcard", "compatible"]))
+    if include_arbitrary and draw(st.booleans()):
+        shape = "arbitrary"
+
+    if shape == "ordered":
+        # ``>= <= > <`` reject ``+local`` on the RHS.
+        return f"{draw(_ordered_ops)}{draw(pep440_versions(include_local=False))}"
+
+    if shape == "equality":
+        return f"{draw(_equality_ops)}{draw(pep440_versions())}"
+
+    if shape == "wildcard":
+        # ``==V.*`` / ``!=V.*`` take a release-only RHS; epochs reach the
+        # epoch-zero family floor (``==1!0.*``).
+        return f"{draw(_equality_ops)}{draw(release_versions(allow_epoch=True))}.*"
+
+    if shape == "compatible":
+        return f"~={draw(multi_segment_versions())}"
+
+    # ``===L`` with a parseable literal. Unparsable literals like
+    # ``===wat`` are skipped: De Morgan can fail when an unparsable
+    # ``===`` interacts with a non-full rangelike, since the bound
+    # universe is parseable Versions but the literal universe is
+    # all strings.
+    return f"==={draw(pep440_versions())}"
+
+
+@st.composite
+def rich_specifier_sets(
+    draw: st.DrawFn,
+    *,
+    include_arbitrary: bool = False,
+) -> SpecifierSet:
+    """1-3 specifiers from :func:`pep440_specifier_strings`, joined."""
+    num = draw(st.integers(min_value=1, max_value=3))
+    parts = [
+        draw(pep440_specifier_strings(include_arbitrary=include_arbitrary))
+        for _ in range(num)
+    ]
     return SpecifierSet(",".join(parts))
 
 

--- a/tests/property/test_ranges_cross_epoch.py
+++ b/tests/property/test_ranges_cross_epoch.py
@@ -1,0 +1,82 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+
+"""Property tests for ``VersionRange`` algebra across distinct epochs.
+
+PEP 440 epochs partition the version order into disjoint cohorts; an
+``==1.0`` predicate in epoch 0 never overlaps an ``==1.0`` predicate in
+epoch 1. The lattice laws still hold across cohorts.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from hypothesis import given
+
+from .strategies import (
+    SETTINGS,
+    VERSION_POOL,
+    pep440_versions,
+    rich_specifier_sets,
+)
+
+if TYPE_CHECKING:
+    from packaging.ranges import VersionRange
+    from packaging.specifiers import SpecifierSet
+    from packaging.version import Version
+
+pytestmark = pytest.mark.property
+
+# Cross-epoch + dev/MIN_VERSION boundary probes for the membership oracle.
+_EPOCH_PROBES = [
+    "0.5",
+    "1.0",
+    "1.0a1",
+    "0.dev0",
+    "1.dev0",
+    "1.dev1",
+    "1.dev2",
+    "1!0.5",
+    "1!1.0",
+    "1!0.dev0",
+    "2!0.5",
+    "2!1.0",
+    "3!1.0",
+]
+
+
+def _mem_eq(a: VersionRange, b: VersionRange) -> bool:
+    """``a`` and ``b`` accept the same versions across the probe sample."""
+    probes = [str(v) for v in VERSION_POOL] + _EPOCH_PROBES
+    return all((p in a) == (p in b) for p in probes)
+
+
+@given(a=rich_specifier_sets(), b=rich_specifier_sets())
+@SETTINGS
+def test_de_morgan_holds_cross_epoch(a: SpecifierSet, b: SpecifierSet) -> None:
+    """De Morgan holds for ranges that may straddle different epochs.
+
+    The minimal engine canonicalizes empty/MIN_VERSION regions, so the two
+    sides can differ in bound representation; compare on the version set.
+    """
+    ra, rb = a.to_range(), b.to_range()
+    assert _mem_eq((ra & rb).complement(), ra.complement() | rb.complement())
+    assert _mem_eq((ra | rb).complement(), ra.complement() & rb.complement())
+
+
+@given(
+    a=rich_specifier_sets(),
+    b=rich_specifier_sets(),
+    v=pep440_versions(),
+)
+@SETTINGS
+def test_membership_consistent_across_epochs(
+    a: SpecifierSet, b: SpecifierSet, v: Version
+) -> None:
+    """``v in (a & b)`` iff ``v in a`` and ``v in b`` regardless of epochs."""
+    ra, rb = a.to_range(), b.to_range()
+    assert (v in (ra & rb)) == ((v in ra) and (v in rb))
+    assert (v in (ra | rb)) == ((v in ra) or (v in rb))

--- a/tests/property/test_ranges_pep440_extended.py
+++ b/tests/property/test_ranges_pep440_extended.py
@@ -1,0 +1,300 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+
+"""Set-algebra invariants re-run on the full PEP 440 specifier surface.
+
+Uses :func:`tests.property.strategies.rich_specifier_sets`, which
+adds wildcards, ``~=``, locals, pre/post/dev RHS, epochs, multi-
+segment release tuples, and optionally ``===``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from hypothesis import given
+
+from packaging.ranges import VersionRange
+
+from .strategies import (
+    SETTINGS,
+    VERSION_POOL,
+    rich_specifier_sets,
+)
+
+if TYPE_CHECKING:
+    from packaging.ranges import VersionRange as _VersionRange
+    from packaging.specifiers import SpecifierSet
+
+pytestmark = pytest.mark.property
+
+# Extra boundary probes for the membership oracle. The minimal engine
+# canonicalizes empty and ``MIN_VERSION`` regions (e.g. ``(1.dev1+, 1.dev2)``
+# collapses to ``(empty)``, ``0.dev0`` lower bounds collapse to ``-inf``), so
+# complement-bearing laws can differ in bound representation while accepting
+# the same versions. These probes plus ``VERSION_POOL`` distinguish any
+# genuine version-set difference.
+_BOUNDARY_PROBES = [
+    "0.dev0",
+    "0.dev1",
+    "1.dev0",
+    "1.dev1",
+    "1.dev2",
+    "0rc0.dev0",
+    "0rc0.dev1",
+    "2.dev0",
+    "1!0.dev0",
+]
+
+
+_ARBITRARY_PROBES = ["garbage", "unparsable", "not-a-version", "wat"]
+
+
+def _version_eq(a: _VersionRange, b: _VersionRange) -> bool:
+    """``a`` and ``b`` accept the same *versions* and ``===`` literals.
+
+    Probes cover ``VERSION_POOL``, dev/MIN_VERSION boundary versions, and
+    every ``===`` literal admitted or rejected by either operand, but not
+    free non-version strings: the ``_admit_arbitrary`` slot attaches only to
+    the genuine universal range, so ``r | ~r`` covers every version yet never
+    admits arbitrary strings the way ``full()`` does. Genuine differences in
+    bounds or literal slots are caught; benign empty/MIN_VERSION bound
+    canonicalization and the ``_admit_arbitrary`` asymmetry are not.
+    """
+    literals = a._admit | a._reject | b._admit | b._reject
+    probes = [str(v) for v in VERSION_POOL] + _BOUNDARY_PROBES + list(literals)
+    return all((p in a) == (p in b) for p in probes)
+
+
+def _mem_eq(a: _VersionRange, b: _VersionRange) -> bool:
+    """``a`` and ``b`` accept the same items, including non-version strings.
+
+    Extends :func:`_version_eq` with free non-version probes, so it also
+    distinguishes the ``_admit_arbitrary`` slot. Use for laws that do not
+    compare against ``full()``.
+    """
+    if not _version_eq(a, b):
+        return False
+    return all((p in a) == (p in b) for p in _ARBITRARY_PROBES)
+
+
+@given(spec_set=rich_specifier_sets())
+@SETTINGS
+def test_double_complement_identity_rich(spec_set: SpecifierSet) -> None:
+    r = spec_set.to_range()
+    # Involution holds on the version set. The minimal engine canonicalizes
+    # a ``MIN_VERSION`` (``0.dev0``) lower bound to ``-inf`` (no version is
+    # below it), so ``~~r`` can differ from ``r`` only in bound
+    # representation, never in which versions it accepts (e.g. ``==0.*``);
+    # compare on the version subset.
+    assert _mem_eq(r.complement().complement(), r)
+
+
+@given(spec_set=rich_specifier_sets())
+@SETTINGS
+def test_complement_partitions_rich(spec_set: SpecifierSet) -> None:
+    r = spec_set.to_range()
+    c = r.complement()
+    assert _mem_eq(r.intersection(c), VersionRange.empty())
+    assert _version_eq(r.union(c), VersionRange.full())
+
+
+@given(a=rich_specifier_sets(), b=rich_specifier_sets())
+@SETTINGS
+def test_de_morgan_intersect_rich(a: SpecifierSet, b: SpecifierSet) -> None:
+    ra = a.to_range()
+    rb = b.to_range()
+    # The minimal engine canonicalizes empty/MIN_VERSION regions, so the two
+    # sides can differ in bound representation; compare on the version set.
+    assert _mem_eq(
+        ra.intersection(rb).complement(),
+        ra.complement().union(rb.complement()),
+    )
+
+
+@given(a=rich_specifier_sets(), b=rich_specifier_sets())
+@SETTINGS
+def test_de_morgan_union_rich(a: SpecifierSet, b: SpecifierSet) -> None:
+    ra = a.to_range()
+    rb = b.to_range()
+    assert _mem_eq(
+        ra.union(rb).complement(),
+        ra.complement().intersection(rb.complement()),
+    )
+
+
+@given(spec_set=rich_specifier_sets())
+@SETTINGS
+def test_idempotence_rich(spec_set: SpecifierSet) -> None:
+    r = spec_set.to_range()
+    assert r.union(r) == r
+    assert r.intersection(r) == r
+
+
+@given(a=rich_specifier_sets(), b=rich_specifier_sets())
+@SETTINGS
+def test_intersect_commutative_rich(a: SpecifierSet, b: SpecifierSet) -> None:
+    ra = a.to_range()
+    rb = b.to_range()
+    assert ra.intersection(rb) == rb.intersection(ra)
+
+
+@given(a=rich_specifier_sets(), b=rich_specifier_sets())
+@SETTINGS
+def test_union_commutative_rich(a: SpecifierSet, b: SpecifierSet) -> None:
+    ra = a.to_range()
+    rb = b.to_range()
+    assert ra.union(rb) == rb.union(ra)
+
+
+@given(a=rich_specifier_sets(), b=rich_specifier_sets(), c=rich_specifier_sets())
+@SETTINGS
+def test_intersect_associative_rich(
+    a: SpecifierSet, b: SpecifierSet, c: SpecifierSet
+) -> None:
+    ra = a.to_range()
+    rb = b.to_range()
+    rc = c.to_range()
+    assert ra.intersection(rb).intersection(rc) == ra.intersection(rb.intersection(rc))
+
+
+@given(a=rich_specifier_sets(), b=rich_specifier_sets(), c=rich_specifier_sets())
+@SETTINGS
+def test_union_associative_rich(
+    a: SpecifierSet, b: SpecifierSet, c: SpecifierSet
+) -> None:
+    ra = a.to_range()
+    rb = b.to_range()
+    rc = c.to_range()
+    assert ra.union(rb).union(rc) == ra.union(rb.union(rc))
+
+
+@given(a=rich_specifier_sets(), b=rich_specifier_sets(), c=rich_specifier_sets())
+@SETTINGS
+def test_intersect_distributes_over_union_rich(
+    a: SpecifierSet, b: SpecifierSet, c: SpecifierSet
+) -> None:
+    ra = a.to_range()
+    rb = b.to_range()
+    rc = c.to_range()
+    assert ra.intersection(rb.union(rc)) == ra.intersection(rb).union(
+        ra.intersection(rc)
+    )
+
+
+@given(a=rich_specifier_sets(), b=rich_specifier_sets(), c=rich_specifier_sets())
+@SETTINGS
+def test_union_distributes_over_intersect_rich(
+    a: SpecifierSet, b: SpecifierSet, c: SpecifierSet
+) -> None:
+    ra = a.to_range()
+    rb = b.to_range()
+    rc = c.to_range()
+    assert ra.union(rb.intersection(rc)) == ra.union(rb).intersection(ra.union(rc))
+
+
+@given(spec_set=rich_specifier_sets())
+@SETTINGS
+def test_membership_consistent_with_complement_rich(
+    spec_set: SpecifierSet,
+) -> None:
+    r = spec_set.to_range()
+    c = r.complement()
+    for v in VERSION_POOL:
+        assert (v in c) == (v not in r)
+
+
+@given(a=rich_specifier_sets(), b=rich_specifier_sets())
+@SETTINGS
+def test_membership_consistent_with_intersect_rich(
+    a: SpecifierSet, b: SpecifierSet
+) -> None:
+    ra = a.to_range()
+    rb = b.to_range()
+    inter = ra.intersection(rb)
+    for v in VERSION_POOL:
+        assert (v in inter) == ((v in ra) and (v in rb))
+
+
+@given(a=rich_specifier_sets(), b=rich_specifier_sets())
+@SETTINGS
+def test_membership_consistent_with_union_rich(
+    a: SpecifierSet, b: SpecifierSet
+) -> None:
+    ra = a.to_range()
+    rb = b.to_range()
+    union = ra.union(rb)
+    for v in VERSION_POOL:
+        assert (v in union) == ((v in ra) or (v in rb))
+
+
+@given(spec_set=rich_specifier_sets(include_arbitrary=True))
+@SETTINGS
+def test_double_complement_with_arbitrary(spec_set: SpecifierSet) -> None:
+    r = spec_set.to_range()
+    # Involution holds on the accepted set. The minimal engine canonicalizes
+    # a ``MIN_VERSION`` (``0.dev0``) lower bound to ``-inf`` (no version is
+    # below it), so ``~~r`` can differ from ``r`` only in bound
+    # representation, never in which items it accepts; compare on the
+    # probe sample (versions plus ``===`` literals).
+    assert _mem_eq(r.complement().complement(), r)
+
+
+@given(spec_set=rich_specifier_sets(include_arbitrary=True))
+@SETTINGS
+def test_complement_partitions_with_arbitrary(spec_set: SpecifierSet) -> None:
+    r = spec_set.to_range()
+    c = r.complement()
+    assert _mem_eq(r.intersection(c), VersionRange.empty())
+    assert _version_eq(r.union(c), VersionRange.full())
+
+
+@given(
+    a=rich_specifier_sets(include_arbitrary=True),
+    b=rich_specifier_sets(include_arbitrary=True),
+)
+@SETTINGS
+def test_de_morgan_intersect_with_arbitrary(a: SpecifierSet, b: SpecifierSet) -> None:
+    ra = a.to_range()
+    rb = b.to_range()
+    # The minimal engine canonicalizes empty/MIN_VERSION regions, so the two
+    # sides can differ in bound representation; compare on the probe sample.
+    assert _mem_eq(
+        ra.intersection(rb).complement(),
+        ra.complement().union(rb.complement()),
+    )
+
+
+@given(
+    a=rich_specifier_sets(include_arbitrary=True),
+    b=rich_specifier_sets(include_arbitrary=True),
+)
+@SETTINGS
+def test_de_morgan_union_with_arbitrary(a: SpecifierSet, b: SpecifierSet) -> None:
+    ra = a.to_range()
+    rb = b.to_range()
+    assert _mem_eq(
+        ra.union(rb).complement(),
+        ra.complement().intersection(rb.complement()),
+    )
+
+
+@given(spec_set=rich_specifier_sets(include_arbitrary=True))
+@SETTINGS
+def test_idempotence_with_arbitrary(spec_set: SpecifierSet) -> None:
+    r = spec_set.to_range()
+    assert r.union(r) == r
+    assert r.intersection(r) == r
+
+
+@given(spec_set=rich_specifier_sets(include_arbitrary=True))
+@SETTINGS
+def test_membership_consistent_with_complement_arbitrary(
+    spec_set: SpecifierSet,
+) -> None:
+    r = spec_set.to_range()
+    c = r.complement()
+    for v in VERSION_POOL:
+        assert (v in c) == (v not in r)

--- a/tests/property/test_ranges_pubgrub.py
+++ b/tests/property/test_ranges_pubgrub.py
@@ -1,0 +1,374 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+
+"""Property tests verifying ``VersionRange`` satisfies PubGrub's invariants.
+
+Each test class quotes the relevant paragraph verbatim from one of:
+
+* `solver.md`_, the Dart pub specification (`Definitions Term`_,
+  `Definitions Incompatibility`_).
+* `Pubgrub blog post`_, Natalie Weizenbaum, 2018.
+
+Unicode set-theoretic operators in the quotations are preserved as
+written; the per-file ``noqa`` overrides silence ruff's ambiguous-glyph
+warning for those quotations only.
+
+.. _solver.md: https://github.com/dart-lang/pub/blob/master/doc/solver.md
+.. _Definitions Term:
+   https://github.com/dart-lang/pub/blob/master/doc/solver.md#term
+.. _Definitions Incompatibility:
+   https://github.com/dart-lang/pub/blob/master/doc/solver.md#incompatibility
+.. _Pubgrub blog post: https://nex3.medium.com/pubgrub-2fb6470504f
+"""
+
+# ruff: noqa: RUF002, RUF003, E501
+# RUF002 / RUF003: ambiguous Unicode in docstrings and comments, the
+#         spec quotations preserve set-theoretic operators verbatim.
+# E501: spec quotations are reproduced as written; wrapping them would
+#       harm searchability against the upstream documents.
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from hypothesis import given
+
+from packaging.ranges import VersionRange
+
+from .strategies import SETTINGS, VERSION_POOL, pep440_versions, specifier_sets
+
+if TYPE_CHECKING:
+    from packaging.specifiers import SpecifierSet
+    from packaging.version import Version
+
+pytestmark = pytest.mark.property
+
+
+def _to_range(spec_set: SpecifierSet) -> VersionRange:
+    """Lift a non-``===`` SpecifierSet into a VersionRange."""
+    return spec_set.to_range()
+
+
+def _term_set(range_: VersionRange, *, positive: bool) -> VersionRange:
+    """Set view of a PubGrub term: ``R`` if positive, ``~R`` if negative."""
+    return range_ if positive else range_.complement()
+
+
+def _is_subset(a: VersionRange, b: VersionRange) -> bool:
+    """``A ⊆ B`` iff ``A & B == A``."""
+    return (a & b) == a
+
+
+def _is_disjoint(a: VersionRange, b: VersionRange) -> bool:
+    """``A ∩ B == ∅``."""
+    return (a & b).is_empty
+
+
+class TestQuoteTermAsStatement:
+    """solver.md § Term, paragraph 1:
+
+    > "The fundamental unit on which Pubgrub operates is a Term, which
+    > represents a statement about a package that may be true or false
+    > for a given selection of package versions. For example, foo
+    > ^1.0.0 is a term that's true if foo 1.2.3 is selected and false
+    > if foo 2.3.4 is selected. Conversely, not foo ^1.0.0 is false if
+    > foo 1.2.3 is selected and true if foo 2.3.4 is selected or if no
+    > version of foo is selected at all."
+    """
+
+    @given(spec_set=specifier_sets())
+    @SETTINGS
+    def test_positive_and_negative_polarities_disagree_pointwise(
+        self, spec_set: SpecifierSet
+    ) -> None:
+        """``v in R`` iff ``v not in ~R`` for every PEP 440 version."""
+        r = _to_range(spec_set)
+        positive = _term_set(r, positive=True)
+        negative = _term_set(r, positive=False)
+        for v in VERSION_POOL:
+            assert (v in positive) is not (v in negative)
+
+
+class TestQuoteTermsDenoteSets:
+    """solver.md § Term, paragraph 4:
+
+    > "Terms can be viewed as denoting sets of allowed versions, with
+    > negative terms denoting the complement of the corresponding
+    > positive term. Set relations and operations can be defined
+    > accordingly."
+    """
+
+    @given(spec_set=specifier_sets())
+    @SETTINGS
+    def test_double_negation_returns_original_term(
+        self, spec_set: SpecifierSet
+    ) -> None:
+        """``not not T == T``."""
+        r = _to_range(spec_set)
+        assert _term_set(_term_set(r, positive=False), positive=False) == r
+
+
+class TestQuoteSetOperationExamples:
+    """solver.md § Term, paragraph 5:
+
+    > "* foo ^1.0.0 ∪ foo ^2.0.0 is foo >=1.0.0 <3.0.0.
+    > * foo >=1.0.0 ∩ not foo >=2.0.0 is foo ^1.0.0.
+    > * foo ^1.0.0 \\ foo ^1.5.0 is foo >=1.0.0 <1.5.0."
+    """
+
+    @given(a=specifier_sets(), b=specifier_sets())
+    @SETTINGS
+    def test_set_difference_equals_intersection_with_complement(
+        self, a: SpecifierSet, b: SpecifierSet
+    ) -> None:
+        """``A \\ B`` (versions in A but not B) equals ``A ∩ ~B``."""
+        ra, rb = _to_range(a), _to_range(b)
+        difference = ra & rb.complement()
+        for v in VERSION_POOL:
+            assert (v in difference) == (v in ra and v not in rb)
+
+    @given(a=specifier_sets(), b=specifier_sets())
+    @SETTINGS
+    def test_intersection_with_negation_excludes_negated_range(
+        self, a: SpecifierSet, b: SpecifierSet
+    ) -> None:
+        """``v in A ∩ not B`` iff ``v in A`` and ``v not in B``."""
+        ra, rb = _to_range(a), _to_range(b)
+        result = ra & rb.complement()
+        for v in VERSION_POOL:
+            assert (v in result) == ((v in ra) and (v not in rb))
+
+
+class TestQuoteSatisfiesAndContradictsIdentities:
+    """solver.md § Term, paragraph 6:
+
+    > "This turns out to be useful for computing satisfaction and
+    > contradiction. Given a term t and a set of terms S, we have the
+    > following identities:
+    > * S satisfies t if and only if ⋂S ⊆ t.
+    > * S contradicts t if and only if ⋂S is disjoint with t."
+    """
+
+    @given(s=specifier_sets(), t=specifier_sets())
+    @SETTINGS
+    def test_subset_implies_pointwise_satisfaction(
+        self, s: SpecifierSet, t: SpecifierSet
+    ) -> None:
+        """Structural ``⋂S ⊆ T`` implies every pooled version satisfying
+        ``S`` also satisfies ``T``. Only this direction is sound: the
+        finite pool makes the pointwise converse spuriously True."""
+        rs, rt = _to_range(s), _to_range(t)
+        if _is_subset(rs, rt):
+            assert all((v not in rs) or (v in rt) for v in VERSION_POOL)
+
+    @given(s=specifier_sets(), t=specifier_sets())
+    @SETTINGS
+    def test_disjoint_implies_pointwise_contradiction(
+        self, s: SpecifierSet, t: SpecifierSet
+    ) -> None:
+        """Structural ``⋂S ∩ T == ∅`` implies no pooled version satisfies
+        both ``S`` and ``T``. The pointwise converse is unsound on a
+        finite pool, so only the forward direction is asserted."""
+        rs, rt = _to_range(s), _to_range(t)
+        if _is_disjoint(rs, rt):
+            assert all((v not in rs) or (v not in rt) for v in VERSION_POOL)
+
+    @given(s=specifier_sets(), t=specifier_sets())
+    @SETTINGS
+    def test_satisfies_iff_subset_negative(
+        self, s: SpecifierSet, t: SpecifierSet
+    ) -> None:
+        """``S`` satisfies negative term ``not T`` iff ``⋂S ⊆ ~T``."""
+        rs, rt = _to_range(s), _to_range(t)
+        neg_t = _term_set(rt, positive=False)
+        assert _is_subset(rs, neg_t) == _is_disjoint(rs, rt)
+
+    @given(s=specifier_sets(), t=specifier_sets())
+    @SETTINGS
+    def test_contradicts_iff_disjoint_negative(
+        self, s: SpecifierSet, t: SpecifierSet
+    ) -> None:
+        """``S`` contradicts negative term ``not T`` iff ``⋂S ⊆ T``."""
+        rs, rt = _to_range(s), _to_range(t)
+        neg_t = _term_set(rt, positive=False)
+        assert _is_disjoint(rs, neg_t) == _is_subset(rs, rt)
+
+
+class TestQuoteTrichotomy:
+    """solver.md § Term, paragraph 2:
+
+    > "We say that a set of terms S 'satisfies' a term t if t must be
+    > true whenever every term in S is true. Conversely, S
+    > 'contradicts' t if t must be false whenever every term in S is
+    > true. If neither of these is true, we say that S is
+    > 'inconclusive' for t. As a shorthand, we say that a term v
+    > satisfies or contradicts t if {v} satisfies or contradicts it."
+    """
+
+    @given(s=specifier_sets(), t=specifier_sets())
+    @SETTINGS
+    def test_satisfies_and_contradicts_mutually_exclusive_on_non_empty(
+        self, s: SpecifierSet, t: SpecifierSet
+    ) -> None:
+        """For non-empty ``⋂S``, ``S`` cannot both satisfy and contradict ``t``."""
+        rs, rt = _to_range(s), _to_range(t)
+        if rs.is_empty:
+            return
+        satisfies = _is_subset(rs, rt)
+        contradicts = _is_disjoint(rs, rt)
+        assert not (satisfies and contradicts)
+
+    @given(s=specifier_sets(), t=specifier_sets())
+    @SETTINGS
+    def test_empty_intersection_is_both_satisfies_and_contradicts(
+        self, s: SpecifierSet, t: SpecifierSet
+    ) -> None:
+        """An unsatisfiable ``S`` (``⋂S == ∅``) is vacuously both."""
+        rs, rt = _to_range(s), _to_range(t)
+        if not rs.is_empty:
+            return
+        assert _is_subset(rs, rt)
+        assert _is_disjoint(rs, rt)
+
+    @given(spec_set=specifier_sets())
+    @SETTINGS
+    def test_singleton_shorthand(self, spec_set: SpecifierSet) -> None:
+        """``{v}`` satisfies ``t`` iff ``v in t``; trichotomy collapses on singletons."""
+        rt = _to_range(spec_set)
+        for v in VERSION_POOL:
+            singleton = VersionRange.singleton(v)
+            satisfies = _is_subset(singleton, rt)
+            contradicts = _is_disjoint(singleton, rt)
+            assert satisfies == (v in rt)
+            assert contradicts == (v not in rt)
+            assert satisfies != contradicts
+
+
+class TestQuoteIncompatibilityNormalisation:
+    """solver.md § Incompatibility, paragraph 2:
+
+    > "Incompatibilities are normalized so that at most one term refers
+    > to any given package name. For example, {foo >=1.0.0, foo
+    > <2.0.0} is normalized to {foo ^1.0.0}. Derived incompatibilities
+    > with more than one term are also normalized to remove positive
+    > terms referring to the root package, since these terms will
+    > always be satisfied."
+    """
+
+    @given(a=specifier_sets(), b=specifier_sets(), c=specifier_sets())
+    @SETTINGS
+    def test_three_term_merge_is_order_independent(
+        self, a: SpecifierSet, b: SpecifierSet, c: SpecifierSet
+    ) -> None:
+        """Merging ``{R1, R2, R3}`` over the same package is order-free."""
+        ra, rb, rc = _to_range(a), _to_range(b), _to_range(c)
+        m1 = ra & rb & rc
+        m2 = ra & rc & rb
+        m3 = rb & ra & rc
+        m4 = rb & rc & ra
+        m5 = rc & ra & rb
+        m6 = rc & rb & ra
+        assert m1 == m2 == m3 == m4 == m5 == m6
+
+
+class TestQuoteBlogPostSatisfaction:
+    """nex3.medium.com/pubgrub, § "So What Does PubGrub Do?":
+
+    > "A term is satisfied if it matches the version of the package
+    > that's selected. menu ≥1.1.0 is satisfied if menu 1.2.0 is
+    > selected, and not dropdown ≥2.0.0 is satisfied if dropdown 1.8.0
+    > is selected (or if no version of dropdown is selected at all)."
+    """
+
+    @given(spec_set=specifier_sets(), v=pep440_versions())
+    @SETTINGS
+    def test_concrete_version_satisfies_negative_term_iff_outside_range(
+        self, spec_set: SpecifierSet, v: Version
+    ) -> None:
+        """Negative ``not T`` satisfied by ``v`` iff ``v not in T``."""
+        rt = _to_range(spec_set)
+        negative_set = _term_set(rt, positive=False)
+        assert (v in negative_set) == (v not in rt)
+
+
+class TestQuoteConcreteExamples:
+    """solver.md § Term, paragraph 3:
+
+    > "* {foo >=1.0.0, foo <2.0.0} satisfies foo ^1.0.0,
+    > * foo ^1.5.0 contradicts not foo ^1.0.0,
+    > * and foo ^1.0.0 is inconclusive for foo ^1.5.0."
+    """
+
+    @given(spec_set=specifier_sets())
+    @SETTINGS
+    def test_self_subset_satisfies_self(self, spec_set: SpecifierSet) -> None:
+        """``R`` satisfies ``R``."""
+        r = _to_range(spec_set)
+        assert _is_subset(r, r)
+
+    @given(a=specifier_sets(), b=specifier_sets())
+    @SETTINGS
+    def test_subset_implies_contradicts_negation(
+        self, a: SpecifierSet, b: SpecifierSet
+    ) -> None:
+        """``A ⊆ B`` implies ``A & ~B == ∅``."""
+        ra, rb = _to_range(a), _to_range(b)
+        if not _is_subset(ra, rb):
+            return
+        assert _is_disjoint(ra, rb.complement())
+
+    @given(a=specifier_sets(), b=specifier_sets())
+    @SETTINGS
+    def test_strict_superset_is_inconclusive_for_subset(
+        self, a: SpecifierSet, b: SpecifierSet
+    ) -> None:
+        """``B ⊊ A`` ⇒ ``A`` neither satisfies nor contradicts ``B``."""
+        ra, rb = _to_range(a), _to_range(b)
+        if rb.is_empty or not _is_subset(rb, ra) or ra == rb:
+            return
+        assert not _is_subset(ra, rb)
+        assert not _is_disjoint(ra, rb)
+
+
+class TestQuoteSetSatisfiesIncompatibility:
+    """solver.md § Incompatibility, paragraph 3:
+
+    > "We say that a set of terms S satisfies an incompatibility I if
+    > S satisfies every term in I. We say that S contradicts I if S
+    > contradicts at least one term in I. If S satisfies all but one
+    > of I's terms and is inconclusive for the remaining term, we say
+    > S 'almost satisfies' I and we call the remaining term the
+    > 'unsatisfied term'."
+    """
+
+    @given(s=specifier_sets(), t1=specifier_sets(), t2=specifier_sets())
+    @SETTINGS
+    def test_satisfies_two_term_incompatibility_iff_subset_of_intersection(
+        self, s: SpecifierSet, t1: SpecifierSet, t2: SpecifierSet
+    ) -> None:
+        """``S satisfies {t1, t2}`` iff ``⋂S ⊆ t1 ∩ t2``."""
+        rs, r1, r2 = _to_range(s), _to_range(t1), _to_range(t2)
+        sat_universal = _is_subset(rs, r1) and _is_subset(rs, r2)
+        sat_via_intersection = _is_subset(rs, r1 & r2)
+        assert sat_universal == sat_via_intersection
+
+    @given(s=specifier_sets(), t1=specifier_sets(), t2=specifier_sets())
+    @SETTINGS
+    def test_contradicts_two_term_incompatibility_iff_disjoint_with_either(
+        self, s: SpecifierSet, t1: SpecifierSet, t2: SpecifierSet
+    ) -> None:
+        """``S contradicts {t1, t2}`` iff ``⋂S ∩ t1 == ∅`` OR ``⋂S ∩ t2 == ∅``."""
+        rs, r1, r2 = _to_range(s), _to_range(t1), _to_range(t2)
+        cont_existential = _is_disjoint(rs, r1) or _is_disjoint(rs, r2)
+        # Per-term subset-of-complement form. Strictly stronger than
+        # ``⋂S ⊆ (~t1 ∪ ~t2)`` (the pointwise existential).
+        cont_existential_alt = _is_subset(rs, r1.complement()) or _is_subset(
+            rs, r2.complement()
+        )
+        assert cont_existential == cont_existential_alt
+        # Incompatibility is a set of terms, so the disjunction is
+        # order-free.
+        cont_reversed = _is_disjoint(rs, r2) or _is_disjoint(rs, r1)
+        assert cont_existential == cont_reversed

--- a/tests/property/test_ranges_set_algebra.py
+++ b/tests/property/test_ranges_set_algebra.py
@@ -1,0 +1,368 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+
+"""Property tests for ``VersionRange`` Boolean lattice laws.
+
+Identity, idempotence, commutativity, associativity, distributivity,
+double-complement, De Morgan, and consistency with ``__contains__``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from hypothesis import given
+
+from packaging.ranges import VersionRange
+from packaging.specifiers import SpecifierSet
+
+from .strategies import (
+    SETTINGS,
+    VERSION_POOL,
+    eq_versions_only,
+    pep440_versions,
+    rich_specifier_sets,
+    specifier_sets,
+)
+
+if TYPE_CHECKING:
+    from packaging.version import Version
+
+pytestmark = pytest.mark.property
+
+
+def _to_range(spec_set: SpecifierSet) -> VersionRange:
+    """Lift a non-``===`` SpecifierSet into a VersionRange."""
+    return spec_set.to_range()
+
+
+@given(spec_set=specifier_sets())
+@SETTINGS
+def test_intersect_with_unbounded_is_identity(spec_set: SpecifierSet) -> None:
+    r = _to_range(spec_set)
+    u = VersionRange.full()
+    assert r.intersection(u) == r
+    assert u.intersection(r) == r
+
+
+@given(spec_set=specifier_sets())
+@SETTINGS
+def test_union_with_empty_is_identity(spec_set: SpecifierSet) -> None:
+    r = _to_range(spec_set)
+    e = VersionRange.empty()
+    assert r.union(e) == r
+    assert e.union(r) == r
+
+
+@given(spec_set=specifier_sets())
+@SETTINGS
+def test_intersect_with_empty_is_empty(spec_set: SpecifierSet) -> None:
+    r = _to_range(spec_set)
+    e = VersionRange.empty()
+    assert r.intersection(e) == e
+    assert e.intersection(r) == e
+
+
+@given(spec_set=specifier_sets())
+@SETTINGS
+def test_union_with_unbounded_is_unbounded(spec_set: SpecifierSet) -> None:
+    r = _to_range(spec_set)
+    u = VersionRange.full()
+    assert r.union(u) == u
+    assert u.union(r) == u
+
+
+@given(spec_set=specifier_sets())
+@SETTINGS
+def test_idempotence(spec_set: SpecifierSet) -> None:
+    r = _to_range(spec_set)
+    assert r.union(r) == r
+    assert r.intersection(r) == r
+
+
+@given(a=specifier_sets(), b=specifier_sets())
+@SETTINGS
+def test_union_commutative(a: SpecifierSet, b: SpecifierSet) -> None:
+    ra, rb = _to_range(a), _to_range(b)
+    assert ra.union(rb) == rb.union(ra)
+
+
+@given(a=specifier_sets(), b=specifier_sets())
+@SETTINGS
+def test_intersect_commutative(a: SpecifierSet, b: SpecifierSet) -> None:
+    ra, rb = _to_range(a), _to_range(b)
+    assert ra.intersection(rb) == rb.intersection(ra)
+
+
+@given(a=specifier_sets(), b=specifier_sets(), c=specifier_sets())
+@SETTINGS
+def test_union_associative(a: SpecifierSet, b: SpecifierSet, c: SpecifierSet) -> None:
+    ra, rb, rc = _to_range(a), _to_range(b), _to_range(c)
+    assert ra.union(rb).union(rc) == ra.union(rb.union(rc))
+
+
+@given(a=specifier_sets(), b=specifier_sets(), c=specifier_sets())
+@SETTINGS
+def test_intersect_associative(
+    a: SpecifierSet, b: SpecifierSet, c: SpecifierSet
+) -> None:
+    ra, rb, rc = _to_range(a), _to_range(b), _to_range(c)
+    assert ra.intersection(rb).intersection(rc) == ra.intersection(rb.intersection(rc))
+
+
+@given(spec_set=specifier_sets())
+@SETTINGS
+def test_double_complement_identity(spec_set: SpecifierSet) -> None:
+    r = _to_range(spec_set)
+    # Complement preserves every membership slot, so involution holds
+    # structurally.
+    assert r.complement().complement() == r
+
+
+@given(spec_set=specifier_sets())
+@SETTINGS
+def test_complement_partitions(spec_set: SpecifierSet) -> None:
+    r = _to_range(spec_set)
+    c = r.complement()
+    # r and ~r are disjoint and together cover every version. Compare on
+    # the version subset: ``_admit_arbitrary`` only attaches to the
+    # genuine universal range, so ``r | ~r`` never carries it when
+    # neither side is empty.
+    assert r.intersection(c).is_empty
+    assert eq_versions_only(r.union(c), VersionRange.full())
+
+
+@given(a=specifier_sets(), b=specifier_sets())
+@SETTINGS
+def test_de_morgan_intersect(a: SpecifierSet, b: SpecifierSet) -> None:
+    ra, rb = _to_range(a), _to_range(b)
+    # ``specifier_sets`` never produces the universal set, so both sides
+    # stay in the PEP 440 universe and De Morgan holds structurally.
+    assert (ra.intersection(rb)).complement() == ra.complement().union(rb.complement())
+
+
+@given(a=specifier_sets(), b=specifier_sets())
+@SETTINGS
+def test_de_morgan_union(a: SpecifierSet, b: SpecifierSet) -> None:
+    ra, rb = _to_range(a), _to_range(b)
+    assert (ra.union(rb)).complement() == ra.complement().intersection(rb.complement())
+
+
+@given(a=specifier_sets(), b=specifier_sets(), c=specifier_sets())
+@SETTINGS
+def test_intersect_distributes_over_union(
+    a: SpecifierSet, b: SpecifierSet, c: SpecifierSet
+) -> None:
+    ra, rb, rc = _to_range(a), _to_range(b), _to_range(c)
+    lhs = ra.intersection(rb.union(rc))
+    rhs = ra.intersection(rb).union(ra.intersection(rc))
+    assert lhs == rhs
+
+
+@given(a=specifier_sets(), b=specifier_sets(), c=specifier_sets())
+@SETTINGS
+def test_union_distributes_over_intersect(
+    a: SpecifierSet, b: SpecifierSet, c: SpecifierSet
+) -> None:
+    ra, rb, rc = _to_range(a), _to_range(b), _to_range(c)
+    lhs = ra.union(rb.intersection(rc))
+    rhs = ra.union(rb).intersection(ra.union(rc))
+    assert lhs == rhs
+
+
+@given(spec_set=specifier_sets())
+@SETTINGS
+def test_operator_aliases(spec_set: SpecifierSet) -> None:
+    """Operators mirror the named methods."""
+    r = _to_range(spec_set)
+    other = _to_range(SpecifierSet(">=1.0,<2.0"))
+    assert (r & other) == r.intersection(other)
+    assert (r | other) == r.union(other)
+    assert (~r) == r.complement()
+
+
+@given(a=specifier_sets(), b=specifier_sets())
+@SETTINGS
+def test_membership_consistent_with_intersect(a: SpecifierSet, b: SpecifierSet) -> None:
+    """``v in (a & b)`` iff ``v in a`` AND ``v in b`` for every version."""
+    ra, rb = _to_range(a), _to_range(b)
+    intersection = ra.intersection(rb)
+    for v in VERSION_POOL:
+        assert (v in intersection) == ((v in ra) and (v in rb))
+
+
+@given(a=specifier_sets(), b=specifier_sets())
+@SETTINGS
+def test_membership_consistent_with_union(a: SpecifierSet, b: SpecifierSet) -> None:
+    """``v in (a | b)`` iff ``v in a`` OR ``v in b`` for every version."""
+    ra, rb = _to_range(a), _to_range(b)
+    union = ra.union(rb)
+    for v in VERSION_POOL:
+        assert (v in union) == ((v in ra) or (v in rb))
+
+
+@given(spec_set=specifier_sets())
+@SETTINGS
+def test_membership_consistent_with_complement(spec_set: SpecifierSet) -> None:
+    """``v in ~r`` iff ``v not in r`` for every version."""
+    r = _to_range(spec_set)
+    c = r.complement()
+    for v in VERSION_POOL:
+        assert (v in c) == (v not in r)
+
+
+@given(spec_set=specifier_sets())
+@SETTINGS
+def test_exact_singleton_membership(spec_set: SpecifierSet) -> None:
+    """``VersionRange.singleton(v)`` contains only ``v`` and no other version."""
+    r = _to_range(spec_set)
+    for v in VERSION_POOL:
+        exact = VersionRange.singleton(v)
+        assert v in exact
+        # ``v`` is in (r & exact) iff v in r.
+        assert (v in r.intersection(exact)) == (v in r)
+
+
+@given(spec_set=specifier_sets())
+@SETTINGS
+def test_hash_equality_consistency(spec_set: SpecifierSet) -> None:
+    """Equal ranges have equal hashes; usable as dict/set keys."""
+    r1 = _to_range(spec_set)
+    r2 = _to_range(spec_set)
+    assert r1 == r2
+    assert hash(r1) == hash(r2)
+
+
+@given(spec_set=specifier_sets())
+@SETTINGS
+def test_complement_is_empty_iff_unbounded(spec_set: SpecifierSet) -> None:
+    """``~r`` is empty exactly when ``r`` covers every version.
+
+    Compares on the version subset only: a ``>=0.dev0``-derived range
+    reaches FULL_RANGE bounds but does not admit arbitrary strings, so its
+    complement is empty even though it is not structurally equal to
+    ``VersionRange.full()``.
+    """
+    r = _to_range(spec_set)
+    if r.complement().is_empty:
+        assert eq_versions_only(r, VersionRange.full())
+    if eq_versions_only(r, VersionRange.full()):
+        assert r.complement().is_empty
+
+
+@given(versions=specifier_sets(), v=pep440_versions())
+@SETTINGS
+def test_exact_equals_singleton_intersection(
+    versions: SpecifierSet, v: Version
+) -> None:
+    """``r & exact(v)`` is non-empty iff v is in r, and equals exact(v) when so."""
+    r = _to_range(versions)
+    e = VersionRange.singleton(v)
+    inter = r.intersection(e)
+    if v in r:
+        assert inter == e
+    else:
+        assert inter.is_empty
+
+
+@given(spec_set=rich_specifier_sets())
+@SETTINGS
+def test_full_range_is_identity_for_filter(spec_set: SpecifierSet) -> None:
+    """``full()`` is the identity for ``&`` w.r.t. filtering.
+
+    Pre-release eligibility rides on ``_prereleases``, which ``==`` and
+    ``__contains__`` ignore by design, so the structural laws above can't see
+    it; only ``filter`` does. Folding ``full() & r1 & r2 & ...`` must never
+    erase a range's tag.
+    """
+    r = spec_set.to_range()
+    full = VersionRange.full()
+    expected = list(r.filter(VERSION_POOL))
+    assert list((r & full).filter(VERSION_POOL)) == expected
+    assert list((full & r).filter(VERSION_POOL)) == expected
+
+
+@given(a=rich_specifier_sets(), b=rich_specifier_sets())
+@SETTINGS
+def test_intersection_filter_matches_merged_set(
+    a: SpecifierSet, b: SpecifierSet
+) -> None:
+    """``to_range`` is a homomorphism w.r.t. filtering.
+
+    ``(a.to_range() & b.to_range()).filter`` equals
+    ``(a & b).to_range().filter``, including pre-release eligibility (which
+    the structural ``==`` laws above cannot observe).
+    """
+    composed = list((a.to_range() & b.to_range()).filter(VERSION_POOL))
+    merged = list((a & b).to_range().filter(VERSION_POOL))
+    assert composed == merged
+
+
+@given(spec_set=rich_specifier_sets(include_arbitrary=True))
+@SETTINGS
+def test_to_range_filter_and_contains_mirror_specifier_set(
+    spec_set: SpecifierSet,
+) -> None:
+    """``filter`` and ``__contains__`` on the range mirror the originating set.
+
+    Closes the gap that the bounds-only fast path in ``SpecifierSet.filter``
+    might diverge from ``VersionRange.filter`` on the ``prereleases=None``
+    default, or that ``v in to_range()`` might drift from ``v in spec_set``.
+    """
+    r = spec_set.to_range()
+    pool = [str(v) for v in VERSION_POOL] + ["unparsable", "garbage"]
+    for prereleases in (None, True, False):
+        assert list(r.filter(pool, prereleases=prereleases)) == list(
+            spec_set.filter(pool, prereleases=prereleases)
+        )
+    for item in pool:
+        assert (item in r) == (item in spec_set)
+
+
+@given(spec_set=rich_specifier_sets(include_arbitrary=True))
+@SETTINGS
+def test_unsatisfiable_implies_no_pool_match(spec_set: SpecifierSet) -> None:
+    """A set flagged unsatisfiable can satisfy nothing under the same policy.
+
+    Pinned to ``prereleases=False`` to exercise the prerelease-only branch
+    that ``is_unsatisfiable`` consults; the implication is sound for any
+    policy.
+    """
+    pinned = SpecifierSet(str(spec_set), prereleases=False)
+    if pinned.is_unsatisfiable():
+        assert not any(pinned.contains(v) for v in VERSION_POOL)
+
+
+# Omitted: test_prerelease_only_implies_all_matches_are_prereleases relied on
+# the dropped ``VersionRange.is_prerelease_only`` property.
+
+
+@given(spec_set=specifier_sets(vary_prereleases=True))
+@SETTINGS
+def test_identity_laws_under_each_policy(spec_set: SpecifierSet) -> None:
+    """``full``/``empty`` stamped with the same policy obey the four identities.
+
+    Stamps ``full()``/``empty()`` with the same configured policy as the
+    drawn range so ``_check_policy_compat`` accepts the pair, then asserts
+    the four lattice identities under the version-only oracle (the
+    universal-range arbitrary-string slot does not survive intersection).
+    """
+    r = spec_set.to_range()
+    p = r._prereleases_configured
+    full = VersionRange.full(prereleases=p)
+    empty = VersionRange.empty(prereleases=p)
+    assert eq_versions_only(r & full, r)
+    assert eq_versions_only(r | empty, r)
+    assert r & empty == empty
+    assert eq_versions_only(r | full, full)
+
+
+@given(spec_set=specifier_sets(vary_prereleases=True))
+@SETTINGS
+def test_idempotence_under_each_policy(spec_set: SpecifierSet) -> None:
+    """``r & r == r`` and ``r | r == r`` for every configured policy."""
+    r = spec_set.to_range()
+    assert r & r == r
+    assert r | r == r

--- a/tests/test_ranges.py
+++ b/tests/test_ranges.py
@@ -1,0 +1,637 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+
+from __future__ import annotations
+
+import pytest
+
+from packaging._ranges import BoundaryKind, BoundaryVersion
+from packaging.ranges import VersionRange
+from packaging.specifiers import SpecifierSet
+from packaging.version import InvalidVersion, Version
+
+
+def vr(spec: str, prereleases: bool | None = None) -> VersionRange:
+    return SpecifierSet(spec, prereleases=prereleases).to_range()
+
+
+class TestConstruction:
+    def test_cannot_construct_directly(self) -> None:
+        with pytest.raises(TypeError, match="cannot create"):
+            VersionRange()
+
+    def test_full(self) -> None:
+        r = VersionRange.full()
+        assert Version("1.0") in r
+        assert "garbage" in r
+        assert not r.is_empty
+
+    def test_full_no_arbitrary(self) -> None:
+        r = VersionRange.full(admit_arbitrary=False)
+        assert Version("1.0") in r
+        assert "garbage" not in r
+
+    def test_empty(self) -> None:
+        r = VersionRange.empty()
+        assert r.is_empty
+        assert Version("1.0") not in r
+        assert "garbage" not in r
+
+    def test_empty_with_prereleases(self) -> None:
+        r = VersionRange.empty(prereleases=True)
+        assert r.is_empty
+        assert r._prereleases_configured is True
+
+    def test_full_with_prereleases(self) -> None:
+        r = VersionRange.full(prereleases=False)
+        assert r._prereleases_configured is False
+
+    def test_singleton(self) -> None:
+        r = VersionRange.singleton("1.2.3")
+        assert Version("1.2.3") in r
+        assert Version("1.2.4") not in r
+
+    def test_singleton_is_strict(self) -> None:
+        # ``==1.0`` matches 1.0+local; the strict singleton does not.
+        assert Version("1.0+local") not in VersionRange.singleton("1.0")
+        assert Version("1.0+local") in vr("==1.0")
+
+    def test_singleton_accepts_version(self) -> None:
+        assert Version("1.0") in VersionRange.singleton(Version("1.0"))
+
+    def test_singleton_with_prereleases(self) -> None:
+        r = VersionRange.singleton("1.0", prereleases=True)
+        assert r._prereleases_configured is True
+
+    def test_singleton_invalid(self) -> None:
+        with pytest.raises(InvalidVersion):
+            VersionRange.singleton("not a version")
+
+    def test_singleton_floor_is_canonical_and_strict(self) -> None:
+        # ``0.dev0`` is the minimum version, so the strict singleton collapses
+        # its floor to the one canonical form ``(-inf, 0.dev0]`` while keeping
+        # strict-equality semantics (locals and higher versions excluded).
+        r = VersionRange.singleton("0.dev0")
+        assert Version("0.dev0") in r
+        assert Version("0.dev0+local") not in r
+        assert Version("0") not in r
+        # Floor collapsed: the lower bound is unbounded (-inf), not [0.dev0.
+        assert r._bounds[0][0].version is None
+
+    def test_singleton_above_floor_stays_strict(self) -> None:
+        # ``0`` sorts above ``0.dev0`` (the floor), so its singleton must not
+        # collapse: ``(-inf, 0]`` would wrongly admit ``0.dev0``.
+        r = VersionRange.singleton("0")
+        assert Version("0.dev0") not in r
+        assert Version("0") in r
+
+
+class TestToRange:
+    def test_any(self) -> None:
+        r = SpecifierSet().to_range()
+        assert Version("1.0") in r
+        assert Version("999.0") in r
+
+    def test_unsatisfiable(self) -> None:
+        assert SpecifierSet(">=2.0,<1.0").to_range().is_empty
+
+    @pytest.mark.parametrize(
+        ("spec", "inside", "outside"),
+        [
+            (">=1.0", "1.0", "0.9"),
+            (">1.0", "1.1", "1.0"),
+            ("<=1.0", "1.0", "1.1"),
+            ("<1.0", "0.9", "1.0"),
+            ("==1.0", "1.0", "1.1"),
+            ("!=1.5", "1.4", "1.5"),
+            ("~=1.4.2", "1.4.5", "1.5"),
+            ("==1.2.*", "1.2.9", "1.3"),
+        ],
+    )
+    def test_operators(self, spec: str, inside: str, outside: str) -> None:
+        r = vr(spec)
+        assert Version(inside) in r
+        assert Version(outside) not in r
+
+    def test_lte_includes_local_excludes_post(self) -> None:
+        r = vr("<=1.0")
+        assert Version("1.0") in r
+        assert Version("1.0+local") in r
+        assert Version("1.0.post1") not in r
+
+    def test_gt_excludes_post(self) -> None:
+        r = vr(">1.0")
+        assert Version("1.0") not in r
+        assert Version("1.0.post1") not in r
+        assert Version("1.0.1") in r
+
+    def test_arbitrary_equality_literal_range(self) -> None:
+        # The nab carve-out contract: the literal string matches, no Version.
+        r = vr("===1.0.special")
+        assert "1.0.special" in r
+        assert Version("1.0") not in r
+
+    def test_arbitrary_equality_valid_version_literal(self) -> None:
+        r = vr("===1.0")
+        assert Version("1.0") in r
+        assert Version("1.0.0") not in r  # arbitrary string, not version, match
+
+    def test_arbitrary_combined_with_bounds(self) -> None:
+        # ``===1.0,>=2.0``: only candidate "1.0" cannot satisfy >=2.0.
+        assert vr("===1.0,>=2.0").is_empty
+
+    def test_prerelease_autodetect(self) -> None:
+        assert vr(">=1.0a1")._prereleases is True
+        assert vr(">=1.0")._prereleases is None
+
+    def test_explicit_prereleases(self) -> None:
+        r = vr(">=1.0", prereleases=False)
+        assert r._prereleases_configured is False
+
+
+class TestSetAlgebra:
+    def test_intersection(self) -> None:
+        assert vr(">=1.0") & vr("<2.0") == vr(">=1.0,<2.0")
+        assert vr(">=1.0").intersection(vr("<2.0")) == vr(">=1.0,<2.0")
+
+    def test_union(self) -> None:
+        u = VersionRange.singleton("1.0") | VersionRange.singleton("2.0")
+        assert Version("1.0") in u
+        assert Version("2.0") in u
+        assert Version("1.5") not in u
+        assert VersionRange.singleton("1.0").union(VersionRange.singleton("2.0")) == u
+
+    def test_complement(self) -> None:
+        r = vr(">=1.0")
+        assert Version("0.5") in r.complement()
+        assert Version("1.5") not in r.complement()
+        assert r.complement().complement() == r
+        assert (~r) == r.complement()
+
+    def test_complement_full_is_empty(self) -> None:
+        assert (~VersionRange.full(admit_arbitrary=False)).is_empty
+
+    def test_floor_singleton_obeys_structural_laws(self) -> None:
+        # The ``0.dev0`` floor singleton used to keep a non-canonical
+        # ``[0.dev0, ...)`` lower through set algebra, breaking these laws
+        # structurally (the version set was always correct).
+        s = VersionRange.singleton("0.dev0")
+        assert s.complement().complement() == s
+        assert s.union(s.complement()) == VersionRange.full(admit_arbitrary=False)
+        assert s.union(s) == s
+
+    def test_union_with_empty_preserves(self) -> None:
+        r = vr(">=1.0")
+        assert (r | VersionRange.empty()) == r
+
+    def test_intersection_with_full_preserves_arbitrary(self) -> None:
+        r = vr(">=1.0")
+        assert (r & VersionRange.full()) == r
+
+    def test_union_full_collapses(self) -> None:
+        # ``r | full()`` collapses to the canonical universal range.
+        r = VersionRange.singleton("1.0")
+        collapsed = r | VersionRange.full()
+        assert collapsed == VersionRange.full()
+
+    def test_union_full_keeps_explicit_policy(self) -> None:
+        r = VersionRange.singleton("1.0", prereleases=True)
+        collapsed = r | VersionRange.full(prereleases=True)
+        assert collapsed._prereleases_configured is True
+
+    def test_arbitrary_flag_distinguishes_full(self) -> None:
+        # nab contract: SpecifierSet("")-full differs from algebra-built full.
+        flagged_full = SpecifierSet("").to_range()
+        exact = VersionRange.singleton(Version("1.0"))
+        plain_full = exact | ~exact
+        assert plain_full != flagged_full
+        assert (flagged_full & ~plain_full).is_empty
+
+    def test_intersection_two_arbitrary(self) -> None:
+        assert (vr("===a") & vr("===b")).is_empty
+        assert "a" in (vr("===a") & vr("===a"))
+
+    def test_union_two_arbitrary(self) -> None:
+        u = vr("===a") | vr("===b")
+        assert "a" in u
+        assert "b" in u
+
+    def test_full_intersect_arbitrary_keeps_literal(self) -> None:
+        r = VersionRange.full() & vr("===garbage")
+        assert "garbage" in r
+        assert Version("1.0") not in r
+
+    def test_complement_of_arbitrary_range(self) -> None:
+        # nab complements root ranges built from ``===`` requirements.
+        r = vr("===custom")
+        assert not (~r).is_empty
+
+    def test_policy_mismatch_raises(self) -> None:
+        with pytest.raises(ValueError, match="different"):
+            vr(">=1.0", prereleases=True) & vr("<2.0", prereleases=False)
+
+    def test_operator_wrong_type(self) -> None:
+        assert vr(">=1.0").__and__("x") is NotImplemented
+        assert vr(">=1.0").__or__("x") is NotImplemented
+
+    def test_intersection_wrong_type_raises(self) -> None:
+        with pytest.raises(TypeError, match="expected VersionRange"):
+            vr(">=1.0").intersection("x")  # type: ignore[arg-type]
+
+
+class TestFilter:
+    def test_filter_bounds(self) -> None:
+        assert list(vr(">=1.0,<2.0").filter(["0.9", "1.5", "2.0"])) == ["1.5"]
+
+    def test_filter_prereleases_default_buffers(self) -> None:
+        assert list(vr(">=1.0").filter(["1.3", "1.5a1"])) == ["1.3"]
+        assert list(vr(">=1.0").filter(["1.5a1"])) == ["1.5a1"]
+
+    def test_filter_prereleases_true(self) -> None:
+        assert list(vr(">=1.0").filter(["1.3", "1.5a1"], prereleases=True)) == [
+            "1.3",
+            "1.5a1",
+        ]
+
+    def test_filter_prereleases_false(self) -> None:
+        assert list(vr(">=1.0").filter(["1.3", "1.5a1"], prereleases=False)) == ["1.3"]
+
+    def test_filter_autodetect_true(self) -> None:
+        assert list(vr(">=1.0a1").filter(["1.0a1", "1.5"])) == ["1.0a1", "1.5"]
+
+    def test_filter_key(self) -> None:
+        items = [{"v": "1.0"}, {"v": "2.0"}]
+        out = list(vr("<2.0").filter(items, key=lambda x: x["v"]))
+        assert out == [{"v": "1.0"}]
+
+    def test_filter_universal(self) -> None:
+        assert list(VersionRange.full().filter(["1.3", "1.5a1"])) == ["1.3"]
+        assert list(VersionRange.full().filter(["1.5a1"])) == ["1.5a1"]
+        assert list(VersionRange.full().filter(["1.3"], prereleases=True)) == ["1.3"]
+        assert list(VersionRange.full().filter(["1.5a1"], prereleases=False)) == []
+        assert list(VersionRange.full().filter(["junk", "1.0"])) == ["junk", "1.0"]
+        assert list(VersionRange.full().filter(["junk"])) == ["junk"]
+
+    def test_filter_admission_modes(self) -> None:
+        r = vr("===1.5a1")
+        assert list(r.filter(["1.5a1"], prereleases=True)) == ["1.5a1"]
+        assert list(r.filter(["1.5a1"], prereleases=False)) == []
+        assert list(r.filter(["1.5a1"])) == ["1.5a1"]
+
+    def test_filter_admission_with_final(self) -> None:
+        r = VersionRange.full() & vr("===garbage")
+        # admit literal then a non-matching final
+        assert list(r.filter(["garbage", "1.0"])) == ["garbage"]
+
+    def test_filter_admission_reject(self) -> None:
+        r = ~vr("===1.0")
+        assert list(r.filter(["1.0", "2.0"])) == ["2.0"]
+
+
+class TestContains:
+    def test_contains_version_and_str(self) -> None:
+        r = vr(">=1.0,<2.0")
+        assert r.contains("1.5")
+        assert r.contains(Version("1.5"))
+        assert not r.contains("2.0")
+
+    def test_contains_prereleases_false(self) -> None:
+        assert not vr(">=1.0").contains("1.5a1", prereleases=False)
+        assert vr(">=1.0").contains("1.5a1", prereleases=True)
+
+    def test_contains_installed(self) -> None:
+        r = vr(">=1.0", prereleases=False)
+        assert r.contains("1.5a1", installed=True)
+        assert r.contains(Version("1.5a1"), installed=True)
+        assert r.contains("1.5", installed=True)
+
+    def test_contains_arbitrary_literal(self) -> None:
+        r = vr("===wat")
+        assert r.contains("wat")
+        assert r.contains("WAT")  # case-insensitive
+        assert not r.contains("other")
+
+    def test_contains_literal_prerelease_excluded(self) -> None:
+        r = vr("===1.0a1", prereleases=False)
+        assert not r.contains("1.0a1")
+
+    def test_contains_literal_prerelease_autodetect(self) -> None:
+        r = vr("===1.0a1")
+        assert r.contains("1.0a1")
+
+    def test_contains_unparsable_non_full(self) -> None:
+        assert not vr(">=1.0").contains("garbage")
+
+    def test_contains_unparsable_full(self) -> None:
+        assert VersionRange.full().contains("garbage")
+
+    def test_contains_reject(self) -> None:
+        r = ~vr("===1.0")
+        assert not r.contains("1.0")
+        assert r.contains("2.0")
+
+    def test_contains_typeerror(self) -> None:
+        with pytest.raises(TypeError, match="expected str or Version"):
+            vr(">=1.0").contains(123)  # type: ignore[arg-type]
+
+
+class TestEquality:
+    def test_eq_and_hash(self) -> None:
+        a = vr(">=1.0,<2.0")
+        b = vr(">=1.0,<2.0")
+        assert a == b
+        assert hash(a) == hash(b)
+        assert len({a, b}) == 1
+
+    def test_eq_wrong_type(self) -> None:
+        assert vr(">=1.0").__eq__("x") is NotImplemented
+        assert vr(">=1.0") != "x"
+
+    def test_neq_bounds(self) -> None:
+        assert vr(">=1.0") != vr(">=2.0")
+
+    @pytest.mark.parametrize(
+        ("spec", "expected"),
+        [
+            (">=1.0,<2.0", "<VersionRange '[1.0, 2.0.dev0)'>"),
+            ("", "<VersionRange '(-inf, +inf)' arbitrary>"),
+            (">=2.0,<1.0", "<VersionRange '(empty)'>"),
+        ],
+    )
+    def test_repr(self, spec: str, expected: str) -> None:
+        assert repr(SpecifierSet(spec).to_range()) == expected
+
+    def test_repr_arbitrary_literal(self) -> None:
+        assert repr(vr("===wat")) == "<VersionRange '{wat}'>"
+
+    def test_repr_reject(self) -> None:
+        assert "\\" in repr(~vr("===1.0"))
+
+    def test_repr_pre(self) -> None:
+        assert "pre=False" in repr(vr(">=1.0", prereleases=False))
+
+    def test_repr_boundary_kinds(self) -> None:
+        assert "AFTER_LOCALS" in repr(vr("==1.0"))
+        assert "AFTER_POSTS" in repr(vr(">1.0"))
+
+
+# Boundary-sensitive specs and versions exercising the union / complement /
+# empty-check edge branches deterministically.
+_GRID_SPECS = [
+    "",
+    ">=1.0,<2.0",
+    "!=1.5",
+    "~=1.4.2",
+    "==1.*",
+    "==2.*",
+    "==2.0.*",
+    "==1.2.*",
+    "==1.2.3.*",
+    "!=1.0",
+    "!=1.5.*",
+    ">1.0.post1",
+    "<=1.0.post2",
+    "==1.0+local",
+    "!=1.0+local",
+    ">=1.0a1",
+    "<1.0rc1",
+    "==2!1.0",
+    ">=2!1.0",
+    "<2!1.0",
+    ">=1.0.dev0",
+    "!=1.0.dev0",
+    "==1.0.dev0",
+    "!=1.0a1",
+    "<1.0",
+    ">1.0",
+    "===wat",
+    "===1.0",
+]
+
+_GRID_VERSIONS = [
+    "0.dev0",
+    "0",
+    "1.0.dev0",
+    "1.0a1",
+    "1.0rc1",
+    "1.0",
+    "1.0+local",
+    "1.0.post0",
+    "1.0.post1",
+    "1.0.post2",
+    "1.0.1",
+    "1.2",
+    "1.2.3",
+    "1.4.2",
+    "1.4.9",
+    "1.5",
+    "1.5.1",
+    "1.6",
+    "2.0.dev0",
+    "2.0",
+    "2!1.0",
+    "3.0",
+]
+
+
+_GRID_RANGES = [SpecifierSet(s).to_range() for s in _GRID_SPECS]
+_GRID_VERSION_OBJS = [Version(v) for v in _GRID_VERSIONS]
+
+
+class TestAlgebraInvariants:
+    """Membership invariants over an exhaustive small grid.
+
+    Every range here is autodetect (configured policy None), so ``contains``
+    on a :class:`Version` reduces to pure bounds membership and the set-algebra
+    identities hold exactly.
+    """
+
+    def _same_versions(self, a: VersionRange, b: VersionRange) -> bool:
+        return all((v in a) == (v in b) for v in _GRID_VERSION_OBJS)
+
+    def test_complement_is_negation(self) -> None:
+        for r in _GRID_RANGES:
+            comp = ~r
+            for v in _GRID_VERSION_OBJS:
+                assert (v in comp) == (v not in r), (r, v)
+
+    def test_double_complement_matches(self) -> None:
+        # ``~~r`` matches the same versions as ``r``. It is structurally equal
+        # for canonical ranges; the degenerate ``>=0.dev0`` canonicalizes to
+        # the full range, which is version-equivalent.
+        for r in _GRID_RANGES:
+            assert self._same_versions(~~r, r), r
+
+    def test_intersection_is_and(self) -> None:
+        for a in _GRID_RANGES:
+            for b in _GRID_RANGES:
+                ab = a & b
+                for v in _GRID_VERSION_OBJS:
+                    assert (v in ab) == ((v in a) and (v in b)), (a, b, v)
+
+    def test_union_is_or(self) -> None:
+        for a in _GRID_RANGES:
+            for b in _GRID_RANGES:
+                ab = a | b
+                for v in _GRID_VERSION_OBJS:
+                    assert (v in ab) == ((v in a) or (v in b)), (a, b, v)
+
+
+class TestCoverageEdges:
+    """Targeted cases for branches the grid does not reach."""
+
+    def test_build_admit_and_reject(self) -> None:
+        r = (vr("===a") | vr("===b")) & vr("===a")
+        assert "a" in r
+        assert "b" not in r
+
+    def test_combine_literal_reject(self) -> None:
+        # Version literals so the reject set survives _build against full bounds.
+        r = (~vr("===1.0")) | vr("===2.0")
+        assert Version("2.0") in r
+        assert Version("1.5") in r
+        assert Version("1.0") not in r
+
+    def test_filter_literal_nonmatching_string(self) -> None:
+        assert list(vr("===wat").filter(["other"])) == []
+
+    def test_filter_admission_false_mixed(self) -> None:
+        r = ~vr("===1.0")
+        assert list(r.filter(["1.0", "2.0"], prereleases=False)) == ["2.0"]
+
+    def test_filter_admission_arbitrary_after_final(self) -> None:
+        r = vr(">=1.0") | vr("===wat")
+        assert list(r.filter(["1.5", "wat"])) == ["1.5", "wat"]
+
+    def test_filter_admission_prerelease_buffer(self) -> None:
+        r = vr(">=1.0") | vr("===wat")
+        assert list(r.filter(["1.5a1", "wat"])) == ["1.5a1", "wat"]
+
+    def test_contains_literal_nonprerelease_false_policy(self) -> None:
+        assert vr("===1.0", prereleases=False).contains("1.0")
+
+    def test_after_posts_boundary_total_order_consistent(self) -> None:
+        # ``AFTER_POSTS(1.0)`` and ``AFTER_POSTS(1.0.post1)`` mark the same point
+        # on the version line, so equality must agree with the ordering:
+        # exactly one of ``<``, ``==``, ``>`` holds for any two boundaries.
+        a = BoundaryVersion(Version("1.0"), BoundaryKind.AFTER_POSTS)
+        b = BoundaryVersion(Version("1.0.post1"), BoundaryKind.AFTER_POSTS)
+        assert a == b
+        assert hash(a) == hash(b)
+        assert (a < b) + (a == b) + (a > b) == 1
+
+        # Distinct points stay unequal and strictly ordered, and the two kinds
+        # at one version are different points.
+        c = BoundaryVersion(Version("1.1"), BoundaryKind.AFTER_POSTS)
+        assert a != c
+        assert (a < c) ^ (a > c)
+        assert a != BoundaryVersion(Version("1.0"), BoundaryKind.AFTER_LOCALS)
+
+    def test_arbitrary_after_locals_dev(self) -> None:
+        # !=1.0.dev0 produces an AFTER_LOCALS(1.0.dev0) boundary with a dev
+        # inner version, exercising the dev successor path under complement.
+        r = ~vr("!=1.0.dev0")
+        assert Version("1.0.dev0") in r
+        assert Version("1.1") not in r
+
+    def test_double_complement_min_boundary(self) -> None:
+        # >=0.dev0 is already canonicalized to the full range at construction,
+        # so ~~ round-trips it (full -> empty -> full).
+        r = vr(">=0.dev0")
+        comp2 = ~~r
+        for v in ["0.dev0", "0", "1.0", "2!1.0"]:
+            assert (Version(v) in comp2) == (Version(v) in r)
+
+    def test_sub_minimum_union(self) -> None:
+        # Union touching the 0.dev0 floor exercises the sub-minimum empty check.
+        r = vr("==0.dev0") | vr(">=1.0")
+        assert Version("0.dev0") in r
+        assert Version("1.0") in r
+        assert Version("0.5") not in r
+
+    def test_ge_floor_is_canonical_full(self) -> None:
+        # >=0.dev0 admits every version, so its bounds canonicalize to the full
+        # range (its complement is empty). It keeps its autodetected pre-release
+        # policy, so it is not equal to the policy-free full().
+        r = vr(">=0.dev0")
+        assert r._bounds == VersionRange.full()._bounds
+        assert (~r).is_empty
+
+    def test_ne_floor_drops_empty_leading_interval(self) -> None:
+        # !=0.dev0's lower (-inf, 0.dev0) interval is empty (sub-floor) and is
+        # dropped, leaving only the upper half.
+        r = vr("!=0.dev0")
+        assert Version("0.dev0") not in r
+        assert Version("1.0") in r
+        assert Version("0") in r
+
+    def test_complement_singleton_floor(self) -> None:
+        # ~singleton(0.dev0): the empty (-inf, 0.dev0) leading gap is dropped.
+        r = ~VersionRange.singleton("0.dev0")
+        assert not r.is_empty
+        assert Version("0.dev0") not in r
+        assert Version("1.0") in r
+
+    def test_eq_ranges_filter_identically(self) -> None:
+        # Two ranges with identical bounds but different resolved pre-release
+        # policy must NOT compare equal, so equal ranges always filter the same.
+        autodetect_true = vr(">=1.0a1") & vr(">=2.0")  # resolved True, [2.0, inf)
+        autodetect_none = vr(">=2.0")  # resolved None, [2.0, inf)
+        assert autodetect_true._bounds == autodetect_none._bounds
+        assert autodetect_true != autodetect_none
+        assert hash(autodetect_true) != hash(autodetect_none)
+        assert list(autodetect_true.filter(["2.0", "2.5a1"])) != list(
+            autodetect_none.filter(["2.0", "2.5a1"])
+        )
+
+    def test_eq_full_resolved_mismatch(self) -> None:
+        # The floor shape that exposed the substitutability bug.
+        b = ~~vr(">=0.dev0")
+        c = VersionRange.full(admit_arbitrary=False)
+        assert b._bounds == c._bounds
+        assert b._admit_arbitrary == c._admit_arbitrary
+        assert b != c
+        assert list(b.filter(["0.dev0", "1.0"])) != list(c.filter(["0.dev0", "1.0"]))
+
+    def test_filter_universal_false_yields_final(self) -> None:
+        assert list(
+            VersionRange.full().filter(["1.0", "1.5a1"], prereleases=False)
+        ) == ["1.0"]
+
+    def test_filter_universal_unparsable_after_final(self) -> None:
+        assert list(VersionRange.full().filter(["1.0", "junk"])) == ["1.0", "junk"]
+
+    def test_complement_zero_singleton(self) -> None:
+        r = ~vr("==0")
+        assert Version("0") not in r
+        assert Version("1.0") in r
+
+    def test_complement_post_boundary(self) -> None:
+        # AFTER_LOCALS boundary adjacent to its post successor.
+        r = ~vr("==1.0") | vr("==1.0.post0")
+        assert Version("1.0") not in r
+        assert Version("1.0.post0") in r
+        assert Version("2.0") in r
+
+    def test_union_after_locals_successor_merge(self) -> None:
+        # ==1.0 upper (AFTER_LOCALS) meets 1.0.post0.dev0: the empty gap merges.
+        r = vr("==1.0") | vr(">=1.0.post0.dev0")
+        assert Version("1.0") in r
+        assert Version("1.0.post0") in r
+        assert Version("0.9") not in r
+
+    def test_filter_universal_two_finals(self) -> None:
+        assert list(VersionRange.full().filter(["1.0", "2.0"])) == ["1.0", "2.0"]
+
+    def test_filter_admission_true_skips_rejected(self) -> None:
+        r = ~vr("===1.0")
+        assert list(r.filter(["1.0", "2.0"], prereleases=True)) == ["2.0"]
+
+    def test_filter_admission_two_finals(self) -> None:
+        r = vr(">=1.0") | vr("===wat")
+        assert list(r.filter(["1.5", "2.5"])) == ["1.5", "2.5"]
+
+    def test_filter_admission_prerelease_after_final(self) -> None:
+        r = vr(">=1.0") | vr("===wat")
+        assert list(r.filter(["1.5", "2.5a1"])) == ["1.5"]

--- a/tests/test_ranges.py
+++ b/tests/test_ranges.py
@@ -478,6 +478,173 @@ class TestAlgebraInvariants:
                     assert (v in ab) == ((v in a) or (v in b)), (a, b, v)
 
 
+class TestSyntheticEmptyGaps:
+    """Intervals that are ordered yet hold no real version.
+
+    ``>V`` excludes V's post-releases (AFTER_POSTS) and ``<=V`` includes V's
+    locals (AFTER_LOCALS), so a bound can sit just below the next real version.
+    When the opposite bound lands on that successor, the interval is ordered but
+    empty: ``>1.0a1`` admits nothing below ``1.0a2.dev0`` because every
+    ``1.0a1.postN`` is excluded. The empty interval must be detected so that
+    ``is_empty``, equality, and the set algebra stay correct.
+    """
+
+    @pytest.mark.parametrize(
+        "spec",
+        [
+            ">1.0a1,<1.0a2.dev0",  # AFTER_POSTS pre-release, next pre-release
+            ">1.0a0,<1.0a1.dev0",
+            ">1.0b0,<1.0b1.dev0",
+            ">1.0rc1,<1.0rc2.dev0",
+            ">1!1.0a1,<1!1.0a2.dev0",  # epoch carried through
+            ">1.0,<1.0.post0.dev0",  # AFTER_POSTS final, below its post0.dev0
+        ],
+    )
+    def test_is_empty(self, spec: str) -> None:
+        assert SpecifierSet(spec).to_range().is_empty
+
+    @pytest.mark.parametrize(
+        "spec",
+        [
+            ">1.0a2,<1.0b0.dev0",  # 1.0a3.dev0 sits between
+            ">1.5,<2",  # 1.5.1.dev0 sits between
+            ">1.0,<1.0.0.1",  # 1.0.0.0.1.dev0 sits between
+            ">1.0a1,<1.0a2",  # 1.0a2.dev0 sits between
+        ],
+    )
+    def test_not_empty(self, spec: str) -> None:
+        assert not SpecifierSet(spec).to_range().is_empty
+
+    def test_equal_substitutability(self) -> None:
+        # Equality is substitutability: two synthetic-empty ranges match no
+        # version, so they compare equal (both reduce to empty bounds).
+        a = vr(">1.0a1,<1.0a2.dev0")
+        b = vr(">1.0b0,<1.0b1.dev0")
+        assert a == b
+        assert hash(a) == hash(b)
+        assert a._bounds == ()
+
+    def test_subset_of_anything(self) -> None:
+        # The PubGrub subset test ``(a & ~b).is_empty``: the empty set is a
+        # subset of every range.
+        empty = vr(">1.0a1,<1.0a2.dev0")
+        assert (empty & ~vr(">=5.0")).is_empty
+
+    @pytest.mark.parametrize(
+        ("spec", "excluded"),
+        [
+            ("!=1.0,<1.0.post0.dev0", "1.0"),  # AFTER_LOCALS, post0 successor
+            ("!=1.0.post3,<1.0.post4.dev0", "1.0.post3"),  # post(N+1) successor
+            ("!=1.0.dev5,<1.0.dev6", "1.0.dev5"),  # dev(N+1) successor
+        ],
+    )
+    def test_intersection_drops_embedded_empty(self, spec: str, excluded: str) -> None:
+        # The empty AFTER_LOCALS interval must not survive in the bounds.
+        r = SpecifierSet(spec).to_range()
+        assert len(r._bounds) == 1
+        assert not r.is_empty
+        assert Version(excluded) not in r
+
+    def test_complement_of_covering_union_is_empty(self) -> None:
+        # ``~(>1.0a1)`` (everything up to and including 1.0a1's posts) and
+        # ``>=1.0a2.dev0`` leave only the empty gap uncovered, so the union is
+        # everything and its complement is empty.
+        covering = ~vr(">1.0a1") | vr(">=1.0a2.dev0")
+        assert covering._bounds == VersionRange.full()._bounds
+        assert covering.complement().is_empty
+
+    def test_double_complement_of_empty(self) -> None:
+        r = vr(">1.0a1,<1.0a2.dev0")
+        assert (~~r).is_empty
+
+
+class TestBoundaryCanonicalization:
+    """Different specifiers for the same set canonicalize to one form.
+
+    ``>1.0a1`` excludes ``1.0a1``'s post-releases, so its smallest member is
+    ``1.0a2.dev0``, exactly what ``>=1.0a2.dev0`` starts at. The two are the
+    same set, so they fold to one boundary form and compare equal. The boundary
+    (non-``.dev0``) form is canonical, so ``>=1.0a2.dev0`` adopts ``>1.0a1``'s.
+    """
+
+    @pytest.mark.parametrize(
+        ("dev_form", "boundary_form"),
+        [
+            # Both operands are pre-releases, so the pair shares one pre-release
+            # policy and equality reduces to the (identical) version set.
+            (">=1.0a2.dev0", ">1.0a1"),  # AFTER_POSTS pre-release
+            (">=1!1.0a2.dev0", ">1!1.0a1"),  # epoch carried through
+            (">=1.0a1.post1.dev0", ">1.0a1.post0"),  # AFTER_LOCALS post(N+1)
+            (">=1.0a1.dev6", ">1.0a1.dev5"),  # AFTER_LOCALS dev(N+1)
+            (">=1.0.dev6", ">1.0.dev5"),  # AFTER_LOCALS dev on a final base
+            (">=1.0a1.post1.dev6", ">1.0a1.post1.dev5"),  # AFTER_LOCALS post+dev
+            (">=1.0.post0.dev1", ">1.0.post0.dev0"),  # post+dev on a final base
+        ],
+    )
+    def test_equal_and_hash(self, dev_form: str, boundary_form: str) -> None:
+        a, b = vr(dev_form), vr(boundary_form)
+        assert a == b
+        assert hash(a) == hash(b)
+        assert a._bounds == b._bounds
+        assert len({a, b}) == 1
+
+    def test_upper_bound_folds_to_boundary(self) -> None:
+        # The exclusive-upper mirror: ``<1.0a2.dev0`` ends at AFTER_POSTS(1.0a1).
+        assert "1.0a1[AFTER_POSTS]" in repr(vr("<1.0a2.dev0"))
+
+    def test_keeps_non_dev_anchor(self) -> None:
+        # The boundary form is canonical, so the repr keeps the non-dev anchor.
+        assert "1.0a1[AFTER_POSTS]" in repr(vr(">=1.0a2.dev0"))
+
+    def test_prerelease_policy_keeps_them_distinct(self) -> None:
+        # Same set, but ``<1.0.post0.dev0`` admits pre-releases by default and
+        # ``<=1.0`` does not, so they are not substitutable and stay unequal.
+        assert vr("<1.0.post0.dev0") != vr("<=1.0")
+
+    def test_plain_version_is_not_folded(self) -> None:
+        # ``1.0a2`` is not a boundary successor, so ``>=1.0a2`` stays plain.
+        assert "1.0a2" in repr(vr(">=1.0a2"))
+        assert "AFTER" not in repr(vr(">=1.0a2"))
+
+
+class TestEmptyMatchesUnsatisfiable:
+    """``is_empty`` agrees with ``SpecifierSet.is_unsatisfiable``.
+
+    Both fold in the pre-release policy: a range whose only members are
+    pre-releases is empty when the policy excludes them.
+    """
+
+    @pytest.mark.parametrize(
+        "spec",
+        [
+            "==1.0a1",
+            "===1.0a1",
+            "==1.0a1,==1.0a1",
+            "==0.dev0",  # floor: only member 0.dev0 is a pre-release
+            "<0.dev1",  # floor: nothing below 0.dev1 but the pre-release 0.dev0
+        ],
+    )
+    def test_prerelease_only_empty_when_policy_excludes(self, spec: str) -> None:
+        assert vr(spec, prereleases=False).is_empty
+        assert not vr(spec, prereleases=True).is_empty
+        assert SpecifierSet(spec, prereleases=False).is_unsatisfiable()
+
+    def test_non_prerelease_literal_survives(self) -> None:
+        # ``===1.0`` admits a final release, so the policy does not empty it.
+        assert not vr("===1.0", prereleases=False).is_empty
+
+    @pytest.mark.parametrize(
+        "spec", [">=1.0", ">=1.0a1.post0,<=1.0", ">=1.0.post0.dev0,<=1.0.post0"]
+    )
+    def test_non_prerelease_bounds_survive(self, spec: str) -> None:
+        # A pre-release-with-post lower still admits the final/post release.
+        assert not vr(spec, prereleases=False).is_empty
+
+    def test_arbitrary_admission_is_not_empty(self) -> None:
+        # The universal range admits any string regardless of policy.
+        assert not vr("", prereleases=False).is_empty
+
+
 class TestCoverageEdges:
     """Targeted cases for branches the grid does not reach."""
 

--- a/tests/test_specifiers.py
+++ b/tests/test_specifiers.py
@@ -14,7 +14,7 @@ import typing
 import pytest
 
 from packaging.specifiers import InvalidSpecifier, Specifier, SpecifierSet
-from packaging.version import Version, parse
+from packaging.version import InvalidVersion, Version, parse
 
 from .test_version import VERSIONS
 
@@ -536,6 +536,8 @@ class TestSpecifier:
     )
     def test_specifiers(self, version: str, spec_str: str, expected: bool) -> None:
         spec = Specifier(spec_str, prereleases=True)
+        # The range conversion must answer membership identically.
+        version_range = SpecifierSet(spec_str, prereleases=True).to_range()
 
         if expected:
             # Test that the plain string form works
@@ -545,6 +547,9 @@ class TestSpecifier:
             # Test that the version instance form works
             assert Version(version) in spec
             assert spec.contains(Version(version))
+
+            assert version in version_range
+            assert Version(version) in version_range
         else:
             # Test that the plain string form works
             assert version not in spec
@@ -553,6 +558,9 @@ class TestSpecifier:
             # Test that the version instance form works
             assert Version(version) not in spec
             assert not spec.contains(Version(version))
+
+            assert version not in version_range
+            assert Version(version) not in version_range
 
     @pytest.mark.parametrize(
         ("spec_str", "version", "expected"),
@@ -574,6 +582,9 @@ class TestSpecifier:
     def test_invalid_version(self, spec_str: str, version: str, expected: bool) -> None:
         spec = Specifier(spec_str, prereleases=True)
         assert spec.contains(version) == expected
+        # The ``===`` carve-out range answers via the literal match.
+        version_range = SpecifierSet(spec_str, prereleases=True).to_range()
+        assert (version in version_range) == expected
 
     @pytest.mark.parametrize(
         (
@@ -951,15 +962,23 @@ class TestSpecifier:
     ) -> None:
         if specifier_prereleases is None:
             spec = Specifier(specifier)
+            version_range = SpecifierSet(specifier).to_range()
         else:
             spec = Specifier(specifier, prereleases=specifier_prereleases)
+            version_range = SpecifierSet(
+                specifier, prereleases=specifier_prereleases
+            ).to_range()
 
         if prereleases is None:
             result = list(spec.filter(input))
+            range_result = list(version_range.filter(input))
         else:
             result = list(spec.filter(input, prereleases=prereleases))
+            range_result = list(version_range.filter(input, prereleases=prereleases))
 
         assert result == expected
+        # The range conversion must filter identically.
+        assert range_result == expected
 
     @pytest.mark.parametrize(
         ("specifier", "input", "expected"),
@@ -1603,13 +1622,18 @@ class TestSpecifierSet:
             spec = SpecifierSet(specifier)
         else:
             spec = SpecifierSet(specifier, prereleases=specifier_prereleases)
+        version_range = spec.to_range()
 
         if prereleases is None:
             result = list(spec.filter(input))
+            range_result = list(version_range.filter(input))
         else:
             result = list(spec.filter(input, prereleases=prereleases))
+            range_result = list(version_range.filter(input, prereleases=prereleases))
 
         assert result == expected
+        # The range conversion must filter identically.
+        assert range_result == expected
 
     @pytest.mark.parametrize(
         ("prereleases", "expected_indexes"),
@@ -2956,15 +2980,24 @@ class TestIsUnsatisfiable:
 
     def test_range_bounds_repr(self) -> None:
         [(lower, upper)] = Specifier(">=1.0")._to_ranges()
-        assert repr(lower) == "<_LowerBound [<Version('1.0')>>"
-        assert repr(upper) == "<_UpperBound None)>"
+        assert repr(lower) == "<LowerBound [<Version('1.0')>>"
+        assert repr(upper) == "<UpperBound None)>"
 
         [(lower2, upper2)] = Specifier(">1.0")._to_ranges()
         assert (
             repr(lower2)
-            == "<_LowerBound (_BoundaryVersion(<Version('1.0')>, AFTER_POSTS)>"
+            == "<LowerBound (BoundaryVersion(<Version('1.0')>, AFTER_POSTS)>"
         )
-        assert repr(upper2) == "<_UpperBound None)>"
+        assert repr(upper2) == "<UpperBound None)>"
+
+    def test_range_bounds_reject_foreign_comparison(self) -> None:
+        # The bound classes only compare to their own kind; anything else
+        # returns NotImplemented so Python falls back to identity.
+        [(lower, upper)] = Specifier(">=1.0")._to_ranges()
+        assert lower.__eq__(object()) is NotImplemented
+        assert lower.__lt__(object()) is NotImplemented  # type: ignore[operator]
+        assert upper.__eq__(object()) is NotImplemented
+        assert upper.__lt__(object()) is NotImplemented  # type: ignore[operator]
 
 
 @pytest.mark.parametrize(
@@ -3431,3 +3464,117 @@ def test_specifierset_contains_reads_cached_bounds() -> None:
 
     ss._ranges = ()
     assert ss.contains("2.0") is False
+
+
+# Every shape ``SpecifierSet`` can take: each operator, wildcards, ``===``,
+# epochs, pre/post/dev/local boundaries, multi-spec sets, and unsatisfiable
+# sets. Used to prove ``to_range()`` preserves membership and filtering.
+_EQUIV_SPECS = [
+    "",
+    ">=1.0",
+    ">1.0",
+    "<=1.0",
+    "<1.0",
+    "==1.0",
+    "!=1.0",
+    "~=1.4.2",
+    "==1.2.*",
+    "!=1.2.*",
+    "==1.0+local",
+    "!=1.0+local",
+    ">=1.0a1",
+    "<1.0rc1",
+    ">2.0.post1",
+    "<=1.0.post2",
+    ">=1.0.dev1",
+    "==2!1.0",
+    ">=2!1.0,<2!2.0",
+    "===foobar",
+    "===1.0",
+    ">=1.0,<2.0",
+    ">=1.0,<2.0,!=1.5",
+    "!=1.4,!=1.6",
+    ">=1.0,<2.0,!=1.2.*",
+    "==1.0,!=1.0",
+    ">=2.0,<1.0",
+    "<0",
+]
+
+# Versions and arbitrary strings that stress every boundary the engine tracks.
+_EQUIV_ITEMS = [
+    "0.dev0",
+    "1.0.dev1",
+    "1.0a1",
+    "1.0rc1",
+    "1.0",
+    "1.0+local",
+    "1.0.post1",
+    "1.0.post2",
+    "1.0.post3",
+    "1.0.1",
+    "1.2",
+    "1.2.3",
+    "1.4.2",
+    "1.4.9",
+    "1.5",
+    "1.6",
+    "2.0",
+    "2.0.dev1",
+    "2!1.0",
+    "1.0.0",
+    "foobar",
+    "garbage",
+]
+
+
+def _parse_or_none(value: str) -> Version | None:
+    try:
+        return Version(value)
+    except InvalidVersion:
+        return None
+
+
+_EQUIV_VERSION_OBJS = [v for v in map(_parse_or_none, _EQUIV_ITEMS) if v is not None]
+
+
+class TestSpecifierSetToRangeEquivalence:
+    """``SpecifierSet.to_range()`` answers ``contains`` and ``filter``
+    identically to the originating :class:`SpecifierSet` for every shape,
+    item, and pre-release setting."""
+
+    @pytest.mark.parametrize("spec_str", _EQUIV_SPECS)
+    @pytest.mark.parametrize("configured", [None, True, False])
+    def test_contains_equivalent(self, spec_str: str, configured: bool | None) -> None:
+        spec_set = SpecifierSet(spec_str, prereleases=configured)
+        version_range = spec_set.to_range()
+        for item in _EQUIV_ITEMS:
+            assert (item in spec_set) == (item in version_range), (spec_str, item)
+            for prereleases in (None, True, False):
+                for installed in (None, True, False):
+                    assert spec_set.contains(
+                        item, prereleases=prereleases, installed=installed
+                    ) == version_range.contains(
+                        item, prereleases=prereleases, installed=installed
+                    ), (spec_str, item, prereleases, installed)
+
+    @pytest.mark.parametrize("spec_str", _EQUIV_SPECS)
+    @pytest.mark.parametrize("configured", [None, True, False])
+    def test_filter_equivalent(self, spec_str: str, configured: bool | None) -> None:
+        spec_set = SpecifierSet(spec_str, prereleases=configured)
+        version_range = spec_set.to_range()
+        for prereleases in (None, True, False):
+            assert list(spec_set.filter(_EQUIV_ITEMS, prereleases=prereleases)) == list(
+                version_range.filter(_EQUIV_ITEMS, prereleases=prereleases)
+            ), (spec_str, prereleases)
+
+    @pytest.mark.parametrize("spec_str", _EQUIV_SPECS)
+    def test_contains_equivalent_with_version_objects(self, spec_str: str) -> None:
+        # The same equivalence holds when the item is a ``Version`` instance.
+        spec_set = SpecifierSet(spec_str)
+        version_range = spec_set.to_range()
+        for version in _EQUIV_VERSION_OBJS:
+            assert (version in spec_set) == (version in version_range), (
+                spec_str,
+                version,
+            )
+            assert spec_set.contains(version) == version_range.contains(version)

--- a/tests/test_specifiers.py
+++ b/tests/test_specifiers.py
@@ -2548,6 +2548,15 @@ class TestIsUnsatisfiable:
     """
 
     UNSATISFIABLE: typing.ClassVar[list[str]] = [
+        # Synthetic gaps: >V excludes V's post-releases, so the least version
+        # >1.0a1 admits is 1.0a2.dev0, which <1.0a2.dev0 excludes (#1267).
+        ">1.0a1,<1.0a2.dev0",
+        ">1!1.0a1,<1!1.0a2.dev0",
+        ">1.0b0,<1.0b1.dev0",
+        ">1.0,<1.0.post0.dev0",
+        # Floor: an exclusive upper at or below 0.dev0 strands an empty interval
+        "!=0.dev0,<0.dev1",
+        "!=0.dev0,<=0.dev0",
         # Crossed bounds
         ">=2.0,<1.0",
         ">=2.0,<2.0",
@@ -2831,6 +2840,10 @@ class TestIsUnsatisfiable:
         # === with parseable pre-release string
         "===1.0a1",
         "===1.0.dev0",
+        # Floor: only members are pre-releases (#1267)
+        "<0.dev1",
+        "<=0.dev0",
+        "<0a1",
         # Already unsatisfiable regardless of prereleases
         ">=2.0,<1.0",
     ]
@@ -2858,6 +2871,9 @@ class TestIsUnsatisfiable:
         # Inclusive upper at non-pre-release boundary
         ">=1.0rc1,<=1.0",
         ">=1.0.dev0,<=1.0",
+        # Pre-release-with-post lower: the final release still satisfies (#1267)
+        ">=1.0a1.post0,<=1.0",
+        ">=1.0.post0.dev0,<=1.0.post0",
     ]
 
     @pytest.mark.parametrize("spec_str", UNSATISFIABLE_NO_PRE)


### PR DESCRIPTION
This supersedes #1182 with a smaller, more focused implementation.

`Specifier` and `SpecifierSet` already run their PEP 440 matching through a shared internal range engine (`_ranges.py`). A specifier becomes a list of bound intervals, and membership, filtering, and intersection all run on those intervals. That is the state on main today.

This PR exposes that capability as a public set-algebra object. `VersionRange` is a second consumer of the same engine: it reuses the engine's bound construction, intersection, membership test, filtering, and pre-release handling, and adds the two operations only it needs, union and complement, plus a canonical interval form. `SpecifierSet` gets one new method, `to_range()`, to hand its bounds over. Nothing else on `Specifier` or `SpecifierSet` changes.

#1182 went the other direction: make `VersionRange` the core and turn `Specifier` / `SpecifierSet` into wrappers around it. That was a larger change to the existing types; sharing the engine keeps this one additive.

## New public APIs

A new module `packaging.ranges` with a single public class, `VersionRange`.

A `VersionRange` is the set of `Version` values matched by a `SpecifierSet`, held as a union of disjoint intervals on the PEP 440 ordering, and closed under intersection, union, and complement. Set operations answer overlap, subset, and complement questions directly, without parsing strings or iterating versions.

`VersionRange` has no public constructor (`VersionRange()` raises `TypeError`); it is not a PEP 440 object, just a predicate on `Version`. Build one from a specifier set, or with a factory:

```python
SpecifierSet(">=1.0,<2.0").to_range()   # the usual entry point
VersionRange.full()                     # every version
VersionRange.empty()                    # no version
VersionRange.singleton("1.5")           # the strict set {1.5}
```

Set algebra. Each returns a new range; operands are not mutated.

```python
a.intersection(b)   # a & b
a.union(b)          # a | b
a.complement()      # ~a
```

Membership and filtering, mirroring `SpecifierSet`, including PEP 440 pre-release handling:

```python
"1.5" in r
r.contains("1.5", prereleases=None, installed=None)
r.filter(["0.9", "1.5", "2.0"])
```

Plus `is_empty`, and the standard `==`, `hash`, and `repr`.

The only addition to an existing type is `SpecifierSet.to_range()`. There is no `Specifier.to_range()`; build a `SpecifierSet` first if you need one.

## Design choices

A new class, not new methods on `SpecifierSet`. `SpecifierSet` is not closed under union or complement. PEP 440 has no syntax for the strict singleton `{V}` (`==V` also matches `V+local`), nor for the inclusive upper bound that complementing `>V` produces. Adding set algebra to `SpecifierSet` would return values no specifier string can represent.

`singleton` is strict. `singleton("1.5")` is exactly `{1.5}` and does not match `1.5+local`, unlike `==1.5`. A range and a single `Version` are different things, so the factory is named rather than implicit.

Pre-release policy travels with the range. The configured and resolved pre-release policy of the originating `SpecifierSet` carries onto the range and through the algebra, so `contains` and `filter` match the originating set exactly. Combining two ranges requires the same configured policy.

`===` survives the algebra. A range built from a `===` specifier keeps the literal-string admission, so it still supports membership and set operations. `===` matches a string verbatim rather than a version set, so its complement is one-way.

Equality is substitutability. Two ranges are equal only when they behave the same under `contains` and `filter`, so `==` covers the pre-release policy and `===` admission, not just the version set. Ranges are stored in one canonical interval form, so `==` and `hash` are well-defined. Because `==` is stricter than matching the same versions, set relations use the algebra: subset is `(a & ~b).is_empty`, disjoint is `(a & b).is_empty`. There is a worked example in the docs. I would be open to removing `==` equality in this initial version if it's considered too confusing.

## Where I use it in nab

nab is a fresh resolver I am building on the PubGrub algorithm. PubGrub represents every fact as a term: a package plus a set of allowed versions. The solver intersects, unions, complements, and tests those sets on every step, so it needs the set algebra to be public.

nab stays version-type agnostic behind a small protocol, and `packaging.ranges.VersionRange` is the PEP 440 implementation that satisfies it:

```python
# nab-resolver: types.py
class RangeProtocol(Protocol[VersionType_contra]):
    @classmethod
    def empty(cls) -> Self: ...
    @classmethod
    def full(cls) -> Self: ...
    @classmethod
    def singleton(cls, version: VersionType_contra) -> Self: ...
    @property
    def is_empty(self) -> bool: ...
    def __contains__(self, version: VersionType_contra, /) -> bool: ...
    def __and__(self, other: object) -> Self: ...   # intersection
    def __or__(self, other: object) -> Self: ...    # union
    def __invert__(self) -> Self: ...               # complement
```

The bridge from PEP 508 is `SpecifierSet.to_range()`. Each requirement's specifier becomes a range and folds into the package's accumulated constraint by intersection, with `full()` as the identity:

```python
# nab-python: resolve.py
previous = ranges.get(name, VersionRange.full())
ranges[name] = previous & req.specifier.to_range()
```

A term and its operations map straight onto the algebra:

```python
# nab-resolver: types.py (Term)
def satisfies(self, assignment):
    if self._positive:                              # assignment subset of constraint
        return (assignment & ~self.constraint).is_empty
    return (assignment & self.constraint).is_empty  # assignment disjoint from constraint

def intersect(self, other):
    # not(A) and not(B) == not(A | B)
    # positive and not(negative) == positive & ~negative
    ...
```

The subset and disjoint tests use the algebra, not `==`. As noted under Design choices, `==` also compares the pre-release policy and `===` admission, which PubGrub does not care about, so two ranges with the same versions can compare unequal. The algebra keeps the relations correct under those flags, which is what the solver's progress argument needs.

nab selects candidates with `filter()`, which does the PEP 440 selection including pre-releases, so nab does not reimplement that or carry its own pre-release flags.
