### PR TITLE
docs: render __all__ exports BuildTag/BaseSpecifier/AppleVersion/PythonVersion in the API reference

### DIFF
--- a/docs/tags.rst
+++ b/docs/tags.rst
@@ -73,6 +73,11 @@ to the implementation to provide.
     (e.g. ``"cpython"`` is ``"cp"``). All interpreter names are lower-case.
 
 
+.. autodata:: PythonVersion
+
+.. autodata:: AppleVersion
+
+
 .. autofunction:: interpreter_name
 
 .. autofunction:: interpreter_version

--- a/src/packaging/specifiers.py
+++ b/src/packaging/specifiers.py
@@ -131,6 +131,10 @@ class InvalidSpecifier(ValueError):
 
 
 class BaseSpecifier(metaclass=abc.ABCMeta):
+    """
+    Abstract base class for :class:`Specifier` and :class:`SpecifierSet`.
+    """
+
     __slots__ = ()
     __match_args__ = ("_str",)
 

--- a/src/packaging/tags.py
+++ b/src/packaging/tags.py
@@ -59,6 +59,7 @@ PythonVersion = Sequence[int]
 """
 A sequence of integers describing a Python version, e.g. ``(3, 13)``.
 """
+
 AppleVersion = tuple[int, int]
 """
 A ``(major, minor)`` integer pair describing an Apple OS version.

--- a/src/packaging/tags.py
+++ b/src/packaging/tags.py
@@ -56,7 +56,13 @@ def __dir__() -> list[str]:
 logger = logging.getLogger(__name__)
 
 PythonVersion = Sequence[int]
+"""
+A sequence of integers describing a Python version, e.g. ``(3, 13)``.
+"""
 AppleVersion = tuple[int, int]
+"""
+A ``(major, minor)`` integer pair describing an Apple OS version.
+"""
 _T = TypeVar("_T")
 
 INTERPRETER_SHORT_NAMES: dict[str, str] = {

--- a/src/packaging/utils.py
+++ b/src/packaging/utils.py
@@ -29,6 +29,9 @@ def __dir__() -> list[str]:
 
 
 BuildTag = Union[tuple[()], tuple[int, str]]
+"""
+A wheel build tag: an empty tuple, or a ``(build number, build tag suffix)`` pair.
+"""
 
 NormalizedName = NewType("NormalizedName", str)
 """


### PR DESCRIPTION
From the #1239 docs list: these four `__all__` exports rendered empty or were dropped by autodoc for lack of docstrings.

- `utils.BuildTag`, `tags.PythonVersion`, `tags.AppleVersion` — bare aliases; added one-line docstrings (matching the `NormalizedName` pattern). `docs/tags.rst` uses per-symbol directives (no `automodule`), so the two `tags` aliases also get `autodata` directives.
- `specifiers.BaseSpecifier` — added a one-line class docstring.

Docs only; no behavior change.