### PR TITLE
requirement: Normalize requested extra names for comparison and hashing

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ Fixes:
   trailing-zero-equivalent specifiers (e.g. ``foo==1.0.0`` and
   ``foo==1.0.0.0``), so equal requirements hash equal and deduplicate in
   sets and dicts. (:pull:`1232`)
+* Normalize requested extra names before comparing or hashing requirements (:issue:`644`)
 * Preserve a ``Requirement``'s specifier ``prereleases`` override across a
   pickle round trip. (:issue:`1204`)
 

--- a/src/packaging/requirements.py
+++ b/src/packaging/requirements.py
@@ -156,7 +156,7 @@ class Requirement:
         if not isinstance(other, Requirement):
             return NotImplemented
 
-        # Extras must be normalized before comparison as per PEP 658.
+        # Extras must be normalized before comparison as per PEP 685.
         self_extras = frozenset(canonicalize_name(e) for e in self.extras)
         other_extras = frozenset(canonicalize_name(e) for e in other.extras)
         return (

--- a/src/packaging/requirements.py
+++ b/src/packaging/requirements.py
@@ -145,7 +145,7 @@ class Requirement:
         return hash(
             (
                 canonicalize_name(self.name),
-                frozenset(self.extras),
+                frozenset(canonicalize_name(e) for e in self.extras),
                 self.specifier,
                 self.url,
                 self.marker,
@@ -156,9 +156,12 @@ class Requirement:
         if not isinstance(other, Requirement):
             return NotImplemented
 
+        # Extras must be normalized before comparison as per PEP 658.
+        self_extras = frozenset(canonicalize_name(e) for e in self.extras)
+        other_extras = frozenset(canonicalize_name(e) for e in other.extras)
         return (
             canonicalize_name(self.name) == canonicalize_name(other.name)
-            and self.extras == other.extras
+            and self_extras == other_extras
             and self.specifier == other.specifier
             and self.url == other.url
             and self.marker == other.marker

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -39,6 +39,11 @@ EQUIVALENT_DEPENDENCIES = [
         'foo[a]==1.0.0; python_version>="3.8"',
         'foo[a]==1.0.0.0; python_version>="3.8"',
     ),
+    # Extras that normalize to the same value are equivalent.
+    ("urllib3[secure]", "urllib3[SECURE]"),
+    ("fishtank[all-blue]", "fishtank[all_blue]"),
+    ("fishtank[all-blue]", "fishtank[all---blue]"),
+    ("fishtank[crazy-bunches]", "fishtank[cRazy_BUnches]"),
 ]
 
 DIFFERENT_DEPENDENCIES = [


### PR DESCRIPTION
This is required since PEP 685 was adopted. Towards https://github.com/pypa/packaging/issues/644#issuecomment-1626274566.

Notably, this doesn't handle extra _markers_.