### PR TITLE
docs(markers): add docstrings to Marker.__and__/__or__ so they render in the API reference

### DIFF
--- a/src/packaging/markers.py
+++ b/src/packaging/markers.py
@@ -427,11 +427,19 @@ class Marker:
         raise TypeError(f"Cannot restore Marker from {state!r}")
 
     def __and__(self, other: Marker) -> Marker:
+        """Combine this marker with another using ``and``.
+
+        .. versionadded:: 26.1
+        """
         if not isinstance(other, Marker):
             return NotImplemented
         return self._from_markers([self._markers, "and", other._markers])
 
     def __or__(self, other: Marker) -> Marker:
+        """Combine this marker with another using ``or``.
+
+        .. versionadded:: 26.1
+        """
         if not isinstance(other, Marker):
             return NotImplemented
         return self._from_markers([self._markers, "or", other._markers])


### PR DESCRIPTION
`docs/markers.rst` already declares `:special-members: __and__, __or__`, but neither operator has a docstring. As a result Sphinx autodoc drops `__and__` from the rendered API Reference entirely, and renders `__or__` with the inherited `object.__or__` text ("Return self|value."), which describes bitwise-or rather than marker combination.

Both operators shipped in 26.1 (#1146). This adds a short docstring carrying `.. versionadded:: 26.1` to each so they render correctly in the Reference.

Docstring-only; no behavior change. Refs #1239.