### PR TITLE
docs(requirements): fix Requirement constructor parameter name in Reference

### DIFF
--- a/docs/requirements.rst
+++ b/docs/requirements.rst
@@ -68,7 +68,7 @@ Usage
 Reference
 ---------
 
-.. class:: Requirement(requirement)
+.. class:: Requirement(requirement_string)
 
     This class abstracts handling the details of a requirement for a project.
     Each requirement will be parsed according to the specification.
@@ -89,8 +89,8 @@ Reference
         specifier's explicit :attr:`~packaging.specifiers.SpecifierSet.prereleases`
         override; it is now included again.
 
-    :param str requirement: The string representation of a requirement.
-    :raises InvalidRequirement: If the given ``requirement`` is not parseable,
+    :param str requirement_string: The string representation of a requirement.
+    :raises InvalidRequirement: If the given ``requirement_string`` is not parseable,
                                 then this exception will be raised.
 
     .. attribute:: name


### PR DESCRIPTION
The Reference documentation for `Requirement` documents its constructor parameter as `requirement`, but the actual constructor is `def __init__(self, requirement_string: str)` (`src/packaging/requirements.py`). So the documented keyword form raises:

```pycon
>>> Requirement(requirement="packaging>=24")
TypeError: Requirement.__init__() got an unexpected keyword argument 'requirement'
```

This points the `.. class::` signature, the `:param:`, and the `:raises:` reference at `requirement_string` so the rendered Reference matches the real keyword. Positional use (`Requirement("packaging>=24")`) was already correct and is unaffected.

Flagged in the Docs section of #1239.
