### PR TITLE
fix: validate package index field is a valid URL

### DIFF
--- a/src/packaging/pylock.py
+++ b/src/packaging/pylock.py
@@ -101,6 +101,16 @@ def _toml_dict_factory(data: list[tuple[str, Any]]) -> dict[str, Any]:
     }
 
 
+def _get_and_validate(
+    d: Mapping[str, Any], typ: type[_T], key: str,
+    validate: Callable[[_T], _T],
+) -> _T | None:
+    value = _get(d, typ, key)
+    if value is not None:
+        return validate(value)
+    return value
+
+
 def _get(d: Mapping[str, Any], expected_type: type[_T], key: str) -> _T | None:
     """Get a value from the dictionary and verify it's the expected type."""
     if (value := d.get(key)) is None:
@@ -230,6 +240,14 @@ def _get_required_sequence_of_objects(
     if (result := _get_sequence_of_objects(d, target_item_type, key)) is None:
         raise _PylockRequiredKeyError(key)
     return result
+
+
+def _validate_url(value: str) -> str:
+    from urllib.parse import urlparse
+    parsed = urlparse(str(value))
+    if not parsed.scheme or not parsed.netloc:
+        raise PylockValidationError(f"{value!r} is not a valid URL")
+    return value
 
 
 def _validate_normalized_name(name: str) -> NormalizedName:
@@ -584,7 +602,7 @@ class Package:
             vcs=_get_object(d, PackageVcs, "vcs"),
             directory=_get_object(d, PackageDirectory, "directory"),
             archive=_get_object(d, PackageArchive, "archive"),
-            index=_get(d, str, "index"),
+            index=_get_and_validate(d, str, "index", _validate_url),
             sdist=_get_object(d, PackageSdist, "sdist"),
             wheels=_get_sequence_of_objects(d, PackageWheel, "wheels"),
             attestation_identities=_get_sequence(d, Mapping, "attestation-identities"),  # type: ignore[type-abstract]

--- a/src/packaging/pylock.py
+++ b/src/packaging/pylock.py
@@ -101,16 +101,6 @@ def _toml_dict_factory(data: list[tuple[str, Any]]) -> dict[str, Any]:
     }
 
 
-def _get_and_validate(
-    d: Mapping[str, Any], typ: type[_T], key: str,
-    validate: Callable[[_T], _T],
-) -> _T | None:
-    value = _get(d, typ, key)
-    if value is not None:
-        return validate(value)
-    return value
-
-
 def _get(d: Mapping[str, Any], expected_type: type[_T], key: str) -> _T | None:
     """Get a value from the dictionary and verify it's the expected type."""
     if (value := d.get(key)) is None:
@@ -243,7 +233,6 @@ def _get_required_sequence_of_objects(
 
 
 def _validate_url(value: str) -> str:
-    from urllib.parse import urlparse
     parsed = urlparse(str(value))
     if not parsed.scheme or not parsed.netloc:
         raise PylockValidationError(f"{value!r} is not a valid URL")
@@ -602,7 +591,7 @@ class Package:
             vcs=_get_object(d, PackageVcs, "vcs"),
             directory=_get_object(d, PackageDirectory, "directory"),
             archive=_get_object(d, PackageArchive, "archive"),
-            index=_get_and_validate(d, str, "index", _validate_url),
+            index=_validate_url(_get(d, str, "index")) if _get(d, str, "index") is not None else None,
             sdist=_get_object(d, PackageSdist, "sdist"),
             wheels=_get_sequence_of_objects(d, PackageWheel, "wheels"),
             attestation_identities=_get_sequence(d, Mapping, "attestation-identities"),  # type: ignore[type-abstract]

--- a/src/packaging/pylock.py
+++ b/src/packaging/pylock.py
@@ -232,7 +232,9 @@ def _get_required_sequence_of_objects(
     return result
 
 
-def _validate_url(value: str) -> str:
+def _validate_url(value: str | None) -> str | None:
+    if value is None:
+        return None
     parsed = urlparse(str(value))
     if not parsed.scheme or not parsed.netloc:
         raise PylockValidationError(f"{value!r} is not a valid URL")
@@ -591,7 +593,7 @@ class Package:
             vcs=_get_object(d, PackageVcs, "vcs"),
             directory=_get_object(d, PackageDirectory, "directory"),
             archive=_get_object(d, PackageArchive, "archive"),
-            index=_validate_url(_get(d, str, "index")) if _get(d, str, "index") is not None else None,
+            index=_validate_url(_get(d, str, "index")),
             sdist=_get_object(d, PackageSdist, "sdist"),
             wheels=_get_sequence_of_objects(d, PackageWheel, "wheels"),
             attestation_identities=_get_sequence(d, Mapping, "attestation-identities"),  # type: ignore[type-abstract]

--- a/tests/test_pylock.py
+++ b/tests/test_pylock.py
@@ -868,7 +868,6 @@ def test_validate_attestation_identity_invalid_kind() -> None:
     )
 
 
-
 def test_pylock_invalid_index_url() -> None:
     """Package index must be a valid URL."""
     data = {
@@ -886,10 +885,14 @@ def test_pylock_valid_index_url() -> None:
         "name": "test-package",
         "version": "1.0.0",
         "index": "https://pypi.org/simple",
-        "wheels": [{"name": "test_package-1.0.0-py3-none-any.whl",
-                     "url": "https://example.com/wheel.whl",
-                     "size": 100,
-                     "hashes": {"sha256": "x" * 64}}],
+        "wheels": [
+            {
+                "name": "test_package-1.0.0-py3-none-any.whl",
+                "url": "https://example.com/wheel.whl",
+                "size": 100,
+                "hashes": {"sha256": "x" * 64},
+            }
+        ],
     }
     pkg = Package._from_dict(data)
     assert pkg.index == "https://pypi.org/simple"
@@ -900,10 +903,14 @@ def test_pylock_none_index_url() -> None:
     data = {
         "name": "test-package",
         "version": "1.0.0",
-        "wheels": [{"name": "test_package-1.0.0-py3-none-any.whl",
-                     "url": "https://example.com/wheel.whl",
-                     "size": 100,
-                     "hashes": {"sha256": "x" * 64}}],
+        "wheels": [
+            {
+                "name": "test_package-1.0.0-py3-none-any.whl",
+                "url": "https://example.com/wheel.whl",
+                "size": 100,
+                "hashes": {"sha256": "x" * 64},
+            }
+        ],
     }
     pkg = Package._from_dict(data)
     assert pkg.index is None

--- a/tests/test_pylock.py
+++ b/tests/test_pylock.py
@@ -866,3 +866,44 @@ def test_validate_attestation_identity_invalid_kind() -> None:
         "Unexpected type int (expected str) "
         "in 'packages[0].attestation-identities[0].kind'"
     )
+
+
+
+def test_pylock_invalid_index_url() -> None:
+    """Package index must be a valid URL."""
+    data = {
+        "name": "test-package",
+        "version": "1.0.0",
+        "index": "not-a-url",
+    }
+    with pytest.raises(PylockValidationError, match="not a valid URL"):
+        Package._from_dict(data)
+
+
+def test_pylock_valid_index_url() -> None:
+    """Package index accepts valid URLs."""
+    data = {
+        "name": "test-package",
+        "version": "1.0.0",
+        "index": "https://pypi.org/simple",
+        "wheels": [{"name": "test_package-1.0.0-py3-none-any.whl",
+                     "url": "https://example.com/wheel.whl",
+                     "size": 100,
+                     "hashes": {"sha256": "x" * 64}}],
+    }
+    pkg = Package._from_dict(data)
+    assert pkg.index == "https://pypi.org/simple"
+
+
+def test_pylock_none_index_url() -> None:
+    """Package index can be None (default)."""
+    data = {
+        "name": "test-package",
+        "version": "1.0.0",
+        "wheels": [{"name": "test_package-1.0.0-py3-none-any.whl",
+                     "url": "https://example.com/wheel.whl",
+                     "size": 100,
+                     "hashes": {"sha256": "x" * 64}}],
+    }
+    pkg = Package._from_dict(data)
+    assert pkg.index is None


### PR DESCRIPTION
Fixes #1185: package index field now validates that the value is a
valid URL, raising PylockValidationError otherwise.

✅ 63 pylock tests pass