### PR TITLE
docs(utils): add 26.3 versionchanged to parse_wheel_filename + complete parse_sdist_filename :raises

### DIFF
--- a/src/packaging/utils.py
+++ b/src/packaging/utils.py
@@ -205,6 +205,9 @@ def parse_wheel_filename(
 
     .. versionadded:: 26.1
        The *validate_order* parameter.
+
+    .. versionchanged:: 26.3
+       Raises :class:`InvalidWheelFilename` on empty tag set components.
     """
     if not filename.endswith(".whl"):
         raise InvalidWheelFilename(
@@ -266,8 +269,9 @@ def parse_sdist_filename(filename: str) -> tuple[NormalizedName, Version]:
 
     :param str filename: The name of the sdist file.
     :raises InvalidSdistFilename: If the filename does not end
-        with an sdist extension (``.zip`` or ``.tar.gz``), or if it does not
-        contain a dash separating the name and the version of the distribution.
+        with an sdist extension (``.zip`` or ``.tar.gz``), if it does not
+        contain a dash separating the name and the version of the distribution,
+        or if the version portion is not a valid version.
 
     >>> from packaging.utils import parse_sdist_filename
     >>> from packaging.version import Version


### PR DESCRIPTION
Two docstring gaps in `src/packaging/utils.py`, both listed in #1239:

- **`parse_wheel_filename`** gained empty-tag-component rejection in 26.3 (via #1234) — it now raises `InvalidWheelFilename` when a tag component is empty — but only `parse_tag` got the matching 26.3 annotation in that PR. Add the `.. versionchanged:: 26.3` note.
- **`parse_sdist_filename`**'s `:raises:` documented the extension and dash-separator cases but omitted that an unparseable version also raises `InvalidSdistFilename` (the `Version(...)` call is wrapped). Add it.

From the #1239 Docs section: *"parse_wheel_filename lacks the 26.3 versionchanged that parse_tag got for the same PR (#1234); parse_sdist_filename's :raises: list omits the invalid-version case"*.
