### PR TITLE
fix(tags): raise SystemError (not IndexError) for empty EXT_SUFFIX in _generic_abi

### DIFF
--- a/src/packaging/tags.py
+++ b/src/packaging/tags.py
@@ -434,7 +434,7 @@ def _generic_abi() -> list[str]:
     #                                               => graalpy_38_native
 
     ext_suffix = _get_config_var("EXT_SUFFIX", warn=True)
-    if not isinstance(ext_suffix, str) or ext_suffix[0] != ".":
+    if not isinstance(ext_suffix, str) or not ext_suffix.startswith("."):
         raise SystemError("invalid sysconfig.get_config_var('EXT_SUFFIX')")
     parts = ext_suffix.split(".")
     if len(parts) < 3:

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -1347,7 +1347,7 @@ class TestGenericTags:
         monkeypatch.setattr(sysconfig, "get_config_var", config.__getitem__)
         assert tags._generic_abi() == []
 
-    @pytest.mark.parametrize("ext_suffix", ["invalid", None])
+    @pytest.mark.parametrize("ext_suffix", ["invalid", "", None])
     def test__generic_abi_error(
         self, ext_suffix: str | None, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
`_generic_abi()` is meant to raise `SystemError("invalid sysconfig.get_config_var('EXT_SUFFIX')")` for a bad `EXT_SUFFIX`, but an **empty** string slips past the guard and raises a cryptic `IndexError` instead:

```python
ext_suffix = _get_config_var("EXT_SUFFIX", warn=True)
if not isinstance(ext_suffix, str) or ext_suffix[0] != ".":   # ""[0] -> IndexError
    raise SystemError("invalid sysconfig.get_config_var('EXT_SUFFIX')")
```

`not isinstance("", str)` is `False`, so `or` evaluates `""[0]` and raises `IndexError: string index out of range` on the public `sys_tags()` / `generic_tags()` path — instead of the actionable `SystemError` the very next line already writes.

Replacing `ext_suffix[0] != "."` with `not ext_suffix.startswith(".")` keeps the exact "must start with a dot" intent (identical for every non-empty value, and the `isinstance` check still short-circuits for `None`/non-str), while returning `False` for `""` without indexing — so the intended `SystemError` is raised.

Spotted in the #1239 review (`tags.py:437`). Added the `""` case to the existing `test__generic_abi_error` parametrization: it fails on `main` (`IndexError` escapes) and passes with the fix. Code + test only — happy to leave the changelog for the release batch as on #1247.
