### PR TITLE
Add `VersionRange.to_specifier_set`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,9 @@ Features:
   :meth:`SpecifierSet.to_range() <packaging.specifiers.SpecifierSet.to_range>`,
   representing the versions a specifier set accepts as an interval set that
   supports intersection, union, complement, membership tests, and filtering.
-  (:pull:`1267`)
+  :meth:`~packaging.ranges.VersionRange.to_specifier_set` converts a range back
+  to a :class:`~packaging.specifiers.SpecifierSet` where a PEP 440 form exists.
+  (:pull:`1267`, :pull:`1270`)
 * Add a ``limit`` argument to ``parse_tag()`` for compressed tag sets.
   (:issue:`1220`)
 

--- a/docs/ranges.rst
+++ b/docs/ranges.rst
@@ -202,6 +202,14 @@ every range, so it returns the simplest set whose own
     >>> # The strict singleton has no spelling: ==1.5 would also match 1.5+local
     >>> VersionRange.singleton("1.5").to_specifier_set() is None
     True
+    >>> # Neither does the full range built by algebra: it opts no pre-release
+    >>> # in, while its only spelling, >=0.dev0, opts them all in
+    >>> r = SpecifierSet(">=2").to_range()
+    >>> (r | ~r).to_specifier_set() is None
+    True
+    >>> # full() itself admits arbitrary strings, which the empty set spells
+    >>> str(VersionRange.full().to_specifier_set())
+    ''
 
 The recovery also caps how many ``!=`` exclusions it will write out, returning
 ``None`` past the cap; without it, some ranges would convert to pathologically

--- a/docs/ranges.rst
+++ b/docs/ranges.rst
@@ -45,6 +45,9 @@ Usage
     >>> # An unsatisfiable set produces the empty range
     >>> SpecifierSet(">=2.0,<1.0").to_range().is_empty
     True
+    >>> # Convert back to a SpecifierSet when possible
+    >>> str(r.to_specifier_set())
+    '<2.0,>=1.0'
 
 Pre-releases
 ------------
@@ -139,6 +142,15 @@ sets directly, so it is not affected by that opt-in difference:
 Like :meth:`VersionRange.intersection`, :meth:`VersionRange.union`, and
 :meth:`VersionRange.difference`, these predicates require both operands to share
 the same configured pre-release policy and raise :exc:`ValueError` otherwise.
+
+Because the operations refuse to mix policies, a range's version set is
+well-defined only under its own configured policy, and set relations stay sound
+only while that policy is held fixed. Reinterpreting a range, or a
+:class:`~packaging.specifiers.SpecifierSet` recovered from one, under a
+different ``prereleases`` value is therefore unsound: under ``prereleases=False``
+the ranges of ``<=1.0,!=1.0`` and ``<1.0`` accept the same releases (they differ
+only in ``1.0``'s pre-releases, which the policy excludes), but that equivalence
+is gone once the policy changes.
 
 Different specifiers that denote the same range, opt-in region included,
 canonicalize to one form, so they compare equal. ``>1.0a1`` excludes

--- a/docs/ranges.rst
+++ b/docs/ranges.rst
@@ -177,6 +177,42 @@ while the second does not; they are not substitutable and compare unequal:
     >>> SpecifierSet("<1.0.post0.dev0").to_range() == SpecifierSet("<=1.0").to_range()
     False
 
+Recovering a specifier set
+--------------------------
+
+:meth:`VersionRange.to_specifier_set` converts a range back to a
+:class:`~packaging.specifiers.SpecifierSet`. Specifier syntax cannot express
+every range, so it returns the simplest set whose own
+:meth:`~packaging.specifiers.SpecifierSet.to_range` reproduces the range, or
+``None`` when no single set does:
+
+.. doctest::
+
+    >>> str(SpecifierSet(">=1.0,<2.0").to_range().to_specifier_set())
+    '<2.0,>=1.0'
+    >>> # A disjoint union usually has no single-set spelling
+    >>> a = SpecifierSet("<1").to_range()
+    >>> b = SpecifierSet(">=2").to_range()
+    >>> (a | b).to_specifier_set() is None
+    True
+    >>> # unless the gap between the pieces is expressible as exclusions
+    >>> u = SpecifierSet("==1.*").to_range() | SpecifierSet("==3.*").to_range()
+    >>> str(u.to_specifier_set())
+    '!=0.*,!=2.*,<4'
+    >>> # The strict singleton has no spelling: ==1.5 would also match 1.5+local
+    >>> VersionRange.singleton("1.5").to_specifier_set() is None
+    True
+
+The recovery also caps how many ``!=`` exclusions it will write out, returning
+``None`` past the cap; without it, some ranges would convert to pathologically
+large sets that are slow to build and to use:
+
+.. doctest::
+
+    >>> far = SpecifierSet("==1.*").to_range() | SpecifierSet("==1000000.*").to_range()
+    >>> far.to_specifier_set() is None
+    True
+
 Limits of the model
 -------------------
 

--- a/src/packaging/ranges.py
+++ b/src/packaging/ranges.py
@@ -6,7 +6,9 @@
 A set-algebra view of the versions accepted by a
 :class:`~packaging.specifiers.SpecifierSet`. Ranges support intersection,
 union, complement, and difference; membership and filtering match the
-originating specifier set.
+originating specifier set; and conversion back to a
+:class:`~packaging.specifiers.SpecifierSet` is available where a PEP 440 form
+exists.
 
 .. testsetup::
 
@@ -42,6 +44,7 @@ from ._ranges import (
     matches_bounds_only,
     range_is_empty,
     ranges_are_prerelease_only,
+    trim_release,
 )
 from .version import Version
 
@@ -311,6 +314,646 @@ def _format_intervals(intervals: Sequence[Interval]) -> str:
     )
 
 
+# ``to_specifier_set`` recovery: encode a range's interval list back into
+# specifier fragments. Each helper returns ``None`` when its shape has no
+# PEP 440 form. The ``prereleases`` argument threaded through is a spelling
+# mode, not a policy: ``None`` emits a prerelease-free form (no synthetic
+# ``.dev0``, so the recovered range has an empty opt-in region), ``True`` keeps
+# the ``.dev0`` markers (so the range opts its bounds in).
+# ``to_specifier_set`` encodes in both modes and keeps whichever round-trips.
+#
+# Bound and interval encoding: turn one interval's bounds into fragments.
+
+
+def _is_dev0_version(version: Version) -> bool:
+    """True when version is exactly ``X[.Y]*.dev0`` (the shape ``<X`` makes)."""
+    return (
+        version.dev == 0
+        and version.pre is None
+        and version.post is None
+        and version.local is None
+    )
+
+
+def _clean_lower(version: Version) -> list[str] | None:
+    """A prerelease-free spelling for an inclusive ``[version`` lower, or ``None``.
+
+    Several ``[V`` lowers come from an operator whose own spelling carries no
+    synthetic ``.dev0``. Recovering that spelling gives the range an empty opt-in
+    region, so it is offered in the ``prereleases is None`` spelling mode (see
+    :meth:`VersionRange.to_specifier_set`).
+    """
+    if version.dev != 0 or version.pre is not None or version.local is not None:
+        return None
+
+    # ``[B.post(k).dev0`` is the lower ``>B.post(k-1)`` builds (k >= 1).
+    if version.post is not None:
+        if version.post < 1:
+            return None
+        return [f">{version.__replace__(post=version.post - 1, dev=None)}"]
+
+    # ``[F.dev0`` is family F's base. The prefix P just below F has
+    # ``==P.* == [P.dev0, F.dev0)``, so ``>=P,!=P.*`` lands exactly on ``[F.dev0``.
+    family = trim_release(version.release)
+    last = family[-1]
+    if last < 1:
+        return None
+
+    below_release = (*family[:-1], last - 1)
+    below = Version.from_parts(epoch=version.epoch, release=below_release)
+
+    # At the epoch-0 floor ``==P.*`` already reaches ``0.dev0``, so the ``>=P``
+    # half is redundant: ``[1.dev0, +inf)`` is plain ``!=0.*``.
+    if version.epoch == 0 and not any(below_release):
+        return [f"!={below}.*"]
+
+    return [f">={below}", f"!={below}.*"]
+
+
+def _epoch_floor_lower(
+    lower: LowerBound, upper: UpperBound
+) -> tuple[Version, int, bool] | None:
+    """The ``E!0`` family of a lower sitting on an epoch>0 zero-family floor.
+
+    An epoch>0 zero-family base such as ``1!0.dev0`` has no ``>=P,!=P.*`` spelling
+    since no version sorts below ``E!0`` within the epoch. While the interval
+    stays within ``==E!0.*`` it is that wildcard, trimmed by the upper and with a
+    leading ``.dev`` run excluded: an ``AFTER_LOCALS(E!0.dev(k))`` lower drops
+    ``E!0.dev0..E!0.dev(k)``, a plain inclusive ``E!0.dev0`` lower drops none.
+    Returns the ``E!0`` family, how many leading ``.dev`` releases to exclude, and
+    whether the upper sits at the family cap (so ``==E!0.*`` needs no upper), else
+    ``None``.
+    """
+    version = lower.version
+    if isinstance(version, BoundaryVersion):
+        if version.kind != BoundaryKind.AFTER_LOCALS:
+            return None
+        version = version.version
+        if version.dev is None:
+            return None
+        excluded_devs = version.dev + 1
+    elif isinstance(version, Version) and lower.inclusive:
+        # A plain inclusive lower only reaches the floor as ``>=E!0.dev0``;
+        # higher ``.dev`` would have canonicalized to an AFTER_LOCALS boundary.
+        if version.dev != 0:
+            return None
+        excluded_devs = 0
+    else:
+        return None
+
+    # Only the bare ``E!0`` floor of a non-zero epoch qualifies.
+    if version.epoch == 0:
+        return None
+    if version.pre is not None or version.post is not None or version.local is not None:
+        return None
+    if any(trim_release(version.release)):
+        return None
+
+    # ``==E!0.*`` spans ``[E!0.dev0, E!1.dev0)``; it fits only below that cap.
+    next_family = Version.from_parts(epoch=version.epoch, release=(1,), dev=0)
+    cap = UpperBound(next_family, False)
+    if upper > cap:
+        return None
+
+    family = Version.from_parts(epoch=version.epoch, release=(0,))
+    return family, excluded_devs, upper == cap
+
+
+def _dev_family_anchor(family: Version) -> list[str] | None:
+    """Prerelease-free fragments for ``[family, ..)``, or ``None`` if it has none.
+
+    ``family`` is an ``X.dev0``. The floor gives ``[]`` (every version); a release
+    base its ``_clean_lower`` family-floor spelling (``!=0.*`` ...); an ``X.post0``
+    base ``>=X,!=X``. A pre-release base has no prerelease-free spelling.
+    """
+    if family <= MIN_VERSION:
+        return []
+    clean = _clean_lower(family)
+    if clean is not None:
+        return clean
+    if family.pre is None and family.post == 0:
+        base = family.__replace__(post=None, dev=None)
+        return [f">={base}", f"!={base}"]
+    return None
+
+
+def _encode_lower(lower: LowerBound, prereleases: bool | None) -> list[str] | None:
+    """Encode a lower bound as specifier fragments, or ``None``.
+
+    ``[]`` for ``-inf``. An ``AFTER_POSTS(V)`` lower is ``>V``. An
+    ``AFTER_LOCALS(V)`` lower is the set ``[successor, ..)`` and emits ``>=V,!=V``,
+    except in the prerelease-free spelling mode (``prereleases`` is ``None``),
+    where it recovers a spelling with no synthetic ``.dev0`` when one exists:
+    ``>3.8.post1`` for a post release, or a dev family's anchor plus the dev run
+    up to V for a ``.dev`` release.
+    """
+    lower_version = lower.version
+    if lower_version is None:
+        return []
+
+    if isinstance(lower_version, BoundaryVersion):
+        if lower_version.kind == BoundaryKind.AFTER_POSTS:
+            # AFTER_POSTS only ever appears as an exclusive ``>V`` lower.
+            return [f">{lower_version.version}"]
+        inner = lower_version.version
+        if inner <= MIN_VERSION:
+            # The ``(-inf, V)`` side was dropped at the floor, so the lone
+            # ``(AFTER_LOCALS(0.dev0), +inf)`` interval is exactly ``!=0.dev0``.
+            return [f"!={inner}"]
+        # An ``(AFTER_LOCALS(V), ..)`` lower is the set ``[successor, ..)``. In
+        # the prerelease-free mode, recover a spelling with no synthetic ``.dev0``
+        # so the range's opt-in region stays empty.
+        if prereleases is None:
+            if inner.dev is not None:
+                # A ``.dev`` V makes ``[successor, ..)`` its dev family's
+                # prerelease-free anchor minus the finite dev run up to ``V``
+                # (e.g. ``>=1.0,!=1.0,!=1.0.post0.dev0``), carrying no synthetic
+                # ``.dev0``.
+                family = inner.__replace__(dev=0)
+                anchor = _dev_family_anchor(family)
+                if anchor is not None:
+                    if inner.dev + 1 > _MAX_EXCLUSION_RUN:
+                        return None
+                    run = [
+                        f"!={family.__replace__(dev=d)}" for d in range(inner.dev + 1)
+                    ]
+                    return anchor + run
+            else:
+                # A ``.post`` release recovers its prerelease-free ``>`` spelling
+                # from the successor (``>3.8.post1`` for ``AFTER_LOCALS(3.8.post1)``).
+                successor = least_version_above(lower_version)
+                clean = _clean_lower(successor) if successor is not None else None
+                if clean is not None:
+                    return clean
+        # Otherwise it is ``[V, ..)`` minus V's local family, i.e. ``>=V,!=V``.
+        # The prerelease-free recoveries above have already returned in that mode;
+        # a residual ``.dev`` V here opts pre-releases in, so this spelling round
+        # trips only for a range whose opt-in region wants it.
+        return [f">={inner}", f"!={inner}"]
+
+    if not lower.inclusive:
+        return None
+
+    # In the prerelease-free mode a ``.dev0`` lower prefers its clean spelling.
+    if prereleases is None:
+        clean = _clean_lower(lower_version)
+        if clean is not None:
+            return clean
+    return [f">={lower_version}"]
+
+
+def _encode_upper(upper: UpperBound, prereleases: bool | None) -> list[str] | None:
+    """Encode an upper bound as specifier fragments, or ``None``.
+
+    ``[]`` for ``+inf``. In the prerelease-free spelling mode (``prereleases`` is
+    ``None``) the ``<X`` spelling is used for the ``X.dev0`` upper that ``<X``
+    builds; in the ``True`` mode the synthetic ``.dev0`` is kept so the range
+    opts its bounds in.
+    """
+    upper_version = upper.version
+    if upper_version is None:
+        return []
+
+    if isinstance(upper_version, BoundaryVersion):
+        # A boundary upper is always inclusive (a boundary already sits between
+        # versions, so no specifier produces an exclusive one).
+        if upper_version.kind == BoundaryKind.AFTER_LOCALS:
+            inner = upper_version.version
+            if (
+                prereleases is None
+                and inner.pre is None
+                and inner.post is not None
+                and inner.dev is None
+            ):
+                # ``AFTER_LOCALS(post-release)]`` upper is ``<next-post`` (e.g.
+                # ``<3.8.post1`` for ``AFTER_LOCALS(3.8.post0)``), the ``<P``
+                # spelling a post-release upper builds, with no ``.dev0``.
+                return [f"<{inner.__replace__(post=inner.post + 1)}"]
+            return [f"<={inner}"]
+        # ``AFTER_POSTS(P)`` sits just below the next pre-release's ``.dev0``
+        # (canonicalization of a ``<P.preN.dev0`` upper), so it is ``<`` that
+        # least successor. A final-release AFTER_POSTS has no successor or form.
+        successor = least_version_above(upper_version)
+        if successor is not None:
+            return [f"<{successor}"]
+        return None
+
+    if not upper.inclusive:
+        # ``<X`` builds an exclusive ``X.dev0`` upper (X final or post-release;
+        # never pre/local). ``<X`` and ``<X.dev0`` define the same bound but
+        # differ in the opt-in they imply, so pick by the spelling mode.
+        if (
+            upper_version.dev == 0
+            and upper_version.pre is None
+            and upper_version.local is None
+        ):
+            if prereleases is None:
+                return [f"<{upper_version.__replace__(dev=None)}"]
+            return [f"<{upper_version}"]
+        # ``V`` (exclusive) upper, including V's pre-releases.
+        return [f"<={upper_version}", f"!={upper_version}"]
+    return None
+
+
+def _detect_equal_wildcard(lower: LowerBound, upper: UpperBound) -> Version | None:
+    """If ``[lower, upper)`` is the ``==V.*`` shape, return ``V``."""
+    if isinstance(lower.version, BoundaryVersion) or isinstance(
+        upper.version, BoundaryVersion
+    ):
+        return None
+    if lower.version is None or upper.version is None:
+        return None
+    if not lower.inclusive or upper.inclusive:
+        return None
+    if not (_is_dev0_version(lower.version) and _is_dev0_version(upper.version)):
+        return None
+    if lower.version.epoch != upper.version.epoch:
+        return None
+
+    lower_release = trim_release(lower.version.release)
+    upper_release = trim_release(upper.version.release)
+    padded_length = max(len(lower_release), len(upper_release))
+    assert padded_length > 0
+    lower_release += (0,) * (padded_length - len(lower_release))
+    upper_release += (0,) * (padded_length - len(upper_release))
+
+    if lower_release[:-1] != upper_release[:-1]:
+        return None
+
+    # A genuine ``==V.*`` spans one family: the upper is exactly the next prefix.
+    # A wider span like ``[3.8.dev0, 3.14.dev0)`` shares the prefix but is not a
+    # single wildcard, so it falls through to the generic ``>=...,<...`` form.
+    if upper_release[-1] != lower_release[-1] + 1:
+        return None
+
+    return lower.version.__replace__(release=lower_release, dev=None)
+
+
+def _encode_interval(
+    lower: LowerBound, upper: UpperBound, prereleases: bool | None
+) -> list[str] | None:
+    """Encode one interval as specifier fragments, or ``None``.
+
+    Special-cases the ``==V`` singleton (``[V, AFTER_LOCALS(V)]`` for a plain
+    ``V``, and ``[V+local, V+local]`` for a local one) and the ``==V.*`` shape
+    so the fragment is one equality rather than a bound pair.
+    """
+    # ``[V+local, V+local]`` (an inclusive local point) is the singleton ``==V+local``.
+    if (
+        lower.version is not None
+        and upper.version is not None
+        and not isinstance(lower.version, BoundaryVersion)
+        and not isinstance(upper.version, BoundaryVersion)
+        and lower.inclusive
+        and upper.inclusive
+        and lower.version == upper.version
+        and lower.version.local is not None
+    ):
+        return [f"=={lower.version}"]
+
+    # ``[V, AFTER_LOCALS(V)]`` (V without a local) is the singleton ``==V``,
+    # which also matches V's local family: one equality, not ``>=V,<=V``.
+    if (
+        isinstance(lower.version, Version)
+        and lower.inclusive
+        and upper.inclusive
+        and isinstance(upper.version, BoundaryVersion)
+        and upper.version.kind == BoundaryKind.AFTER_LOCALS
+        and upper.version.version == lower.version
+    ):
+        return [f"=={lower.version}"]
+
+    wildcard = _detect_equal_wildcard(lower, upper)
+    if wildcard is not None:
+        return [f"=={wildcard}.*"]
+
+    # A ``[E!0.dev0`` lower has no prerelease-free ``>=`` spelling; within its own
+    # family it is ``==E!0.*`` trimmed by the upper.
+    floor = _epoch_floor_lower(lower, upper) if prereleases is None else None
+    if floor is not None:
+        family, excluded_devs, upper_at_cap = floor
+        if excluded_devs > _MAX_EXCLUSION_RUN:
+            return None
+        parts = [f"=={family}.*"]
+        parts.extend(f"!={family.__replace__(dev=d)}" for d in range(excluded_devs))
+
+        # ``==E!0.*`` already caps at the next family; add the upper only if tighter.
+        if not upper_at_cap:
+            upper_parts = _encode_upper(upper, prereleases)
+            if upper_parts is None:
+                return None
+            parts.extend(upper_parts)
+
+        return parts
+
+    lower_parts = _encode_lower(lower, prereleases)
+    if lower_parts is None:
+        return None
+
+    upper_parts = _encode_upper(upper, prereleases)
+    if upper_parts is None:
+        return None
+
+    return lower_parts + upper_parts
+
+
+# Gap detection: classify the gap between two adjacent intervals.
+
+
+def _detect_not_equal(
+    left_upper: UpperBound, right_lower: LowerBound
+) -> list[Version] | None:
+    """If the gap between two intervals is a ``!=V`` chain, list its points.
+
+    A plain exclusive left upper names the first excluded V directly; an inclusive
+    boundary left upper names it via its least successor. Adjacent exclusions
+    (``V`` and its immediate successors) share a single gap spanning a contiguous
+    dev run, so one gap can name a short chain: ``!=1.0,!=1.0.post0.dev0`` is one
+    gap from ``1.0`` up to ``AFTER_LOCALS(1.0.post0.dev0)``.
+    """
+    if isinstance(left_upper.version, BoundaryVersion):
+        # A boundary upper is always inclusive; its least successor is the first
+        # excluded V (``None`` for a final AFTER_POSTS, which names no point).
+        first = least_version_above(left_upper.version)
+        if first is None:
+            return None
+    elif left_upper.version is None or left_upper.inclusive:
+        return None
+    else:
+        first = left_upper.version
+
+    if not isinstance(right_lower.version, BoundaryVersion):
+        if (
+            right_lower.version is not None
+            and not right_lower.inclusive
+            and right_lower.version == first
+            and first.local is not None
+        ):
+            return [first]
+        return None
+
+    if right_lower.version.kind != BoundaryKind.AFTER_LOCALS:
+        return None
+
+    # The right interval resumes just above the last excluded V and its locals.
+    last = right_lower.version.version
+    if first == last:
+        return [first]
+
+    # Adjacent exclusions: the successor of ``first`` opens a ``.dev`` family and
+    # every later point is a higher ``.dev`` in that same family, so the gap is
+    # exactly ``first`` plus a contiguous dev run up to ``last``. Any other gap
+    # (e.g. ``2.3`` to ``AFTER_LOCALS(2.7)`` from complementing ``>=2.3,<=2.7``)
+    # spans a whole interval and fails this test.
+    second = least_version_above(BoundaryVersion(first, BoundaryKind.AFTER_LOCALS))
+    if (
+        second is not None
+        and second.dev is not None
+        and last.dev is not None
+        and last.dev >= second.dev
+        and last.__replace__(dev=second.dev) == second
+    ):
+        if last.dev - second.dev + 1 > _MAX_EXCLUSION_RUN:
+            return None
+        run = (second.__replace__(dev=d) for d in range(second.dev, last.dev + 1))
+        return [first, *run]
+    return None
+
+
+#: The most ``!=`` points a single recovered specifier set will materialize. A
+#: gap wider than this at one level (or, for :func:`_decompose_dev0_gap`, summed
+#: across levels) has no practical single-set form, so the recovery gives up
+#: rather than emit an unbounded chain such as ``==5.* | ==1000000.*`` would
+#: otherwise drive.
+_MAX_EXCLUSION_RUN = 128
+
+
+def _decompose_dev0_gap(
+    lower_trim: tuple[int, ...],
+    upper_trim: tuple[int, ...],
+    epoch: int,
+    budget: int = _MAX_EXCLUSION_RUN,
+) -> list[Version] | None:
+    """Decompose the gap ``[L.dev0, U.dev0)`` into wildcard prefixes.
+
+    ``lower_trim``/``upper_trim`` are trimmed release tuples with
+    ``lower_trim < upper_trim`` lexicographically. The chain sweeps at the
+    first differing level. The gap is undecomposable when L has trailing
+    components below that level (the chain cannot escape L's subtree), or when
+    the chain, summed across levels, would exceed ``budget`` prefixes.
+    """
+    diff = 0
+    while (
+        diff < len(lower_trim)
+        and diff < len(upper_trim)
+        and lower_trim[diff] == upper_trim[diff]
+    ):
+        diff += 1
+
+    if len(lower_trim) > diff + 1:
+        return None
+
+    common = lower_trim[:diff]
+    lower_val = lower_trim[diff] if len(lower_trim) > diff else 0
+    upper_val = upper_trim[diff]
+
+    span = upper_val - lower_val
+    if span > budget:
+        return None
+
+    fragments = [
+        Version.from_parts(epoch=epoch, release=(*common, segment))
+        for segment in range(lower_val, upper_val)
+    ]
+
+    if len(upper_trim) == diff + 1:
+        return fragments
+
+    # Recurse into the next release component, charging at least one to the budget
+    # per level (not just the span), so a run of zero-span levels (a release with
+    # many trailing components) exhausts the budget and returns None instead of
+    # recursing past the interpreter's stack limit.
+    tail = _decompose_dev0_gap(
+        (*common, upper_val), upper_trim, epoch, budget - max(span, 1)
+    )
+    if tail is None:
+        return None
+    return fragments + tail
+
+
+def _detect_not_equal_wildcards(
+    left_upper: UpperBound, right_lower: LowerBound
+) -> list[Version] | None:
+    """Decompose a ``[L.dev0, U.dev0)`` gap into a chain of ``!=P.*`` prefixes."""
+    left_upper_v = left_upper.version
+    right_lower_v = right_lower.version
+
+    if not isinstance(left_upper_v, Version) or not isinstance(right_lower_v, Version):
+        return None
+    if left_upper.inclusive or not right_lower.inclusive:
+        return None
+    if not (_is_dev0_version(left_upper_v) and _is_dev0_version(right_lower_v)):
+        return None
+    if left_upper_v.epoch != right_lower_v.epoch:
+        return None
+
+    return _decompose_dev0_gap(
+        trim_release(left_upper_v.release),
+        trim_release(right_lower_v.release),
+        left_upper_v.epoch,
+    )
+
+
+def _detect_wildcards_then_dev0(
+    left_upper: UpperBound, right_lower: LowerBound
+) -> tuple[list[Version], list[Version]] | None:
+    """Split a ``[L.dev0, AFTER_LOCALS(U.dev(k))]`` gap into ``!=P.*`` + a dev run.
+
+    A leading ``!=U.dev0,...,!=U.dev(k)`` run sitting just above an excluded
+    ``!=family.*`` chain leaves the right interval at ``AFTER_LOCALS(U.dev(k))``:
+    one gap covers the wildcard families ``[L.dev0, U.dev0)`` and then a contiguous
+    dev run in U's own family. Returns the ``!=P.*`` chain prefixes and the
+    ``U.dev0..U.dev(k)`` run, or ``None``.
+    """
+    left_upper_v = left_upper.version
+    right_lower_v = right_lower.version
+
+    # The gap runs from an exclusive ``L.dev0`` up to ``AFTER_LOCALS(U.dev(k))``.
+    if not isinstance(left_upper_v, Version):
+        return None
+    if not isinstance(right_lower_v, BoundaryVersion):
+        return None
+    if right_lower_v.kind != BoundaryKind.AFTER_LOCALS:
+        return None
+    if left_upper.inclusive or right_lower.inclusive:
+        return None
+
+    # ``L`` is a dev0 family base; ``U`` is a release base bearing a ``.dev`` run
+    # (``U.dev0`` for a single point, higher for a run), both in the same epoch.
+    # ``_is_dev0_version`` on ``U.dev0`` rejects any pre/post/local on ``U``.
+    upper = right_lower_v.version
+    if upper.dev is None:
+        return None
+    upper_dev0 = upper.__replace__(dev=0)
+    if not (_is_dev0_version(left_upper_v) and _is_dev0_version(upper_dev0)):
+        return None
+    if left_upper_v.epoch != upper_dev0.epoch or left_upper_v >= upper_dev0:
+        return None
+
+    # The chain ``[L.dev0, U.dev0)`` decomposes into the ``==P.*`` prefixes.
+    prefixes = _decompose_dev0_gap(
+        trim_release(left_upper_v.release),
+        trim_release(upper_dev0.release),
+        left_upper_v.epoch,
+    )
+    if prefixes is None:
+        return None
+
+    if upper.dev + 1 > _MAX_EXCLUSION_RUN:
+        return None
+    run = [upper.__replace__(dev=d) for d in range(upper.dev + 1)]
+    return prefixes, run
+
+
+# Group assembly: encode each group of intervals as one fragment list.
+
+
+def _close_group(
+    group_lower: LowerBound,
+    group_upper: UpperBound,
+    exclusions: list[str],
+    prereleases: bool | None,
+) -> list[str] | None:
+    """Encode one accumulated group as specifier fragments, or ``None``.
+
+    A group is a single contiguous interval (its members joined through ``!=``
+    gaps), never a disjoint union: a multi-family dev0 span such as
+    ``[3.8.dev0, 3.14.dev0)`` is the contiguous ``>=3.8.dev0,<3.14``. Genuinely
+    disjoint families land in separate groups, which
+    :meth:`VersionRange.to_specifier_set` rejects by group count. The outer span
+    itself may still have no PEP 440 form, in which case this returns ``None``.
+    """
+    outer = _encode_interval(group_lower, group_upper, prereleases)
+    if outer is None:
+        return None
+
+    return outer + exclusions
+
+
+def _encode_grouped(
+    bounds: list[Interval], prereleases: bool | None
+) -> list[list[str]] | None:
+    """Split bounds into disjoint groups, encoding each as fragments.
+
+    Consecutive intervals whose gap is an ``!=V`` / ``!=V+local`` / ``!=V.*``
+    exclusion stay in one group; any other gap starts a new group. Returns one
+    fragment list per group, or ``None`` if any group has no PEP 440 form.
+    """
+    groups: list[list[str]] = []
+    group_lower, group_upper = bounds[0]
+    exclusions: list[str] = []
+
+    for next_lower, next_upper in bounds[1:]:
+        # Classify the gap to the next interval: an ``!=`` exclusion keeps the
+        # group open, anything else closes it.
+        not_equal = _detect_not_equal(group_upper, next_lower)
+        not_equal_wildcards = _detect_not_equal_wildcards(group_upper, next_lower)
+        wildcards_then_dev0 = _detect_wildcards_then_dev0(group_upper, next_lower)
+
+        if not_equal is not None:
+            exclusions.extend(f"!={point}" for point in not_equal)
+        elif not_equal_wildcards is not None:
+            exclusions.extend(f"!={prefix}.*" for prefix in not_equal_wildcards)
+        elif wildcards_then_dev0 is not None:
+            chain, run = wildcards_then_dev0
+            exclusions.extend(f"!={prefix}.*" for prefix in chain)
+            exclusions.extend(f"!={point}" for point in run)
+        else:
+            closed = _close_group(group_lower, group_upper, exclusions, prereleases)
+            if closed is None:
+                return None
+            groups.append(closed)
+            group_lower, exclusions = next_lower, []
+
+        group_upper = next_upper
+
+    closed = _close_group(group_lower, group_upper, exclusions, prereleases)
+    if closed is None:
+        return None
+    groups.append(closed)
+
+    return groups
+
+
+def _tighten_no_prereleases(bounds: tuple[Interval, ...]) -> tuple[Interval, ...]:
+    """Snap the range's final upper out of the pre-release band ``False`` drops.
+
+    An exclusive upper at a final ``V`` admits the versions in ``[V.dev0, V)`` at
+    the bounds level, but a ``prereleases=False`` policy filters them all out, so
+    it accepts the same releases as ``<V`` (upper at ``V.dev0``). Snapping it lets
+    :meth:`VersionRange.to_specifier_set` reach the ``<V`` spelling.
+
+    Only the last interval's upper is snapped, the one that gives a terser outer
+    bound. Inner uppers are left alone: snapping one turns its gap to the next
+    interval into a ``.dev0`` wildcard gap, which a far-apart neighbour would blow
+    up into an unbounded ``!=N.*`` chain. Those shapes recover as ``None`` here,
+    the same as under ``None`` / ``True``. The snap is conservative (it skips
+    boundary, pre-release, and local uppers); the caller keeps it only when it
+    stays release-equivalent, so an unsnapped shape falls back to the exact form.
+    """
+    lower, upper = bounds[-1]
+    version = upper.version
+    if (
+        isinstance(version, Version)
+        and not upper.inclusive
+        and not version.is_prerelease
+        and version.local is None
+    ):
+        upper = UpperBound(version.__replace__(dev=0), inclusive=False)
+        return (*bounds[:-1], (lower, upper))
+    return bounds
+
+
 class VersionRange:
     """A set of :class:`~packaging.version.Version` values accepted by a
     :class:`~packaging.specifiers.SpecifierSet`.
@@ -320,7 +963,8 @@ class VersionRange:
     Compose with :meth:`intersection`, :meth:`union`, :meth:`complement`, and
     :meth:`difference` (or the ``&`` / ``|`` / ``~`` / ``-`` operators). Test
     membership with ``in`` or :meth:`contains`, filter an iterable with
-    :meth:`filter`.
+    :meth:`filter`, and convert back to a
+    :class:`~packaging.specifiers.SpecifierSet` with :meth:`to_specifier_set`.
 
     The configured pre-release policy of the originating specifier set carries
     onto the range and controls whether pre-releases are admitted under ``in``,
@@ -344,10 +988,11 @@ class VersionRange:
 
     PEP 440's ``===`` operator matches a candidate string verbatim
     (case-insensitive) rather than a set of versions. Ranges built from
-    ``===`` specifiers still support membership and set operations; matching
-    follows the literal-equality rule. A ``===`` literal that names a
-    pre-release is admitted under the default policy by both :meth:`contains`
-    and :meth:`filter`, since it was named outright.
+    ``===`` specifiers still support membership, set operations, and conversion
+    back to a :class:`~packaging.specifiers.SpecifierSet`; matching follows the
+    literal-equality rule. A ``===`` literal that names a pre-release is
+    admitted under the default policy by both :meth:`contains` and
+    :meth:`filter`, since it was named outright.
 
     .. versionadded:: 26.3
     """
@@ -933,6 +1578,16 @@ class VersionRange:
             return not intersect_ranges(self._bounds, other._bounds)
         return self.intersection(other).is_empty
 
+    def _same_releases(self, other: VersionRange) -> bool:
+        """Whether self and other admit the same non-pre-release versions.
+
+        Used by :meth:`to_specifier_set` under a ``prereleases=False`` policy,
+        where pre-releases are unobservable: the symmetric difference is empty
+        exactly when the two ranges accept the same releases. Both operands
+        carry that policy, so the difference below reads emptiness through it.
+        """
+        return self.difference(other).is_empty and other.difference(self).is_empty
+
     @typing.overload
     def filter(
         self,
@@ -1122,6 +1777,126 @@ class VersionRange:
             pre_region=tuple(region),
             configured=specifier_set._prereleases,
         )
+
+    def to_specifier_set(self) -> SpecifierSet | None:
+        """Return a :class:`~packaging.specifiers.SpecifierSet` matching the same
+        versions as self, or ``None`` if no single set expresses it.
+
+        PEP 440 has no syntax for the strict singleton ``{V}`` (an exclusive
+        plain-version bound), a disjoint union of two or more intervals, or a
+        partial pre-release opt-in region, so ranges built by set algebra often
+        return ``None``. A gap spanning a very large number of release families
+        returns ``None`` too, rather than a pathologically long ``!=`` chain;
+        reaching that takes either set algebra or a specifier set that already
+        spells the gap out with hundreds of contiguous ``!=N.*`` exclusions. An
+        empty range maps to ``SpecifierSet("<0")``, unless it still carries the
+        arbitrary-string flag (which no set reproduces), and a full range that
+        admits arbitrary strings maps to ``SpecifierSet("")``.
+
+        A range built from a :class:`~packaging.specifiers.SpecifierSet`
+        re-encodes, short of that exclusion cap. The result is the simplest
+        candidate whose own
+        :meth:`~packaging.specifiers.SpecifierSet.to_range` reproduces self
+        exactly (bounds, ``===`` literals, and the opt-in region are all part of
+        equality), so it filters the same versions. Two cases relax that
+        exactness without changing what is filtered: an empty range recovers as
+        the canonical empty range (same versions, none, but not self's bounds),
+        and under a ``prereleases=False`` policy the result need only match self's
+        releases, so ``(-inf, 3.14)`` recovers as the tighter ``<3.14`` rather
+        than ``!=3.14,<=3.14``.
+
+        >>> str(SpecifierSet(">=1.0,<2.0").to_range().to_specifier_set())
+        '<2.0,>=1.0'
+        >>> str(SpecifierSet("==1.0").to_range().to_specifier_set())
+        '==1.0'
+        >>> VersionRange.singleton("1.5").to_specifier_set() is None
+        True
+        """
+        from .specifiers import SpecifierSet  # noqa: PLC0415
+
+        configured = self._prereleases_configured
+
+        if self._reject:
+            return None
+        if self._admit_arbitrary and self._bounds != FULL_RANGE:
+            return None
+        if self.is_empty:
+            # Every member-free spelling accepts the same versions (none), so the
+            # canonical ``<0`` stands in for all of them; a configured policy
+            # rides along it.
+            return SpecifierSet("<0", prereleases=configured)
+
+        admit_pieces = [f"==={literal}" for literal in sorted(self._admit)]
+        if not self._bounds:
+            # Pure ``===`` literals; only a single literal has a single-set form.
+            if len(admit_pieces) != 1:
+                return None
+            bases = [admit_pieces[0]]
+        elif admit_pieces:
+            # Bounds plus literals cannot be one set.
+            return None
+        elif self._bounds == FULL_RANGE:
+            bases = ["" if self._admit_arbitrary else ">=0.dev0"]
+        else:
+            # Under ``prereleases=False`` an exclusive final upper admits the same
+            # releases as ``<V`` (the ``[V.dev0, V)`` band is excluded), so offer
+            # the tightened bounds as well; a tightening that is not
+            # release-equivalent is dropped by the acceptance check below.
+            layouts = [self._bounds]
+            if configured is False:
+                tightened = _tighten_no_prereleases(self._bounds)
+                if tightened != self._bounds:
+                    layouts.append(tightened)
+
+            # Encode each layout in both spelling modes: prerelease-free, then
+            # keeping the synthetic ``.dev0`` markers. Which spelling reproduces
+            # self is settled by the round trip below, not up front.
+            bases = []
+            for layout in layouts:
+                for mode in (None, True):
+                    groups = _encode_grouped(list(layout), mode)
+                    if groups is not None and len(groups) == 1:
+                        bases.append(",".join(groups[0]))
+
+        # Keep the simplest candidate that recovers self. ``==`` compares bounds,
+        # literals, and the opt-in region, so a candidate that would filter
+        # differently, or an op-built range with no single-set form, is rejected
+        # below. Under ``prereleases=False`` a candidate need only match self's
+        # releases (policies never mix, so the excluded pre-releases are
+        # unobservable), which admits the tightened spellings above.
+        best: SpecifierSet | None = None
+        best_key = (0, 0)
+        seen: set[str] = set()
+
+        for base in bases:
+            # Offer each base with the no-op ``>=0.dev0`` floor too, which
+            # restores a ``True`` opt-in that rode on a floor the clean encoding
+            # dropped (e.g. ``>=0.dev0,!=1.0``).
+            floored = f"{base},>=0.dev0" if base else ">=0.dev0"
+
+            for spec_str in (base, floored):
+                if spec_str in seen:
+                    continue
+                seen.add(spec_str)
+
+                # Fewest fragments, then shortest string. Rank before the round
+                # trip so a candidate that cannot beat the best skips the check
+                # (its ``==`` and, under ``False``, two ``difference`` calls).
+                recovered = SpecifierSet(spec_str, prereleases=configured)
+                key = (len(recovered), len(str(recovered)))
+                if best is not None and key >= best_key:
+                    continue
+
+                # Accept an exact round trip, or (under ``False``) one that only
+                # matches the releases the policy leaves observable.
+                candidate = recovered.to_range()
+                matches = candidate == self or (
+                    configured is False and self._same_releases(candidate)
+                )
+                if matches:
+                    best, best_key = recovered, key
+
+        return best
 
     @property
     def is_empty(self) -> bool:

--- a/src/packaging/ranges.py
+++ b/src/packaging/ranges.py
@@ -1767,7 +1767,7 @@ class VersionRange:
         >>> VersionRange.singleton("1.5").to_specifier_set() is None
         True
         """
-        from .specifiers import SpecifierSet  # noqa: PLC0415
+        from .specifiers import InvalidSpecifier, SpecifierSet  # noqa: PLC0415
 
         configured = self._prereleases_configured
 
@@ -1842,10 +1842,18 @@ class VersionRange:
                 candidates.append(f"{base},>=0.dev0" if base else ">=0.dev0")
 
             for spec_str in candidates:
+                # A ``===`` literal can hold a comma (its arbitrary version
+                # excludes only whitespace, ``;`` and ``)``), which the set
+                # string splits on. Such a literal has no single specifier-set
+                # spelling, so drop the unparsable candidate and let the range
+                # fall through to ``None`` rather than raise.
+                try:
+                    recovered = SpecifierSet(spec_str, prereleases=configured)
+                except InvalidSpecifier:
+                    continue
                 # Fewest fragments, then shortest string. Rank before the round
                 # trip so a candidate that cannot beat the best skips the check
                 # (its ``==`` and, under ``False``, two ``difference`` calls).
-                recovered = SpecifierSet(spec_str, prereleases=configured)
                 key = (len(recovered), len(str(recovered)))
                 if best is not None and key >= best_key:
                     continue

--- a/src/packaging/ranges.py
+++ b/src/packaging/ranges.py
@@ -61,6 +61,16 @@ T = TypeVar("T")
 UnparsedVersion = Union[Version, str]
 UnparsedVersionVar = TypeVar("UnparsedVersionVar", bound=UnparsedVersion)
 
+#: The most ``!=`` exclusion fragments (``!=V`` points or ``!=P.*`` prefixes)
+#: that :meth:`VersionRange.to_specifier_set` will materialize to spell a
+#: single gap or run. Every site that expands a version-number-driven chain
+#: charges it against this cap, and chains that spell one gap together share
+#: it (see :func:`_decompose_dev0_gap` and :func:`_detect_wildcards_then_dev0`),
+#: so no gap ever materializes more than this many exclusions. Past the cap
+#: the recovery returns ``None`` rather than emit the unbounded chain a range
+#: such as ``==5.* | ==1000000.*`` would otherwise drive.
+_MAX_EXCLUSION_RUN = 128
+
 
 class _SetOp(enum.Enum):
     """The binary set operation ``_combine_literals`` resolves over ``===`` literals."""
@@ -713,19 +723,12 @@ def _detect_not_equal(
         and last.dev >= second.dev
         and last.__replace__(dev=second.dev) == second
     ):
-        if last.dev - second.dev + 1 > _MAX_EXCLUSION_RUN:
+        # ``first`` and the run spell this gap together, so they share the cap.
+        if last.dev - second.dev + 2 > _MAX_EXCLUSION_RUN:
             return None
         run = (second.__replace__(dev=d) for d in range(second.dev, last.dev + 1))
         return [first, *run]
     return None
-
-
-#: The most ``!=`` points a single recovered specifier set will materialize. A
-#: gap wider than this at one level (or, for :func:`_decompose_dev0_gap`, summed
-#: across levels) has no practical single-set form, so the recovery gives up
-#: rather than emit an unbounded chain such as ``==5.* | ==1000000.*`` would
-#: otherwise drive.
-_MAX_EXCLUSION_RUN = 128
 
 
 def _decompose_dev0_gap(
@@ -840,18 +843,23 @@ def _detect_wildcards_then_dev0(
     if left_upper_v.epoch != upper_dev0.epoch or left_upper_v >= upper_dev0:
         return None
 
+    # The prefixes and the dev run spell this gap together, so they share one
+    # ``_MAX_EXCLUSION_RUN`` budget rather than getting a full cap each.
+    run_length = upper.dev + 1
+    if run_length > _MAX_EXCLUSION_RUN:
+        return None
+
     # The chain ``[L.dev0, U.dev0)`` decomposes into the ``==P.*`` prefixes.
     prefixes = _decompose_dev0_gap(
         trim_release(left_upper_v.release),
         trim_release(upper_dev0.release),
         left_upper_v.epoch,
+        _MAX_EXCLUSION_RUN - run_length,
     )
     if prefixes is None:
         return None
 
-    if upper.dev + 1 > _MAX_EXCLUSION_RUN:
-        return None
-    run = [upper.__replace__(dev=d) for d in range(upper.dev + 1)]
+    run = [upper.__replace__(dev=d) for d in range(run_length)]
     return prefixes, run
 
 
@@ -895,17 +903,19 @@ def _encode_grouped(
 
     for next_lower, next_upper in bounds[1:]:
         # Classify the gap to the next interval: an ``!=`` exclusion keeps the
-        # group open, anything else closes it.
-        not_equal = _detect_not_equal(group_upper, next_lower)
-        not_equal_wildcards = _detect_not_equal_wildcards(group_upper, next_lower)
-        wildcards_then_dev0 = _detect_wildcards_then_dev0(group_upper, next_lower)
-
-        if not_equal is not None:
+        # group open, anything else closes it. The detectors run in priority
+        # order and short-circuit, so a plain ``!=V`` gap never pays for the
+        # budgeted sweep in ``_detect_wildcards_then_dev0``.
+        if (not_equal := _detect_not_equal(group_upper, next_lower)) is not None:
             exclusions.extend(f"!={point}" for point in not_equal)
-        elif not_equal_wildcards is not None:
-            exclusions.extend(f"!={prefix}.*" for prefix in not_equal_wildcards)
-        elif wildcards_then_dev0 is not None:
-            chain, run = wildcards_then_dev0
+        elif (
+            wildcards := _detect_not_equal_wildcards(group_upper, next_lower)
+        ) is not None:
+            exclusions.extend(f"!={prefix}.*" for prefix in wildcards)
+        elif (
+            chain_run := _detect_wildcards_then_dev0(group_upper, next_lower)
+        ) is not None:
+            chain, run = chain_run
             exclusions.extend(f"!={prefix}.*" for prefix in chain)
             exclusions.extend(f"!={point}" for point in run)
         else:
@@ -1785,13 +1795,14 @@ class VersionRange:
         PEP 440 has no syntax for the strict singleton ``{V}`` (an exclusive
         plain-version bound), a disjoint union of two or more intervals, or a
         partial pre-release opt-in region, so ranges built by set algebra often
-        return ``None``. A gap spanning a very large number of release families
-        returns ``None`` too, rather than a pathologically long ``!=`` chain;
-        reaching that takes either set algebra or a specifier set that already
-        spells the gap out with hundreds of contiguous ``!=N.*`` exclusions. An
-        empty range maps to ``SpecifierSet("<0")``, unless it still carries the
-        arbitrary-string flag (which no set reproduces), and a full range that
-        admits arbitrary strings maps to ``SpecifierSet("")``.
+        return ``None``. A gap that takes more than ``_MAX_EXCLUSION_RUN``
+        (128) contiguous ``!=`` exclusions to spell returns ``None`` too,
+        rather than a pathologically long chain; reaching that cap takes either
+        set algebra or a specifier set that already spells the gap out with
+        over a hundred contiguous ``!=N.*`` exclusions. An empty range maps to
+        ``SpecifierSet("<0")``, unless it still carries the arbitrary-string
+        flag (which no set reproduces), and a full range that admits arbitrary
+        strings maps to ``SpecifierSet("")``.
 
         A range built from a :class:`~packaging.specifiers.SpecifierSet`
         re-encodes, short of that exclusion cap. The result is the simplest
@@ -1804,6 +1815,14 @@ class VersionRange:
         and under a ``prereleases=False`` policy the result need only match self's
         releases, so ``(-inf, 3.14)`` recovers as the tighter ``<3.14`` rather
         than ``!=3.14,<=3.14``.
+
+        Each call encodes a handful of candidate spellings and keeps the
+        simplest one that verifies, where verifying means parsing the candidate
+        and round-tripping it through
+        :meth:`~packaging.specifiers.SpecifierSet.to_range`. The work grows
+        with the number of intervals and exclusions in the range, and the
+        result is not cached, so convert once and reuse the returned set rather
+        than converting per candidate version in a hot loop.
 
         >>> str(SpecifierSet(">=1.0,<2.0").to_range().to_specifier_set())
         '<2.0,>=1.0'

--- a/src/packaging/ranges.py
+++ b/src/packaging/ranges.py
@@ -65,7 +65,7 @@ UnparsedVersionVar = TypeVar("UnparsedVersionVar", bound=UnparsedVersion)
 #: that :meth:`VersionRange.to_specifier_set` will materialize to spell a
 #: single gap or run. Every site that expands a version-number-driven chain
 #: charges it against this cap, and chains that spell one gap together share
-#: it (see :func:`_decompose_dev0_gap` and :func:`_detect_wildcards_then_dev0`),
+#: it (see :func:`_decompose_dev0_gap` and :func:`_encode_gap`),
 #: so no gap ever materializes more than this many exclusions. Past the cap
 #: the recovery returns ``None`` rather than emit the unbounded chain a range
 #: such as ``==5.* | ==1000000.*`` would otherwise drive.
@@ -326,10 +326,10 @@ def _format_intervals(intervals: Sequence[Interval]) -> str:
 
 # ``to_specifier_set`` recovery: encode a range's interval list back into
 # specifier fragments. Each helper returns ``None`` when its shape has no
-# PEP 440 form. The ``prereleases`` argument threaded through is a spelling
-# mode, not a policy: ``None`` emits a prerelease-free form (no synthetic
-# ``.dev0``, so the recovered range has an empty opt-in region), ``True`` keeps
-# the ``.dev0`` markers (so the range opts its bounds in).
+# PEP 440 form. The ``keep_dev0`` argument threaded through is a spelling
+# mode, not a pre-release policy: false emits a prerelease-free form (no
+# synthetic ``.dev0``, so the recovered range has an empty opt-in region),
+# true keeps the ``.dev0`` markers (so the range opts its bounds in).
 # ``to_specifier_set`` encodes in both modes and keeps whichever round-trips.
 #
 # Bound and interval encoding: turn one interval's bounds into fragments.
@@ -350,7 +350,7 @@ def _clean_lower(version: Version) -> list[str] | None:
 
     Several ``[V`` lowers come from an operator whose own spelling carries no
     synthetic ``.dev0``. Recovering that spelling gives the range an empty opt-in
-    region, so it is offered in the ``prereleases is None`` spelling mode (see
+    region, so it is offered in the prerelease-free spelling mode (see
     :meth:`VersionRange.to_specifier_set`).
     """
     if version.dev != 0 or version.pre is not None or version.local is not None:
@@ -447,13 +447,13 @@ def _dev_family_anchor(family: Version) -> list[str] | None:
     return None
 
 
-def _encode_lower(lower: LowerBound, prereleases: bool | None) -> list[str] | None:
+def _encode_lower(lower: LowerBound, keep_dev0: bool) -> list[str] | None:
     """Encode a lower bound as specifier fragments, or ``None``.
 
     ``[]`` for ``-inf``. An ``AFTER_POSTS(V)`` lower is ``>V``. An
     ``AFTER_LOCALS(V)`` lower is the set ``[successor, ..)`` and emits ``>=V,!=V``,
-    except in the prerelease-free spelling mode (``prereleases`` is ``None``),
-    where it recovers a spelling with no synthetic ``.dev0`` when one exists:
+    except in the prerelease-free spelling mode (``keep_dev0`` false), where it
+    recovers a spelling with no synthetic ``.dev0`` when one exists:
     ``>3.8.post1`` for a post release, or a dev family's anchor plus the dev run
     up to V for a ``.dev`` release.
     """
@@ -473,7 +473,7 @@ def _encode_lower(lower: LowerBound, prereleases: bool | None) -> list[str] | No
         # An ``(AFTER_LOCALS(V), ..)`` lower is the set ``[successor, ..)``. In
         # the prerelease-free mode, recover a spelling with no synthetic ``.dev0``
         # so the range's opt-in region stays empty.
-        if prereleases is None:
+        if not keep_dev0:
             if inner.dev is not None:
                 # A ``.dev`` V makes ``[successor, ..)`` its dev family's
                 # prerelease-free anchor minus the finite dev run up to ``V``
@@ -505,20 +505,20 @@ def _encode_lower(lower: LowerBound, prereleases: bool | None) -> list[str] | No
         return None
 
     # In the prerelease-free mode a ``.dev0`` lower prefers its clean spelling.
-    if prereleases is None:
+    if not keep_dev0:
         clean = _clean_lower(lower_version)
         if clean is not None:
             return clean
     return [f">={lower_version}"]
 
 
-def _encode_upper(upper: UpperBound, prereleases: bool | None) -> list[str] | None:
+def _encode_upper(upper: UpperBound, keep_dev0: bool) -> list[str] | None:
     """Encode an upper bound as specifier fragments, or ``None``.
 
-    ``[]`` for ``+inf``. In the prerelease-free spelling mode (``prereleases`` is
-    ``None``) the ``<X`` spelling is used for the ``X.dev0`` upper that ``<X``
-    builds; in the ``True`` mode the synthetic ``.dev0`` is kept so the range
-    opts its bounds in.
+    ``[]`` for ``+inf``. In the prerelease-free spelling mode (``keep_dev0``
+    false) the ``<X`` spelling is used for the ``X.dev0`` upper that ``<X``
+    builds; otherwise the synthetic ``.dev0`` is kept so the range opts its
+    bounds in.
     """
     upper_version = upper.version
     if upper_version is None:
@@ -530,7 +530,7 @@ def _encode_upper(upper: UpperBound, prereleases: bool | None) -> list[str] | No
         if upper_version.kind == BoundaryKind.AFTER_LOCALS:
             inner = upper_version.version
             if (
-                prereleases is None
+                not keep_dev0
                 and inner.pre is None
                 and inner.post is not None
                 and inner.dev is None
@@ -557,7 +557,7 @@ def _encode_upper(upper: UpperBound, prereleases: bool | None) -> list[str] | No
             and upper_version.pre is None
             and upper_version.local is None
         ):
-            if prereleases is None:
+            if not keep_dev0:
                 return [f"<{upper_version.__replace__(dev=None)}"]
             return [f"<{upper_version}"]
         # ``V`` (exclusive) upper, including V's pre-releases.
@@ -600,7 +600,7 @@ def _detect_equal_wildcard(lower: LowerBound, upper: UpperBound) -> Version | No
 
 
 def _encode_interval(
-    lower: LowerBound, upper: UpperBound, prereleases: bool | None
+    lower: LowerBound, upper: UpperBound, keep_dev0: bool
 ) -> list[str] | None:
     """Encode one interval as specifier fragments, or ``None``.
 
@@ -639,7 +639,7 @@ def _encode_interval(
 
     # A ``[E!0.dev0`` lower has no prerelease-free ``>=`` spelling; within its own
     # family it is ``==E!0.*`` trimmed by the upper.
-    floor = _epoch_floor_lower(lower, upper) if prereleases is None else None
+    floor = _epoch_floor_lower(lower, upper) if not keep_dev0 else None
     if floor is not None:
         family, excluded_devs, upper_at_cap = floor
         if excluded_devs > _MAX_EXCLUSION_RUN:
@@ -649,25 +649,25 @@ def _encode_interval(
 
         # ``==E!0.*`` already caps at the next family; add the upper only if tighter.
         if not upper_at_cap:
-            upper_parts = _encode_upper(upper, prereleases)
+            upper_parts = _encode_upper(upper, keep_dev0)
             if upper_parts is None:
                 return None
             parts.extend(upper_parts)
 
         return parts
 
-    lower_parts = _encode_lower(lower, prereleases)
+    lower_parts = _encode_lower(lower, keep_dev0)
     if lower_parts is None:
         return None
 
-    upper_parts = _encode_upper(upper, prereleases)
+    upper_parts = _encode_upper(upper, keep_dev0)
     if upper_parts is None:
         return None
 
     return lower_parts + upper_parts
 
 
-# Gap detection: classify the gap between two adjacent intervals.
+# Gap encoding: spell the gap between two adjacent intervals as exclusions.
 
 
 def _detect_not_equal(
@@ -784,155 +784,91 @@ def _decompose_dev0_gap(
     return fragments + tail
 
 
-def _detect_not_equal_wildcards(
-    left_upper: UpperBound, right_lower: LowerBound
-) -> list[Version] | None:
-    """Decompose a ``[L.dev0, U.dev0)`` gap into a chain of ``!=P.*`` prefixes."""
-    left_upper_v = left_upper.version
-    right_lower_v = right_lower.version
+def _encode_gap(left_upper: UpperBound, right_lower: LowerBound) -> list[str] | None:
+    """Encode the gap between two adjacent intervals as ``!=`` fragments.
 
-    if not isinstance(left_upper_v, Version) or not isinstance(right_lower_v, Version):
-        return None
-    if left_upper.inclusive or not right_lower.inclusive:
-        return None
-    if not (_is_dev0_version(left_upper_v) and _is_dev0_version(right_lower_v)):
-        return None
-    if left_upper_v.epoch != right_lower_v.epoch:
-        return None
-
-    return _decompose_dev0_gap(
-        trim_release(left_upper_v.release),
-        trim_release(right_lower_v.release),
-        left_upper_v.epoch,
-    )
-
-
-def _detect_wildcards_then_dev0(
-    left_upper: UpperBound, right_lower: LowerBound
-) -> tuple[list[Version], list[Version]] | None:
-    """Split a ``[L.dev0, AFTER_LOCALS(U.dev(k))]`` gap into ``!=P.*`` + a dev run.
-
-    A leading ``!=U.dev0,...,!=U.dev(k)`` run sitting just above an excluded
-    ``!=family.*`` chain leaves the right interval at ``AFTER_LOCALS(U.dev(k))``:
-    one gap covers the wildcard families ``[L.dev0, U.dev0)`` and then a contiguous
-    dev run in U's own family. Returns the ``!=P.*`` chain prefixes and the
-    ``U.dev0..U.dev(k)`` run, or ``None``.
+    A point chain becomes ``!=V`` fragments and a dev0 family span becomes
+    ``!=P.*`` prefixes, followed by a leading dev run in the last family when
+    the gap ends inside it. Any other gap has no exclusion form and returns
+    ``None``.
     """
-    left_upper_v = left_upper.version
-    right_lower_v = right_lower.version
+    # Cheapest first: a plain ``!=V`` chain never pays for the budgeted
+    # wildcard sweep below.
+    points = _detect_not_equal(left_upper, right_lower)
+    if points is not None:
+        return [f"!={point}" for point in points]
 
-    # The gap runs from an exclusive ``L.dev0`` up to ``AFTER_LOCALS(U.dev(k))``.
-    if not isinstance(left_upper_v, Version):
-        return None
-    if not isinstance(right_lower_v, BoundaryVersion):
-        return None
-    if right_lower_v.kind != BoundaryKind.AFTER_LOCALS:
-        return None
-    if left_upper.inclusive or right_lower.inclusive:
+    # Both wildcard shapes start at an exclusive family base ``L.dev0``.
+    left_v = left_upper.version
+    if (
+        not isinstance(left_v, Version)
+        or left_upper.inclusive
+        or not _is_dev0_version(left_v)
+    ):
         return None
 
-    # ``L`` is a dev0 family base; ``U`` is a release base bearing a ``.dev`` run
-    # (``U.dev0`` for a single point, higher for a run), both in the same epoch.
+    right_v = right_lower.version
+    if isinstance(right_v, Version) and right_lower.inclusive:
+        # ``[L.dev0, U.dev0)`` is a pure ``!=P.*`` chain up to U's family.
+        upper_dev0 = right_v
+        run_length = 0
+        budget = _MAX_EXCLUSION_RUN
+    elif (
+        isinstance(right_v, BoundaryVersion)
+        and right_v.kind == BoundaryKind.AFTER_LOCALS
+        and not right_lower.inclusive
+    ):
+        # ``[L.dev0, AFTER_LOCALS(U.dev(k))]`` ends inside U's family: the
+        # ``!=P.*`` chain, then the ``U.dev0..U.dev(k)`` run. Both spell the
+        # gap together, so they share one ``_MAX_EXCLUSION_RUN`` budget.
+        upper = right_v.version
+        if upper.dev is None or upper.dev + 1 > _MAX_EXCLUSION_RUN:
+            return None
+        upper_dev0 = upper.__replace__(dev=0)
+        run_length = upper.dev + 1
+        budget = _MAX_EXCLUSION_RUN - run_length
+    else:
+        return None
+
+    # ``U`` must be a plain release base in L's epoch, above L.
     # ``_is_dev0_version`` on ``U.dev0`` rejects any pre/post/local on ``U``.
-    upper = right_lower_v.version
-    if upper.dev is None:
+    if not _is_dev0_version(upper_dev0):
         return None
-    upper_dev0 = upper.__replace__(dev=0)
-    if not (_is_dev0_version(left_upper_v) and _is_dev0_version(upper_dev0)):
-        return None
-    if left_upper_v.epoch != upper_dev0.epoch or left_upper_v >= upper_dev0:
+    if left_v.epoch != upper_dev0.epoch or left_v >= upper_dev0:
         return None
 
-    # The prefixes and the dev run spell this gap together, so they share one
-    # ``_MAX_EXCLUSION_RUN`` budget rather than getting a full cap each.
-    run_length = upper.dev + 1
-    if run_length > _MAX_EXCLUSION_RUN:
-        return None
-
-    # The chain ``[L.dev0, U.dev0)`` decomposes into the ``==P.*`` prefixes.
     prefixes = _decompose_dev0_gap(
-        trim_release(left_upper_v.release),
+        trim_release(left_v.release),
         trim_release(upper_dev0.release),
-        left_upper_v.epoch,
-        _MAX_EXCLUSION_RUN - run_length,
+        left_v.epoch,
+        budget,
     )
     if prefixes is None:
         return None
 
-    run = [upper.__replace__(dev=d) for d in range(run_length)]
-    return prefixes, run
+    exclusions = [f"!={prefix}.*" for prefix in prefixes]
+    exclusions.extend(f"!={upper_dev0.__replace__(dev=d)}" for d in range(run_length))
+    return exclusions
 
 
-# Group assembly: encode each group of intervals as one fragment list.
+def _encode_gaps(bounds: Sequence[Interval]) -> list[str] | None:
+    """Encode every between-interval gap as ``!=`` fragments, or ``None``.
 
-
-def _close_group(
-    group_lower: LowerBound,
-    group_upper: UpperBound,
-    exclusions: list[str],
-    prereleases: bool | None,
-) -> list[str] | None:
-    """Encode one accumulated group as specifier fragments, or ``None``.
-
-    A group is a single contiguous interval (its members joined through ``!=``
-    gaps), never a disjoint union: a multi-family dev0 span such as
-    ``[3.8.dev0, 3.14.dev0)`` is the contiguous ``>=3.8.dev0,<3.14``. Genuinely
-    disjoint families land in separate groups, which
-    :meth:`VersionRange.to_specifier_set` rejects by group count. The outer span
-    itself may still have no PEP 440 form, in which case this returns ``None``.
+    When each gap has an exclusion spelling, the intervals fuse into one
+    contiguous span (``==1.* | ==3.*`` is ``!=0.*,!=2.*,<4``): the outer
+    interval across all the bounds plus these exclusions. A gap with no
+    exclusion spelling makes the bounds a disjoint union, which no single
+    set expresses.
     """
-    outer = _encode_interval(group_lower, group_upper, prereleases)
-    if outer is None:
-        return None
-
-    return outer + exclusions
-
-
-def _encode_grouped(
-    bounds: list[Interval], prereleases: bool | None
-) -> list[list[str]] | None:
-    """Split bounds into disjoint groups, encoding each as fragments.
-
-    Consecutive intervals whose gap is an ``!=V`` / ``!=V+local`` / ``!=V.*``
-    exclusion stay in one group; any other gap starts a new group. Returns one
-    fragment list per group, or ``None`` if any group has no PEP 440 form.
-    """
-    groups: list[list[str]] = []
-    group_lower, group_upper = bounds[0]
     exclusions: list[str] = []
 
-    for next_lower, next_upper in bounds[1:]:
-        # Classify the gap to the next interval: an ``!=`` exclusion keeps the
-        # group open, anything else closes it. The detectors run in priority
-        # order and short-circuit, so a plain ``!=V`` gap never pays for the
-        # budgeted sweep in ``_detect_wildcards_then_dev0``.
-        if (not_equal := _detect_not_equal(group_upper, next_lower)) is not None:
-            exclusions.extend(f"!={point}" for point in not_equal)
-        elif (
-            wildcards := _detect_not_equal_wildcards(group_upper, next_lower)
-        ) is not None:
-            exclusions.extend(f"!={prefix}.*" for prefix in wildcards)
-        elif (
-            chain_run := _detect_wildcards_then_dev0(group_upper, next_lower)
-        ) is not None:
-            chain, run = chain_run
-            exclusions.extend(f"!={prefix}.*" for prefix in chain)
-            exclusions.extend(f"!={point}" for point in run)
-        else:
-            closed = _close_group(group_lower, group_upper, exclusions, prereleases)
-            if closed is None:
-                return None
-            groups.append(closed)
-            group_lower, exclusions = next_lower, []
+    for index in range(1, len(bounds)):
+        gap = _encode_gap(bounds[index - 1][1], bounds[index][0])
+        if gap is None:
+            return None
+        exclusions.extend(gap)
 
-        group_upper = next_upper
-
-    closed = _close_group(group_lower, group_upper, exclusions, prereleases)
-    if closed is None:
-        return None
-    groups.append(closed)
-
-    return groups
+    return exclusions
 
 
 def _tighten_no_prereleases(bounds: tuple[Interval, ...]) -> tuple[Interval, ...]:
@@ -1796,7 +1732,7 @@ class VersionRange:
         plain-version bound), a disjoint union of two or more intervals, or a
         partial pre-release opt-in region, so ranges built by set algebra often
         return ``None``. A gap that takes more than ``_MAX_EXCLUSION_RUN``
-        (128) contiguous ``!=`` exclusions to spell returns ``None`` too,
+        contiguous ``!=`` exclusions to spell returns ``None`` too,
         rather than a pathologically long chain; reaching that cap takes either
         set algebra or a specifier set that already spells the gap out with
         over a hundred contiguous ``!=N.*`` exclusions. An empty range maps to
@@ -1845,13 +1781,13 @@ class VersionRange:
             # rides along it.
             return SpecifierSet("<0", prereleases=configured)
 
-        admit_pieces = [f"==={literal}" for literal in sorted(self._admit)]
         if not self._bounds:
             # Pure ``===`` literals; only a single literal has a single-set form.
-            if len(admit_pieces) != 1:
+            if len(self._admit) != 1:
                 return None
-            bases = [admit_pieces[0]]
-        elif admit_pieces:
+            (literal,) = self._admit
+            bases = [f"==={literal}"]
+        elif self._admit:
             # Bounds plus literals cannot be one set.
             return None
         elif self._bounds == FULL_RANGE:
@@ -1869,13 +1805,27 @@ class VersionRange:
 
             # Encode each layout in both spelling modes: prerelease-free, then
             # keeping the synthetic ``.dev0`` markers. Which spelling reproduces
-            # self is settled by the round trip below, not up front.
+            # self is settled by the round trip below, not up front. The gap
+            # exclusions do not depend on the mode, so they encode once.
             bases = []
             for layout in layouts:
-                for mode in (None, True):
-                    groups = _encode_grouped(list(layout), mode)
-                    if groups is not None and len(groups) == 1:
-                        bases.append(",".join(groups[0]))
+                exclusions = _encode_gaps(layout)
+                if exclusions is None:
+                    continue
+
+                for keep_dev0 in (False, True):
+                    outer = _encode_interval(layout[0][0], layout[-1][1], keep_dev0)
+                    if outer is None:
+                        continue
+                    base = ",".join(outer + exclusions)
+                    if base not in bases:
+                        bases.append(base)
+
+        # A trailing no-op ``>=0.dev0`` floor restores a ``True`` opt-in that
+        # rode on a floor the clean encoding dropped (e.g. ``>=0.dev0,!=1.0``).
+        # It always recovers the whole bounds as the opt-in region, so it can
+        # only round-trip when self opts everything in.
+        add_floor = configured is None and self._pre_region == self._bounds
 
         # Keep the simplest candidate that recovers self. ``==`` compares bounds,
         # literals, and the opt-in region, so a candidate that would filter
@@ -1885,19 +1835,13 @@ class VersionRange:
         # unobservable), which admits the tightened spellings above.
         best: SpecifierSet | None = None
         best_key = (0, 0)
-        seen: set[str] = set()
 
         for base in bases:
-            # Offer each base with the no-op ``>=0.dev0`` floor too, which
-            # restores a ``True`` opt-in that rode on a floor the clean encoding
-            # dropped (e.g. ``>=0.dev0,!=1.0``).
-            floored = f"{base},>=0.dev0" if base else ">=0.dev0"
+            candidates = [base]
+            if add_floor:
+                candidates.append(f"{base},>=0.dev0" if base else ">=0.dev0")
 
-            for spec_str in (base, floored):
-                if spec_str in seen:
-                    continue
-                seen.add(spec_str)
-
+            for spec_str in candidates:
                 # Fewest fragments, then shortest string. Rank before the round
                 # trip so a candidate that cannot beat the best skips the check
                 # (its ``==`` and, under ``False``, two ``difference`` calls).

--- a/tests/property/strategies.py
+++ b/tests/property/strategies.py
@@ -239,14 +239,22 @@ def rich_specifier_sets(
     draw: st.DrawFn,
     *,
     include_arbitrary: bool = False,
+    vary_prereleases: bool = False,
 ) -> SpecifierSet:
-    """1-3 specifiers from :func:`pep440_specifier_strings`, joined."""
+    """1-3 specifiers from :func:`pep440_specifier_strings`, joined.
+
+    With ``vary_prereleases=True`` the configured pre-release policy is drawn
+    from ``(None, True, False)``; otherwise it is left as ``None`` (autodetect).
+    """
     num = draw(st.integers(min_value=1, max_value=3))
     parts = [
         draw(pep440_specifier_strings(include_arbitrary=include_arbitrary))
         for _ in range(num)
     ]
-    return SpecifierSet(",".join(parts))
+    prereleases = (
+        draw(st.sampled_from([None, True, False])) if vary_prereleases else None
+    )
+    return SpecifierSet(",".join(parts), prereleases=prereleases)
 
 
 @st.composite
@@ -265,3 +273,73 @@ def related_version_triple(
         return Version(f"{base}{pre or ''}{post or ''}{dev or ''}")
 
     return (_build(draw), _build(draw), _build(draw))
+
+
+# Bases for adjacency chains, one per family (final, post, dev, floor, epoch).
+_ADJACENCY_BASES = [
+    Version(v)
+    for v in (
+        "0",
+        "1.0",
+        "1.0.post0",
+        "3.8",
+        "1!0",
+        "0.dev0",
+        "1.0.dev0",
+        "1!0.dev0",
+        # Non-floor release-dev bases a ``!=W.*`` lead can abut (W just below).
+        "2.dev0",
+        "3.dev0",
+    )
+]
+
+# Leads: a lower bound, a release-family wildcard the run can sit inside, or a
+# ``!=W.*`` wildcard exclusion the dev run can abut (driving wildcard-then-dev-run).
+_ADJACENCY_LEADS = [
+    "",
+    ">=0.dev0",
+    ">=1.0",
+    ">=1.0.post0",
+    "==1.0.*",
+    "==1!0.*",
+    "==3.8.*",
+    "==0.*",
+    "!=0.*",
+    "!=1.*",
+    "!=2.*",
+]
+
+
+def _next_adjacent(version: Version) -> Version:
+    """The immediate successor of *version* and its local family.
+
+    Independent of the production ``least_version_above`` so the strategy does
+    not validate the encoder against itself: a dev release steps its dev; any
+    other release steps to its next post at ``.dev0`` (``.post0.dev0`` for a
+    final release, ``.post(N+1).dev0`` for a ``.postN`` release).
+    """
+    if version.dev is not None:
+        return version.__replace__(dev=version.dev + 1, local=None)
+    next_post = (version.post + 1) if version.post is not None else 0
+    return version.__replace__(post=next_post, dev=0, local=None)
+
+
+@st.composite
+def adjacency_exclusion_sets(draw: st.DrawFn) -> SpecifierSet:
+    """An optional lower/wildcard lead plus a run of adjacent exclusions.
+
+    Excluding a version and several of its immediate successors removes a
+    contiguous block whose canonical bounds are a single merged gap. When the
+    lead and base line up, this drives the ``to_specifier_set`` ``!=`` chain,
+    dev-run, wildcard-then-dev-run, and epoch floor-run recovery paths that the
+    independent specifier strategies never reach by chance.
+    """
+    base = draw(st.sampled_from(_ADJACENCY_BASES))
+    points = [base]
+    for _ in range(draw(st.integers(min_value=0, max_value=4))):
+        points.append(_next_adjacent(points[-1]))
+
+    lead = draw(st.sampled_from(_ADJACENCY_LEADS))
+    parts = ([lead] if lead else []) + [f"!={point}" for point in points]
+    prereleases = draw(st.sampled_from([None, True, False]))
+    return SpecifierSet(",".join(parts), prereleases=prereleases)

--- a/tests/property/test_ranges_cross_epoch.py
+++ b/tests/property/test_ranges_cross_epoch.py
@@ -6,7 +6,8 @@
 
 PEP 440 epochs partition the version order into disjoint cohorts; an
 ``==1.0`` predicate in epoch 0 never overlaps an ``==1.0`` predicate in
-epoch 1. The lattice laws still hold across cohorts.
+epoch 1. The lattice laws still hold across cohorts, and round-tripping
+through :meth:`to_specifier_set` must preserve the epoch on every side.
 """
 
 from __future__ import annotations
@@ -80,3 +81,32 @@ def test_membership_consistent_across_epochs(
     ra, rb = a.to_range(), b.to_range()
     assert (v in (ra & rb)) == ((v in ra) and (v in rb))
     assert (v in (ra | rb)) == ((v in ra) or (v in rb))
+
+
+@given(spec_set=rich_specifier_sets())
+@SETTINGS
+def test_single_set_round_trip_preserves_epoch(spec_set: SpecifierSet) -> None:
+    """``to_specifier_set`` round-trips epochs when the single-set form exists.
+
+    When the conversion returns a single set, feeding it back through
+    ``to_range`` must accept exactly the same versions; in particular any
+    cross-epoch boundary in the source survives.
+    """
+    r = spec_set.to_range()
+    converted = r.to_specifier_set()
+    if converted is None:
+        return
+    recovered = converted.to_range()
+    # Membership on a cross-epoch probe set must round-trip.
+    probes = [
+        "0.5",
+        "1.0",
+        "1.0a1",
+        "1!0.5",
+        "1!1.0",
+        "2!0.5",
+        "2!1.0",
+        "3!1.0",
+    ]
+    for probe in probes:
+        assert (probe in r) == (probe in recovered)

--- a/tests/property/test_ranges_to_specifier_set.py
+++ b/tests/property/test_ranges_to_specifier_set.py
@@ -1,0 +1,276 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+
+"""Property tests for ``VersionRange.to_specifier_set`` round-tripping.
+
+The conversion is partial (not every range is specifier-expressible).
+When it succeeds, the round trip equals the source: structurally, or (under a
+``prereleases=False`` policy) on the releases the policy leaves observable.
+``None`` is allowed; silent semantic drift is not.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from hypothesis import example, given
+
+from packaging.specifiers import SpecifierSet
+
+from .strategies import (
+    SETTINGS,
+    VERSION_POOL,
+    adjacency_exclusion_sets,
+    pep440_specifier_strings,
+    rich_specifier_sets,
+    specifier_sets,
+)
+
+if TYPE_CHECKING:
+    from packaging.ranges import VersionRange
+
+pytestmark = pytest.mark.property
+
+
+_FILTER_PROBES = [
+    "0.5a1",
+    "1.0",
+    "1.0a1",
+    "1.0.dev0",
+    "1.0.post1",
+    "1.5a1",
+    "1.5",
+    "2.0",
+    "1!1.0",
+    "0",
+]
+
+
+def _equivalent_round_trip(source: VersionRange, recovered: VersionRange) -> bool:
+    """A successful round trip matches the same versions as the source.
+
+    Whether the encoder keeps or drops the synthetic ``.dev0`` markers, the
+    recovered set's range equals the source, so equality is exact, except in two
+    cases. A range that is empty under its policy has no unique structural form
+    (e.g. ``===0.dev0`` with ``prereleases=False`` recovers as the canonical
+    ``<0``): any empty recovery is equivalent. And under ``prereleases=False``
+    the encoder may return a release-equivalent set with tighter bounds (``<3.14``
+    for ``(-inf, 3.14)``), which the policy makes indistinguishable.
+    """
+    if source.is_empty and recovered.is_empty:
+        return True
+    if source == recovered:
+        return True
+    return source._prereleases_configured is False and source._same_releases(recovered)
+
+
+@given(spec_set=specifier_sets(vary_prereleases=True))
+@SETTINGS
+def test_specifier_derived_ranges_always_have_a_specifier_set(
+    spec_set: SpecifierSet,
+) -> None:
+    """Specifier-derived ranges re-encode (incl. ``<0`` for empty).
+
+    The strategy stays well under the exclusion cap, so every drawn range has a
+    single-set form; only a set spelling out hundreds of contiguous exclusions
+    reaches the cap and returns ``None`` (see
+    ``test_specifier_set_exclusion_cap_returns_none`` in tests/test_ranges.py).
+    """
+    r = spec_set.to_range()
+    converted = r.to_specifier_set()
+    assert converted is not None, (
+        f"specifier-derived range {r!r} should always re-encode "
+        f"(input was {spec_set!r})"
+    )
+    assert _equivalent_round_trip(r, converted.to_range())
+
+
+@example(spec_set=SpecifierSet(">=3.8.dev0,<3.14", prereleases=True))
+@example(spec_set=SpecifierSet(">3.8.post1"))
+@example(spec_set=SpecifierSet("!=0.dev0"))
+@example(spec_set=SpecifierSet("==1!0.*,<=1!0"))
+@example(spec_set=SpecifierSet("!=1!0.dev0,==1!0.*"))
+# Canonicalization folds these so two adjacent exclusions share one gap, a
+# ``<pre.dev0`` upper becomes an inclusive AFTER_POSTS boundary, and the floor
+# run collapses to one interval; each must still re-encode.
+@example(spec_set=SpecifierSet("!=1.0,!=1.0.post0.dev0"))
+@example(spec_set=SpecifierSet("!=1!0,!=1!0.post0.dev0", prereleases=True))
+@example(spec_set=SpecifierSet("!=0.dev0,!=0.dev1"))
+@example(spec_set=SpecifierSet("<1.0a1.dev0"))
+# Adjacent exclusions can also collapse into the leading interval's lower; each
+# recovers by anchoring at the dev family's prerelease-free base.
+@example(spec_set=SpecifierSet(">=1.0,!=1.0,!=1.0.post0.dev0"))
+@example(spec_set=SpecifierSet("==1.0.*,!=1.0.dev0,!=1.0.dev1"))
+@example(spec_set=SpecifierSet("==1!0.*,!=1!0.dev0,!=1!0.dev1"))
+@example(spec_set=SpecifierSet("!=2.*,!=3.dev0,!=3.dev1"))
+@given(
+    spec_set=rich_specifier_sets(include_arbitrary=True, vary_prereleases=True),
+)
+@SETTINGS
+def test_rich_specifier_derived_ranges_always_have_a_specifier_set(
+    spec_set: SpecifierSet,
+) -> None:
+    """The full version-bearing PEP 440 surface re-encodes too.
+
+    The narrow :func:`specifier_sets` strategy only emits ``major.minor`` bounds,
+    so it never produced the ``.dev0`` / post-release / wildcard / epoch /
+    parseable ``===`` shapes whose recovery this exercises. Every specifier-derived
+    range the rich strategy builds has a single-set form, and the round trip is
+    structurally exact. A lone arbitrary (non-version) ``===`` string re-encodes
+    too, recovering as ``===string``; see ``test_arbitrary_literal_recovers_bare``
+    in tests/test_ranges.py.
+    """
+    r = spec_set.to_range()
+    converted = r.to_specifier_set()
+    assert converted is not None, (
+        f"specifier-derived range {r!r} should always re-encode "
+        f"(input was {spec_set!r})"
+    )
+    assert _equivalent_round_trip(r, converted.to_range())
+
+
+@given(spec_set=adjacency_exclusion_sets())
+@SETTINGS
+def test_adjacency_collapse_ranges_always_re_encode(spec_set: SpecifierSet) -> None:
+    """A version excluded with a run of its immediate successors merges into one
+    gap; the specifier-derived range still re-encodes and round-trips.
+
+    The independent strategies draw exclusions at random, so they essentially
+    never produce a contiguous successor run. This exercises the ``!=`` chain,
+    dev-run, wildcard-then-dev-run, and epoch floor-run recovery paths when the
+    drawn lead and base line up.
+    """
+    r = spec_set.to_range()
+    converted = r.to_specifier_set()
+    assert converted is not None, (
+        f"adjacency-collapse range {r!r} should always re-encode "
+        f"(input was {spec_set!r})"
+    )
+    assert _equivalent_round_trip(r, converted.to_range())
+
+
+def _conflicting_configured(a: SpecifierSet, b: SpecifierSet) -> bool:
+    """``VersionRange`` requires matching configured pre-release policies."""
+    return a._prereleases != b._prereleases
+
+
+@given(a=specifier_sets(vary_prereleases=True), b=specifier_sets(vary_prereleases=True))
+@SETTINGS
+def test_intersection_round_trips_when_not_none(
+    a: SpecifierSet, b: SpecifierSet
+) -> None:
+    """SpecifierSet is closed under intersection."""
+    if _conflicting_configured(a, b):
+        return
+    ra = a.to_range()
+    rb = b.to_range()
+    inter = ra & rb
+    converted = inter.to_specifier_set()
+    assert converted is not None
+    assert _equivalent_round_trip(inter, converted.to_range())
+
+
+@example(spec_set=SpecifierSet(">=2.3,<=2.7"))
+@given(spec_set=specifier_sets(vary_prereleases=True))
+@SETTINGS
+def test_complement_round_trips_or_returns_none(spec_set: SpecifierSet) -> None:
+    """The complement of a specifier-derived range is often not
+    specifier-expressible (e.g. ``~(>=1,<2)`` is two disjoint intervals).
+    Exercises the partial-conversion contract: ``to_specifier_set`` either
+    returns ``None`` or round-trips equivalently (structural under
+    autodetect / True, filter-equivalent under explicit False)."""
+    r = spec_set.to_range().complement()
+    converted = r.to_specifier_set()
+    if converted is not None:
+        assert _equivalent_round_trip(r, converted.to_range())
+
+
+@given(spec_string=pep440_specifier_strings(include_arbitrary=True))
+@SETTINGS
+def test_single_specifier_round_trips_when_encodable(spec_string: str) -> None:
+    """Single-specifier ranges round-trip exactly when
+    ``to_specifier_set`` returns a set.
+
+    The narrow round-trip tests above lift through ``to_range``, which folds
+    via ``intersect_ranges`` and silently canonicalizes the non-canonical
+    leading interval some single specifiers (e.g. ``!=0.dev0``) produce.
+    This property exercises the single-specifier entry point. Every single
+    specifier has ``_admit_arbitrary=False``, and the encoder preserves it,
+    so full equality holds.
+    """
+    r = SpecifierSet(spec_string).to_range()
+    converted = r.to_specifier_set()
+    if converted is not None:
+        assert converted.to_range() == r
+
+
+@given(
+    a=rich_specifier_sets(include_arbitrary=True),
+    b=rich_specifier_sets(include_arbitrary=True),
+)
+@SETTINGS
+def test_rich_algebra_round_trips_when_encodable(
+    a: SpecifierSet, b: SpecifierSet
+) -> None:
+    """Ranges built by set algebra over the rich strategy round-trip on
+    the version subset when ``to_specifier_set`` returns a set.
+
+    The narrow round-trip strategy never reaches the encoder paths that
+    handle ``!=V`` / ``!=V+local`` / ``!=V.*`` gaps, the ``==V+local``
+    singleton, or multi-group unions; this property does. Pre-release
+    policy tags can differ between the algebra result and its encoded
+    round trip (the encoder collapses configured-None vs autodetect), and
+    a ``MIN_VERSION`` lower bound canonicalizes to ``-inf``; both leave the
+    accepted version set unchanged, so compare on the version subset.
+
+    The complement variant ``~ra`` is split out into
+    :func:`test_rich_algebra_complement_round_trips_when_encodable`.
+    """
+    ra, rb = a.to_range(), b.to_range()
+    for r in (ra, ra & rb, ra | rb):
+        converted = r.to_specifier_set()
+        if converted is not None:
+            recovered = converted.to_range()
+            for v in VERSION_POOL:
+                assert (v in recovered) == (v in r)
+
+
+@example(spec_set=SpecifierSet(">=1.0,<=5.0"))
+@given(spec_set=rich_specifier_sets(include_arbitrary=True))
+@SETTINGS
+def test_rich_algebra_complement_round_trips_when_encodable(
+    spec_set: SpecifierSet,
+) -> None:
+    """``~r`` round-trips on the version subset when ``to_specifier_set``
+    returns a set. Same contract as
+    :func:`test_rich_algebra_round_trips_when_encodable` for the complement
+    operand the original property covered in its ``~ra`` loop iteration."""
+    r = spec_set.to_range().complement()
+    converted = r.to_specifier_set()
+    if converted is not None:
+        recovered = converted.to_range()
+        for v in VERSION_POOL:
+            assert (v in recovered) == (v in r)
+
+
+@given(spec_string=pep440_specifier_strings(include_arbitrary=True))
+@SETTINGS
+def test_round_trip_never_filter_drifts(spec_string: str) -> None:
+    """When ``to_specifier_set`` returns a set, it filters identically.
+
+    Guards the no-drift contract end-to-end: any time the encoder is willing
+    to emit a single set, the recovered set must accept the same versions
+    as the source range across a representative probe set. The
+    ``recovered.to_range() == self`` round trip in ``to_specifier_set`` is what
+    enforces this; the property is the observable contract.
+    """
+    r = SpecifierSet(spec_string).to_range()
+    for variant in (r, ~r):
+        converted = variant.to_specifier_set()
+        if converted is None:
+            continue
+        assert list(variant.filter(_FILTER_PROBES)) == list(
+            converted.filter(_FILTER_PROBES)
+        )

--- a/tests/test_ranges.py
+++ b/tests/test_ranges.py
@@ -1200,7 +1200,7 @@ class TestToSpecifierSet:
 
     def test_disjoint_none(self) -> None:
         # Two intervals split by a whole-interval gap (not a ``!=`` exclusion)
-        # are two groups, which have no single-set form.
+        # are a disjoint union, which has no single-set form.
         assert (vr(">=1,<2") | vr(">=4,<5")).to_specifier_set() is None
 
     def test_disjoint_wildcards_roundtrip(self) -> None:
@@ -1259,8 +1259,8 @@ class TestToSpecifierSet:
 
     def test_cross_epoch_dev_gap_none(self) -> None:
         # A dev-run gap whose family sits in another epoch is not a
-        # wildcard-plus-run shape; the detector bails and the union stays two
-        # groups with no single-set form.
+        # wildcard-plus-run shape; the gap has no exclusion spelling and the
+        # disjoint union has no single-set form.
         assert (vr("<1") | vr(">=1!0.dev1,!=1!0.dev1")).to_specifier_set() is None
 
     def test_recovery_caps_long_dev_runs(self) -> None:
@@ -2039,7 +2039,8 @@ class TestCoverageEdges:
         assert comp.to_specifier_set() is None
 
     def test_two_singletons_complement_no_form(self) -> None:
-        # Three intervals where a middle group fails to encode.
+        # The strict-point gaps have no ``!=`` spelling (``!=1.0`` would also
+        # drop 1.0's locals), so the three intervals cannot fuse.
         r = ~(VersionRange.singleton("1.0") | VersionRange.singleton("2.0"))
         assert Version("1.5") in r
         assert Version("1.0") not in r

--- a/tests/test_ranges.py
+++ b/tests/test_ranges.py
@@ -1060,8 +1060,488 @@ class TestEquality:
         assert "AFTER_POSTS" in repr(vr(">1.0"))
 
 
+class TestToSpecifierSet:
+    @pytest.mark.parametrize(
+        "spec",
+        [
+            ">=1.0,<2.0",
+            "!=1.5",
+            "==1.2.*",
+            ">=1.0",
+            "<2.0",
+            ">1.0",
+            "<=1.0",
+            "~=1.4.2",
+            "==1.0",
+            "==1.0+local",
+            "!=1.5+local",
+            "",
+            ">=1.0,<2.0,!=1.4,!=1.6",
+            # Pre-release-bearing bounds that once failed to re-encode: a
+            # ``.dev0`` lower, a post-release boundary, and a dev0 upper.
+            ">=3.8.dev0,<3.14",
+            ">3.8.post1",
+            "<3.8.post1",
+            ">=3.8,<3.14.dev0",
+            # Family-base lowers recovered as ``>=P,!=P.*`` / ``!=P.*``.
+            ">=3,!=3.*",
+            ">=3.8,!=3.8.*",
+            "!=0.*",
+            "!=0.0.*",
+            "!=0.dev0",
+            # An AFTER_LOCALS(dev0) lower and a wildcard-chain + dev0-point gap.
+            "!=3.8.dev0,==3.8.*",
+            "!=3.9.dev0,!=3.8.*",
+        ],
+    )
+    def test_roundtrip(self, spec: str) -> None:
+        r = vr(spec)
+        recovered = r.to_specifier_set()
+        assert recovered is not None
+        assert recovered.to_range() == r
+
+    def test_empty(self) -> None:
+        assert str(vr(">=2.0,<1.0").to_specifier_set()) == "<0"
+
+    def test_empty_range_recovers_as_canonical_empty(self) -> None:
+        # An empty range carries no opt-in region under clipping, so an empty
+        # range that named a pre-release (``>=1.0,<=1.0a1``) recovers as the
+        # canonical ``<0`` (the same members: none).
+        r = vr(">=1.0,<=1.0a1")
+        assert r.is_empty
+        assert r._pre_region == ()
+        recovered = r.to_specifier_set()
+        assert recovered is not None
+        assert str(recovered) == "<0"
+        assert recovered.to_range().is_empty
+
+    def test_full_arbitrary(self) -> None:
+        assert str(SpecifierSet("").to_range().to_specifier_set()) == ""
+
+    def test_full_no_arbitrary_none(self) -> None:
+        # The only full-bounds spelling ``>=0.dev0`` opts pre-releases in
+        # (whole-bounds region), but this range has an empty opt-in region, so
+        # no candidate round-trips.
+        assert VersionRange.full(admit_arbitrary=False).to_specifier_set() is None
+
+    def test_full_bounds_partial_region_none(self) -> None:
+        # ``>=1.0a1 | ~>=1.0a1`` widens to full bounds but keeps the opt-in
+        # region ``[1.0a1, +inf)``. No single SpecifierSet pairs full bounds with
+        # a partial region (a pre-release specifier also bounds the range), so it
+        # has no single-set form.
+        r = vr(">=1.0a1") | ~vr(">=1.0a1")
+        assert r._bounds == VersionRange.full()._bounds
+        assert r._pre_region
+        assert r._pre_region != r._bounds
+        assert r.to_specifier_set() is None
+
+    def test_full_configured_false(self) -> None:
+        # ">=0.dev0" (not ">=0"): the floor must stay so the recovered set still
+        # admits 0.dev0 under a prereleases=True override, matching the range.
+        r = VersionRange.full(admit_arbitrary=False, prereleases=False)
+        assert str(r.to_specifier_set()) == ">=0.dev0"
+
+    def test_arbitrary_literal(self) -> None:
+        assert str(vr("===wat").to_specifier_set()) == "===wat"
+
+    def test_multiple_arbitrary_none(self) -> None:
+        assert (vr("===a") | vr("===b")).to_specifier_set() is None
+
+    def test_bounds_plus_literal_none(self) -> None:
+        r = VersionRange.singleton("1.0") | vr("===garbage")
+        assert r.to_specifier_set() is None
+
+    def test_singleton_none(self) -> None:
+        assert VersionRange.singleton("1.5").to_specifier_set() is None
+
+    def test_equals_singleton_recovers_as_equals(self) -> None:
+        # ``[V, AFTER_LOCALS(V)]`` is the natural ``==V``, not ``>=V,<=V``.
+        assert str(vr("==1.0").to_specifier_set()) == "==1.0"
+        assert str(vr("==1!2.3").to_specifier_set()) == "==1!2.3"
+        assert str(vr("==1.0.post1").to_specifier_set()) == "==1.0.post1"
+        # A pre-release singleton keeps its opt-in and still compacts.
+        assert str(vr("==1.0a1").to_specifier_set()) == "==1.0a1"
+        # A local segment keeps the existing ``==V+local`` compaction.
+        assert str(vr("==1.0+local").to_specifier_set()) == "==1.0+local"
+
+    def test_false_policy_recovers_release_equivalent(self) -> None:
+        # ``~(>=3.14)`` is ``(-inf, 3.14)``, whose exclusive final upper admits
+        # 3.14's pre-releases at the bounds level. Under ``prereleases=False``
+        # those are excluded, so it recovers as the terser release-equivalent
+        # ``<3.14``; the recovered set accepts the same releases.
+        r = ~vr(">=3.14", prereleases=False)
+        recovered = r.to_specifier_set()
+        assert recovered is not None
+        assert str(recovered) == "<3.14"
+        assert r._same_releases(recovered.to_range())
+        # None / True keep pre-releases, so the tightening is not equivalent and
+        # the exact ``!=3.14,<=3.14`` form stands.
+        assert str((~vr(">=3.14")).to_specifier_set()) == "!=3.14,<=3.14"
+        true_recovered = (~vr(">=3.14", prereleases=True)).to_specifier_set()
+        assert str(true_recovered) == "!=3.14,<=3.14"
+
+    def test_false_policy_no_tightening_when_unbounded_above(self) -> None:
+        # ``~(==3.14+local)`` extends to +inf, so its last upper is not a final
+        # exclusive bound; nothing is tightened and the exact ``!=`` form stands.
+        r = ~vr("==3.14+local", prereleases=False)
+        recovered = r.to_specifier_set()
+        assert recovered is not None
+        assert str(recovered) == "!=3.14+local"
+        assert recovered.to_range() == r
+
+    def test_false_policy_disjoint_union_stays_none(self) -> None:
+        # A disjoint union under ``prereleases=False`` has no single-set form, the
+        # same as under None/True. Tightening only the last (here pre-release dev0)
+        # upper avoids snapping the inner ``5)`` into a ``.dev0`` gap, which would
+        # otherwise fabricate a long ``!=5.*,...,!=999.*`` chain.
+        r = vr("<=5,!=5", prereleases=False) | vr("==1000.*", prereleases=False)
+        assert len(r._bounds) == 2
+        assert r.to_specifier_set() is None
+
+    def test_disjoint_none(self) -> None:
+        # Two intervals split by a whole-interval gap (not a ``!=`` exclusion)
+        # are two groups, which have no single-set form.
+        assert (vr(">=1,<2") | vr(">=4,<5")).to_specifier_set() is None
+
+    def test_disjoint_wildcards_roundtrip(self) -> None:
+        # ``==1.* | ==3.*`` is one span with an ``!=2.*`` hole: !=0.*,!=2.*,<4.
+        r = vr("==1.*") | vr("==3.*")
+        recovered = r.to_specifier_set()
+        assert recovered is not None
+        assert recovered.to_range() == r
+        assert str(recovered) == "!=0.*,!=2.*,<4"
+
+    def test_wide_wildcard_gap_none(self) -> None:
+        # A far-apart wildcard union would decompose into one ``!=N.*`` per family
+        # in the gap. Past ``_MAX_EXCLUSION_RUN`` that has no practical single-set
+        # form, so it returns None instead of an unbounded chain.
+        r = vr("==5.*") | vr("==1000000.*")
+        assert len(r._bounds) == 2
+        assert r.to_specifier_set() is None
+        # The budget is the total across the recursion, so a chain that stays
+        # narrow at the top level but widens (or deepens) below is bounded too.
+        assert (vr("==5.*") | vr("==7.200.*")).to_specifier_set() is None
+        wide = vr("==0.*") | vr("==" + ".".join(["128"] * 100) + ".*")
+        assert wide.to_specifier_set() is None
+        # Each level also costs at least one, so a deep run of zero-span levels
+        # (a valid version with hundreds of trailing components) is bounded and
+        # returns None rather than recursing past the interpreter's stack limit.
+        deep = vr("==0.*") | vr("==1." + ".".join(["0"] * 400) + ".1.*")
+        assert deep.to_specifier_set() is None
+
+    def test_specifier_set_exclusion_cap_returns_none(self) -> None:
+        # A plain specifier set that spells out a long exclusion run reaches the
+        # same cap: past ``_MAX_EXCLUSION_RUN`` families the recovery gives up. So
+        # a specifier-derived range can return None without any set algebra.
+        def excl(n: int) -> str:
+            return ",".join(f"!={k}.*" for k in range(1, n + 1))
+
+        assert SpecifierSet(excl(128)).to_range().to_specifier_set() is not None
+        assert SpecifierSet(excl(129)).to_range().to_specifier_set() is None
+
+    def test_recovery_caps_long_dev_runs(self) -> None:
+        # A ``.dev`` run longer than ``_MAX_EXCLUSION_RUN`` also has no practical
+        # single-set form. The bound encoders keep the terse ``>=V,!=V`` spelling
+        # or return None rather than spell out a huge ``!=`` chain from a short
+        # input. The four run sites, driven by an attacker-controlled dev number:
+        anchor = vr(">=1.dev200,!=1.dev200").to_specifier_set()
+        assert str(anchor) == "!=1.dev200,>=1.dev200"
+        assert (
+            str(vr(">=1!0.dev200,!=1!0.dev200,<1!1").to_specifier_set())
+            == "!=1!0.dev200,<1!1.dev0,>=1!0.dev200"
+        )
+        assert (~vr(">=1.0,<=1.0.post0.dev200")).to_specifier_set() is None
+        assert (~vr(">=1.dev0,<=2.dev200")).to_specifier_set() is None
+
+    def test_reject_none(self) -> None:
+        assert (~vr("===1.0")).to_specifier_set() is None
+
+    def test_arbitrary_admitting_empty_none(self) -> None:
+        # ``~vr("")`` is the empty set still tagged arbitrary-admitting. No
+        # SpecifierSet reproduces that shape (the empty ``<0`` admits no
+        # strings), so it returns None rather than the usual empty ``<0``.
+        r = ~vr("")
+        assert r.is_empty
+        assert r.to_specifier_set() is None
+
+    def test_complement_gt_none(self) -> None:
+        # (-inf, AFTER_POSTS] inclusive upper has no specifier form.
+        assert (~vr(">1.0")).to_specifier_set() is None
+
+    def test_complement_closed_interval_none(self) -> None:
+        # ~(>=2.3,<=2.7) is two disjoint intervals, NOT a single ``!=2.3``;
+        # the gap spans the whole [2.3, 2.7] interval so there is no form.
+        r = ~vr(">=2.3,<=2.7")
+        assert r.to_specifier_set() is None
+        assert Version("2.5") not in r
+        assert Version("2.3") not in r
+        assert Version("2.8") in r
+        assert Version("2.0") in r
+
+    def test_whole_region_recovers_with_floor(self) -> None:
+        # Bounds ``[2.0, +inf)`` with the whole range opted in (inherited from the
+        # ``>=1.0a1`` operand). Clean ``>=2.0`` alone carries no opt-in, so the
+        # no-op ``>=0.dev0`` floor is added to force-admit the in-bounds pre-releases.
+        r = vr(">=1.0a1") & vr(">=2.0")
+        assert r._pre_region == r._bounds
+        recovered = r.to_specifier_set()
+        assert recovered is not None
+        assert recovered.to_range() == r
+        assert str(recovered) == ">=0.dev0,>=2.0"
+
+    def test_wildcard_with_exclusion(self) -> None:
+        r = vr("==1.*") & ~vr("==1.5.*")
+        recovered = r.to_specifier_set()
+        assert recovered is not None
+        assert recovered.to_range() == r
+
+    def test_explicit_policy_recovers(self) -> None:
+        # An explicit configured policy carries onto the recovered set, so a
+        # pre-release-naming range under ``prereleases=True`` still re-encodes.
+        r = vr(">=1.0a1,>=2.0", prereleases=True)
+        recovered = r.to_specifier_set()
+        assert recovered is not None
+
+    @pytest.mark.parametrize("prereleases", [None, True, False])
+    def test_dev0_span_roundtrips_every_policy(self, prereleases: bool | None) -> None:
+        # The reported regression: a ``.dev0`` lower with a wider-than-one-family
+        # span (``>=3.8.dev0,<3.14``) re-encodes under every pre-release policy.
+        r = vr(">=3.8.dev0,<3.14", prereleases=prereleases)
+        recovered = r.to_specifier_set()
+        assert recovered is not None
+        assert recovered.to_range() == r
+        assert str(recovered) == "<3.14.dev0,>=3.8.dev0"
+
+    @pytest.mark.parametrize(
+        ("spec", "expected"),
+        [
+            # Family-base ``.dev0`` lowers recover without a synthetic prerelease.
+            (">=3,!=3.*", "!=3.*,>=3"),
+            (">=3.8,!=3.8.*", "!=3.8.*,>=3.8"),
+            # At the floor the ``>=P`` half is redundant.
+            ("!=0.*", "!=0.*"),
+            ("!=0.0.*", "!=0.0.*"),
+            ("!=0.dev0", "!=0.dev0"),
+            # Post-release boundary and dev0 upper keep their clean spellings.
+            (">3.8.post1", ">3.8.post1"),
+            ("<3.8.post1", "<3.8.post1"),
+            # AFTER_LOCALS(dev0) lower, then a wildcard-chain + dev0-point gap.
+            ("!=3.8.dev0,==3.8.*", "!=3.7.*,!=3.8.dev0,<3.9,>=3.7"),
+            ("!=3.9.dev0,!=3.8.*", "!=3.8.*,!=3.9.dev0"),
+        ],
+    )
+    def test_prerelease_free_recovery_spelling(self, spec: str, expected: str) -> None:
+        # With an empty opt-in region the encoder must avoid a synthetic
+        # ``.dev0`` so the recovered set opts no pre-release in either.
+        recovered = vr(spec).to_specifier_set()
+        assert recovered is not None
+        assert str(recovered) == expected
+        assert recovered.to_range() == vr(spec)
+
+    def test_after_locals_final_lower_roundtrips(self) -> None:
+        # ``~(<=1.0)`` is ``(AFTER_LOCALS(1.0), +inf)``; a final-version
+        # AFTER_LOCALS lower has no clean family form, so it stays ``>=1.0,!=1.0``.
+        r = ~vr("<=1.0")
+        recovered = r.to_specifier_set()
+        assert recovered is not None
+        assert str(recovered) == "!=1.0,>=1.0"
+        assert recovered.to_range() == r
+
+    def test_literal_sibling_dev_recovers_bare(self) -> None:
+        # ``>=3.8.dev0,===3.8`` intersects to the bare literal ``{3.8}`` (empty
+        # bounds), which carries no opt-in region under clipping, so it recovers
+        # as the plain ``===3.8`` with no restoring floor.
+        r = vr(">=3.8.dev0,===3.8")
+        assert r._admit == {"3.8"}
+        assert r._pre_region == ()
+        recovered = r.to_specifier_set()
+        assert recovered is not None
+        assert str(recovered) == "===3.8"
+        assert recovered.to_range() == r
+
+    def test_epoch_base_dev0_lower_none(self) -> None:
+        # ``[1!0.dev0, +inf)`` has no prerelease-free family form (``1!0`` cannot
+        # decrement), and ``>=1!0.dev0`` would opt pre-releases in (a whole-bounds
+        # region) that this range does not, so it returns None.
+        r = ~vr("<1!0")
+        assert not r.is_empty
+        assert r.to_specifier_set() is None
+
+    def test_after_locals_final_lower_recovers(self) -> None:
+        # Canonicalization folds ``[3.8.post0.dev0, +inf)`` to
+        # ``(AFTER_LOCALS(3.8), +inf)``. A final-release AFTER_LOCALS lower has
+        # no clean ``>`` form, so it recovers as ``>=3.8,!=3.8``.
+        r = ~vr("<3.8.post0")
+        recovered = r.to_specifier_set()
+        assert recovered is not None
+        assert str(recovered) == "!=3.8,>=3.8"
+        assert recovered.to_range() == r
+
+    def test_undecomposable_chain_before_dev0_point_none(self) -> None:
+        # The gap before ``AFTER_LOCALS(1.3.dev0)`` starts at ``1.2.3.dev0``,
+        # whose wildcard chain to ``1.3.dev0`` is undecomposable, so the
+        # combined chain + ``!=1.3.dev0`` gap has no form.
+        r = ~vr(">=1.2.3.dev0,<=1.3.dev0")
+        assert not r.is_empty
+        assert r.to_specifier_set() is None
+
+    @pytest.mark.parametrize(
+        ("spec", "expected"),
+        [
+            # The epoch-zero family floor: 1!0.dev0 has no >=P,!=P.* spelling, so
+            # within its family it recovers as ==1!0.* trimmed by the upper.
+            ("==1!0.*,<=1!0", "<=1!0,==1!0.*"),
+            ("==1!0.*,<1!0.5", "<1!0.5,==1!0.*"),
+            ("==2!0.*,<=2!0", "<=2!0,==2!0.*"),
+            ("==1!0.0.*,<=1!0.0", "<=1!0.0,==1!0.*"),
+            # An AFTER_LOCALS(1!0.dev0) lower drops 1!0.dev0 from the family.
+            ("!=1!0.dev0,==1!0.*", "!=1!0.dev0,==1!0.*"),
+        ],
+    )
+    def test_epoch_zero_family_floor_roundtrips(self, spec: str, expected: str) -> None:
+        recovered = vr(spec).to_specifier_set()
+        assert recovered is not None
+        assert str(recovered) == expected
+        assert recovered.to_range() == vr(spec)
+
+    def test_arbitrary_literal_recovers_bare(self) -> None:
+        # ``{abc}`` (an arbitrary ``===`` string) carries no opt-in region under
+        # clipping, so it recovers as the plain ``===abc``, with no restoring
+        # floor to reject the non-version string.
+        r = (vr("===abc") & vr(">=1.0a1")) | vr("===abc")
+        assert "abc" in r
+        assert r._pre_region == ()
+        recovered = r.to_specifier_set()
+        assert recovered is not None
+        assert str(recovered) == "===abc"
+        assert recovered.to_range() == r
+
+    def test_epoch_dev0_with_post_is_not_a_family_floor(self) -> None:
+        # 1!0.post1.dev0 is an epoch-zero release with a post, not the family
+        # floor, so it recovers through the post-release path, not ==1!0.*.
+        r = ~vr("<1!0.post1")
+        recovered = r.to_specifier_set()
+        assert recovered is not None
+        assert str(recovered) == ">1!0.post0"
+        assert recovered.to_range() == r
+
+    def test_epoch_floor_unencodable_upper_none(self) -> None:
+        # An epoch-floor lower inside its family, but the upper is an inclusive
+        # AFTER_POSTS boundary with no specifier form.
+        r = vr("==1!0.*") & ~vr(">1!0.5")
+        assert not r.is_empty
+        assert r.to_specifier_set() is None
+
+    def test_adjacent_not_equal_chain_roundtrips(self) -> None:
+        # Two adjacent exclusions (V and its immediate successor) share one gap
+        # that recovers as the ``!=`` chain.
+        r = vr("!=1.0,!=1.0.post0.dev0")
+        recovered = r.to_specifier_set()
+        assert recovered is not None
+        assert str(recovered) == "!=1.0,!=1.0.post0.dev0"
+        assert recovered.to_range() == r
+
+    def test_long_not_equal_chain_roundtrips(self) -> None:
+        # Three adjacent exclusions collapse to one gap spanning a dev run.
+        r = vr(">=0.dev0,!=1.0,!=1.0.post0.dev0,!=1.0.post0.dev1")
+        recovered = r.to_specifier_set()
+        assert recovered is not None
+        assert recovered.to_range() == r
+
+    def test_floor_dev_run_roundtrips(self) -> None:
+        # ``!=0.dev0,!=0.dev1`` excludes the two least versions, leaving the lone
+        # ``(AFTER_LOCALS(0.dev1), +inf)`` interval, which recovers the floor run.
+        r = vr("!=0.dev0,!=0.dev1")
+        recovered = r.to_specifier_set()
+        assert recovered is not None
+        assert str(recovered) == "!=0.dev0,!=0.dev1"
+        assert recovered.to_range() == r
+
+    def test_after_posts_inclusive_upper_roundtrips(self) -> None:
+        # ``<1.0a1.dev0`` folds to an inclusive ``AFTER_POSTS(1.0a0)]`` upper,
+        # which recovers as ``<`` its least successor.
+        r = vr("<1.0a1.dev0")
+        recovered = r.to_specifier_set()
+        assert recovered is not None
+        assert str(recovered) == "<1.0a1.dev0"
+        assert recovered.to_range() == r
+
+    def test_final_after_posts_left_upper_none(self) -> None:
+        # A two-interval range whose left interval ends at an inclusive final
+        # ``AFTER_POSTS(1.0)]`` upper names no single point, so the gap is not a
+        # ``!=`` chain and the disjoint union has no specifier form.
+        r = ~vr(">1.0") | ~vr("<2.0")
+        assert len(r._bounds) == 2
+        assert r.to_specifier_set() is None
+
+    def test_epoch_prerelease_singleton_no_opt_in_none(self) -> None:
+        # ``~(!=1!0a0.dev0)`` holds just ``1!0a0.dev0`` and its locals, which
+        # ``==1!0a0.dev0`` also spells, but that spelling opts the pre-release in
+        # (whole-bounds region) while this range carries no opt-in, so None.
+        r = ~vr("!=1!0a0.dev0")
+        assert not r.is_empty
+        assert r._pre_region == ()
+        assert r.to_specifier_set() is None
+
+    def test_leading_interval_post_dev_collapse_recovers(self) -> None:
+        # Adjacent exclusions collapse into the leading interval's lower
+        # (``(AFTER_LOCALS(1.0.post0.dev0), +inf)``). Anchoring at the
+        # prerelease-free base 1.0 recovers ``>=1.0,!=1.0,!=1.0.post0.dev0``.
+        r = vr(">=1.0,!=1.0,!=1.0.post0.dev0")
+        recovered = r.to_specifier_set()
+        assert recovered is not None
+        assert str(recovered) == "!=1.0,!=1.0.post0.dev0,>=1.0"
+        assert recovered.to_range() == r
+
+    def test_release_base_dev_floor_recovers(self) -> None:
+        # ``==1.0.*`` minus its two least dev releases leaves an
+        # ``AFTER_LOCALS(1.0.dev1)`` lower, recovered via the ``!=0.*`` family
+        # floor plus the dev run.
+        r = vr("==1.0.*,!=1.0.dev0,!=1.0.dev1")
+        recovered = r.to_specifier_set()
+        assert recovered is not None
+        assert str(recovered) == "!=0.*,!=1.0.dev0,!=1.0.dev1,<1.1"
+        assert recovered.to_range() == r
+
+    def test_epoch_floor_dev_run_recovers(self) -> None:
+        # An epoch>0 zero-family floor with a leading dev run recovers as
+        # ``==1!0.*`` plus the excluded dev releases.
+        r = vr("==1!0.*,!=1!0.dev0,!=1!0.dev1")
+        recovered = r.to_specifier_set()
+        assert recovered is not None
+        assert str(recovered) == "!=1!0.dev0,!=1!0.dev1,==1!0.*"
+        assert recovered.to_range() == r
+
+    def test_wildcard_then_adjacent_dev_run_roundtrips(self) -> None:
+        # A wildcard exclusion abutting a dev run of length 2+ shares one gap:
+        # the ``!=2.*`` family and then ``3.dev0,3.dev1`` in 3's own family.
+        r = vr("!=2.*,!=3.dev0,!=3.dev1")
+        recovered = r.to_specifier_set()
+        assert recovered is not None
+        assert str(recovered) == "!=2.*,!=3.dev0,!=3.dev1"
+        assert recovered.to_range() == r
+
+    def test_prerelease_dev_singleton_no_opt_in_none(self) -> None:
+        # ``~(!=1.0a1.dev1)`` is the singleton ``{1.0a1.dev1}`` with no opt-in
+        # region; every spelling of a pre-release singleton opts it in, so None.
+        r = ~vr("!=1.0a1.dev1")
+        assert not r.is_empty
+        assert r._pre_region == ()
+        assert r.to_specifier_set() is None
+
+    def test_epoch_prerelease_floor_lower_declines_family_form(self) -> None:
+        # An epoch>0 floor lower that names a pre-release (``1!0a0.dev0``) has no
+        # ``==1!0.*`` family form, so the encoder falls back to the generic
+        # ``>=,<`` spelling.
+        r = vr(">=1!0a0.dev0,<1!5")
+        recovered = r.to_specifier_set()
+        assert recovered is not None
+        assert str(recovered) == "<1!5,>=1!0a0.dev0"
+        assert recovered.to_range() == r
+
+
 # Boundary-sensitive specs and versions exercising the union / complement /
-# empty-check edge branches deterministically.
+# empty-check / encoder edge branches deterministically.
 _GRID_SPECS = [
     "",
     ">=1.0,<2.0",
@@ -1160,6 +1640,27 @@ class TestAlgebraInvariants:
                 ab = a | b
                 for v in _GRID_VERSION_OBJS:
                     assert (v in ab) == ((v in a) or (v in b)), (a, b, v)
+
+    def test_to_specifier_set_roundtrips(self) -> None:
+        for r in _GRID_RANGES:
+            recovered = r.to_specifier_set()
+            if recovered is not None:
+                assert self._same_versions(recovered.to_range(), r), r
+
+    def test_complement_to_specifier_set_roundtrips(self) -> None:
+        for r in _GRID_RANGES:
+            comp = ~r
+            recovered = comp.to_specifier_set()
+            if recovered is not None:
+                assert self._same_versions(recovered.to_range(), comp), comp
+
+    def test_union_to_specifier_set_roundtrips(self) -> None:
+        for a in _GRID_RANGES:
+            for b in _GRID_RANGES:
+                ab = a | b
+                recovered = ab.to_specifier_set()
+                if recovered is not None:
+                    assert self._same_versions(recovered.to_range(), ab), ab
 
 
 class TestSyntheticEmptyGaps:
@@ -1362,6 +1863,47 @@ class TestCoverageEdges:
     def test_contains_literal_nonprerelease_false_policy(self) -> None:
         assert vr("===1.0", prereleases=False).contains("1.0")
 
+    def test_multi_wildcard_adjacent_roundtrips(self) -> None:
+        # ==2.0.* adjoins ==1.* (both touch 2.dev0), so the union is the single
+        # contiguous span [1.dev0, 2.1.dev0), recovered as !=0.*,<2.1.
+        r = vr("==1.*") | vr("==2.0.*")
+        recovered = r.to_specifier_set()
+        assert recovered is not None
+        assert recovered.to_range() == r
+        assert str(recovered) == "!=0.*,<2.1"
+
+    def test_multi_wildcard_with_exclusion_roundtrips(self) -> None:
+        # The span [1.dev0, 3.dev0) minus the 1.5 family is one set: !=0.*,!=1.5,<3.
+        r = (vr("==1.*") | vr("==2.*")) & ~vr("==1.5")
+        assert Version("1.5") not in r
+        assert Version("1.4") in r
+        assert Version("2.5") in r
+        recovered = r.to_specifier_set()
+        assert recovered is not None
+        assert recovered.to_range() == r
+        assert str(recovered) == "!=0.*,!=1.5,<3"
+
+    def test_multi_wildcard_wildcard_exclusion_roundtrips(self) -> None:
+        # A ``==V.*`` outer with several ``!=P.*`` holes (including nested
+        # ``1.0.1.*`` / ``1.3.1.*``) re-encodes to a single set.
+        r = vr("==1.*,!=1.0.1.*,!=1.3.1.*,!=1.2.*")
+        assert Version("1.0.0") in r
+        assert Version("1.0.1") not in r
+        assert Version("1.2.5") not in r
+        assert Version("1.3.1") not in r
+        assert Version("1.4") in r
+        recovered = r.to_specifier_set()
+        assert recovered is not None
+        assert recovered.to_range() == r
+
+    def test_not_equal_local_gap(self) -> None:
+        r = vr("!=1.0+local")
+        assert Version("1.0+local") not in r
+        assert Version("1.0") in r
+        recovered = r.to_specifier_set()
+        assert recovered is not None
+        assert recovered.to_range() == r
+
     def test_after_posts_boundary_total_order_consistent(self) -> None:
         # ``AFTER_POSTS(1.0)`` and ``AFTER_POSTS(1.0.post1)`` mark the same point
         # on the version line, so equality must agree with the ordering:
@@ -1386,6 +1928,28 @@ class TestCoverageEdges:
         assert Version("1.0.dev0") in r
         assert Version("1.1") not in r
 
+    def test_encode_interval_undecomposable_dev0(self) -> None:
+        # [1.2.dev0, 3.dev0): not a clean wildcard family, falls through to the
+        # plain bounds encoding.
+        r = vr(">=1.2.dev0,<3")
+        recovered = r.to_specifier_set()
+        assert recovered is not None
+        assert recovered.to_range() == r
+
+    def test_wildcard_chain_cross_epoch_gap(self) -> None:
+        # !=V.* gap between two different-epoch wildcard families.
+        r = vr("==1!1.*") | vr("==2!1.*")
+        assert Version("1!1.5") in r
+        assert Version("2!1.5") in r
+        assert r.to_specifier_set() is None
+
+    def test_equal_wildcard_cross_epoch_interval(self) -> None:
+        # A single interval spanning two epochs is not a wildcard family.
+        r = vr(">=1!1.dev0,<2!1")
+        recovered = r.to_specifier_set()
+        assert recovered is not None
+        assert recovered.to_range() == r
+
     def test_double_complement_min_boundary(self) -> None:
         # >=0.dev0 is already canonicalized to the full range at construction,
         # so ~~ round-trips it (full -> empty -> full).
@@ -1393,6 +1957,23 @@ class TestCoverageEdges:
         comp2 = ~~r
         for v in ["0.dev0", "0", "1.0", "2!1.0"]:
             assert (Version(v) in comp2) == (Version(v) in r)
+
+    def test_configured_false_lower_keeps_dev0(self) -> None:
+        # Under configured False the recovered set keeps the synthetic .dev0 so
+        # it matches the range under a prereleases=True override (no stripping).
+        r = ~vr("<1.5", prereleases=False)
+        recovered = r.to_specifier_set()
+        assert recovered is not None
+        assert recovered.to_range() == r
+        assert r.contains("1.5a1", prereleases=True) == recovered.contains(
+            "1.5a1", prereleases=True
+        )
+
+    def test_configured_false_upper_keeps_dev0(self) -> None:
+        r = ~vr(">1.0.post1", prereleases=False)
+        recovered = r.to_specifier_set()
+        assert recovered is not None
+        assert recovered.to_range() == r
 
     def test_sub_minimum_union(self) -> None:
         # Union touching the 0.dev0 floor exercises the sub-minimum empty check.
@@ -1425,6 +2006,26 @@ class TestCoverageEdges:
         assert list(a.filter(["1.0.dev1", "0.9"])) == ["0.9"]
         assert list(b.filter(["1.0.dev1", "0.9"])) == ["1.0.dev1", "0.9"]
 
+    def test_strict_singleton_complement_no_form(self) -> None:
+        # ~singleton has an exclusive plain-version lower with no specifier form.
+        comp = ~VersionRange.singleton("1.0")
+        assert Version("1.0") not in comp
+        assert Version("2.0") in comp
+        assert comp.to_specifier_set() is None
+
+    def test_two_singletons_complement_no_form(self) -> None:
+        # Three intervals where a middle group fails to encode.
+        r = ~(VersionRange.singleton("1.0") | VersionRange.singleton("2.0"))
+        assert Version("1.5") in r
+        assert Version("1.0") not in r
+        assert r.to_specifier_set() is None
+
+    def test_configured_false_multi_bound_roundtrip(self) -> None:
+        r = vr(">=1.5,<3", prereleases=False)
+        recovered = r.to_specifier_set()
+        assert recovered is not None
+        assert recovered.to_range() == r
+
     def test_ge_floor_is_canonical_full(self) -> None:
         # >=0.dev0 admits every version, so its bounds canonicalize to the full
         # range (its complement is empty). It still carries an opt-in region from
@@ -1447,6 +2048,7 @@ class TestCoverageEdges:
         assert not r.is_empty
         assert Version("0.dev0") not in r
         assert Version("1.0") in r
+        assert r.to_specifier_set() is None
 
     def test_eq_ranges_filter_identically(self) -> None:
         # Two ranges with identical bounds but a different opt-in region must NOT
@@ -1513,3 +2115,9 @@ class TestCoverageEdges:
     def test_filter_admission_prerelease_after_final(self) -> None:
         r = vr(">=1.0") | vr("===wat")
         assert list(r.filter(["1.5", "2.5a1"])) == ["1.5"]
+
+    def test_configured_false_le_roundtrip(self) -> None:
+        r = vr("<=1.0", prereleases=False)
+        recovered = r.to_specifier_set()
+        assert recovered is not None
+        assert recovered.to_range() == r

--- a/tests/test_ranges.py
+++ b/tests/test_ranges.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import pytest
 
 from packaging._ranges import BoundaryKind, BoundaryVersion
-from packaging.ranges import VersionRange
+from packaging.ranges import _MAX_EXCLUSION_RUN, VersionRange
 from packaging.specifiers import SpecifierSet
 from packaging.version import InvalidVersion, Version
 
@@ -1221,7 +1221,7 @@ class TestToSpecifierSet:
         # The budget is the total across the recursion, so a chain that stays
         # narrow at the top level but widens (or deepens) below is bounded too.
         assert (vr("==5.*") | vr("==7.200.*")).to_specifier_set() is None
-        wide = vr("==0.*") | vr("==" + ".".join(["128"] * 100) + ".*")
+        wide = vr("==0.*") | vr("==" + ".".join(["99"] * 100) + ".*")
         assert wide.to_specifier_set() is None
         # Each level also costs at least one, so a deep run of zero-span levels
         # (a valid version with hundreds of trailing components) is bounded and
@@ -1236,22 +1236,47 @@ class TestToSpecifierSet:
         def excl(n: int) -> str:
             return ",".join(f"!={k}.*" for k in range(1, n + 1))
 
-        assert SpecifierSet(excl(128)).to_range().to_specifier_set() is not None
-        assert SpecifierSet(excl(129)).to_range().to_specifier_set() is None
+        at_cap = SpecifierSet(excl(_MAX_EXCLUSION_RUN)).to_range()
+        assert at_cap.to_specifier_set() is not None
+        over_cap = SpecifierSet(excl(_MAX_EXCLUSION_RUN + 1)).to_range()
+        assert over_cap.to_specifier_set() is None
+
+    def test_wildcards_then_dev_run_share_cap(self) -> None:
+        # A gap spelled by a ``!=P.*`` chain plus a trailing dev run charges
+        # both against one budget, so the pair caps at ``_MAX_EXCLUSION_RUN``
+        # total rather than getting a full cap each.
+        run = _MAX_EXCLUSION_RUN // 2
+
+        def spec(families: int) -> SpecifierSet:
+            prefixes = [f"!={k}.*" for k in range(1, families + 1)]
+            devs = [f"!={families + 1}.dev{d}" for d in range(run)]
+            return SpecifierSet(",".join(prefixes + devs))
+
+        at_cap = spec(_MAX_EXCLUSION_RUN - run).to_range()
+        assert at_cap.to_specifier_set() is not None
+        over_cap = spec(_MAX_EXCLUSION_RUN - run + 1).to_range()
+        assert over_cap.to_specifier_set() is None
+
+    def test_cross_epoch_dev_gap_none(self) -> None:
+        # A dev-run gap whose family sits in another epoch is not a
+        # wildcard-plus-run shape; the detector bails and the union stays two
+        # groups with no single-set form.
+        assert (vr("<1") | vr(">=1!0.dev1,!=1!0.dev1")).to_specifier_set() is None
 
     def test_recovery_caps_long_dev_runs(self) -> None:
         # A ``.dev`` run longer than ``_MAX_EXCLUSION_RUN`` also has no practical
         # single-set form. The bound encoders keep the terse ``>=V,!=V`` spelling
         # or return None rather than spell out a huge ``!=`` chain from a short
         # input. The four run sites, driven by an attacker-controlled dev number:
-        anchor = vr(">=1.dev200,!=1.dev200").to_specifier_set()
-        assert str(anchor) == "!=1.dev200,>=1.dev200"
+        dev = _MAX_EXCLUSION_RUN
+        anchor = vr(f">=1.dev{dev},!=1.dev{dev}").to_specifier_set()
+        assert str(anchor) == f"!=1.dev{dev},>=1.dev{dev}"
         assert (
-            str(vr(">=1!0.dev200,!=1!0.dev200,<1!1").to_specifier_set())
-            == "!=1!0.dev200,<1!1.dev0,>=1!0.dev200"
+            str(vr(f">=1!0.dev{dev},!=1!0.dev{dev},<1!1").to_specifier_set())
+            == f"!=1!0.dev{dev},<1!1.dev0,>=1!0.dev{dev}"
         )
-        assert (~vr(">=1.0,<=1.0.post0.dev200")).to_specifier_set() is None
-        assert (~vr(">=1.dev0,<=2.dev200")).to_specifier_set() is None
+        assert (~vr(f">=1.0,<=1.0.post0.dev{dev}")).to_specifier_set() is None
+        assert (~vr(f">=1.dev0,<=2.dev{dev}")).to_specifier_set() is None
 
     def test_reject_none(self) -> None:
         assert (~vr("===1.0")).to_specifier_set() is None

--- a/tests/test_ranges.py
+++ b/tests/test_ranges.py
@@ -8,7 +8,7 @@ import pytest
 
 from packaging._ranges import BoundaryKind, BoundaryVersion
 from packaging.ranges import _MAX_EXCLUSION_RUN, VersionRange
-from packaging.specifiers import SpecifierSet
+from packaging.specifiers import Specifier, SpecifierSet
 from packaging.version import InvalidVersion, Version
 
 
@@ -1146,6 +1146,13 @@ class TestToSpecifierSet:
 
     def test_multiple_arbitrary_none(self) -> None:
         assert (vr("===a") | vr("===b")).to_specifier_set() is None
+
+    def test_arbitrary_literal_with_comma_none(self) -> None:
+        # A ``===`` literal may hold a comma (its arbitrary version excludes only
+        # whitespace, ``;`` and ``)``), which the set string splits on, so it has
+        # no single specifier-set spelling. It must return ``None``, not raise.
+        r = SpecifierSet([Specifier("===a,b")]).to_range()
+        assert r.to_specifier_set() is None
 
     def test_bounds_plus_literal_none(self) -> None:
         r = VersionRange.singleton("1.0") | vr("===garbage")

--- a/tests/test_specifiers.py
+++ b/tests/test_specifiers.py
@@ -3522,6 +3522,7 @@ _EQUIV_SPECS = [
     "!=1.4,!=1.6",
     ">=1.0,<2.0,!=1.2.*",
     "==1.0,!=1.0",
+    "<=1.0,!=1.0",
     ">=2.0,<1.0",
     "<0",
 ]
@@ -3592,6 +3593,43 @@ class TestSpecifierSetToRangeEquivalence:
             assert list(spec_set.filter(_EQUIV_ITEMS, prereleases=prereleases)) == list(
                 version_range.filter(_EQUIV_ITEMS, prereleases=prereleases)
             ), (spec_str, prereleases)
+
+    @pytest.mark.parametrize("spec_str", _EQUIV_SPECS)
+    @pytest.mark.parametrize("configured", [None, True, False])
+    def test_to_specifier_set_roundtrip_matches(
+        self, spec_str: str, configured: bool | None
+    ) -> None:
+        # When to_specifier_set() returns a non-None set, that set matches the
+        # same versions as the range. Under a None/True policy the recovery is an
+        # exact round trip, so it matches under every prereleases/installed
+        # override. A configured False policy admits no pre-releases, so its
+        # recovery need only match the releases the policy leaves observable;
+        # overrides that admit pre-releases (prereleases=True / installed=True)
+        # reinterpret the range cross-policy, which is unsound (see
+        # docs/ranges.rst), so they are checked only for the None/True policies.
+        version_range = SpecifierSet(spec_str, prereleases=configured).to_range()
+        recovered = version_range.to_specifier_set()
+        if recovered is None:
+            return
+        exact = configured is not False
+        pre_opts = (None, True, False) if exact else (None, False)
+        inst_opts = (None, True, False) if exact else (None, False)
+        for item in _EQUIV_ITEMS:
+            for prereleases in pre_opts:
+                for installed in inst_opts:
+                    assert version_range.contains(
+                        item, prereleases=prereleases, installed=installed
+                    ) == recovered.contains(
+                        item, prereleases=prereleases, installed=installed
+                    ), (spec_str, configured, item, prereleases, installed)
+        for prereleases in pre_opts:
+            assert list(
+                version_range.filter(_EQUIV_ITEMS, prereleases=prereleases)
+            ) == list(recovered.filter(_EQUIV_ITEMS, prereleases=prereleases)), (
+                spec_str,
+                configured,
+                prereleases,
+            )
 
     @pytest.mark.parametrize("spec_str", _EQUIV_SPECS)
     def test_contains_equivalent_with_version_objects(self, spec_str: str) -> None:


### PR DESCRIPTION
Builds on #1267 (the `VersionRange` core). This branch stacks on #1267, so the diff below includes it; review and merge #1267 first. The addition here is `VersionRange.to_specifier_set()`, the inverse of `SpecifierSet.to_range()`.

It returns a `SpecifierSet` matching the same versions as the range, or `None` when no single set expresses it. PEP 440 has no syntax for the strict singleton `{V}`, the inclusive upper bound that complementing `>V` produces, or a disjoint union of two or more intervals, so those return `None`. The empty range maps to `SpecifierSet("<0")` and the full range to `SpecifierSet("")`.

Every range built from a `SpecifierSet` round-trips: feeding the result back through `to_range()` reproduces the range, pre-release policy included. The encoder picks a spelling whose pre-release autodetect matches the range's resolved policy, so a recovered set filters the same versions.

```python
str(SpecifierSet(">=1.0,<2.0").to_range().to_specifier_set())  # '<2.0,>=1.0'
VersionRange.singleton("1.5").to_specifier_set()               # None
```
