### PR TITLE
test(markers): pin === (arbitrary equality) evaluation on non-version keys (#1239)

### DIFF
--- a/tests/test_markers.py
+++ b/tests/test_markers.py
@@ -105,6 +105,16 @@ class TestOperatorEvaluation:
         with pytest.raises(UndefinedComparison):
             Marker("'2.7.0' ~= os_name").evaluate()
 
+    def test_arbitrary_equality_on_non_version_key_is_undefined(self) -> None:
+        # ``===`` has no entry in ``_operators`` and the version-specifier path
+        # only runs for ``MARKERS_REQUIRING_VERSION`` keys, so evaluating ``===``
+        # against a non-version key raises ``UndefinedComparison``. This pins the
+        # post-#939 behavior (``packaging`` <= 25.0 evaluated it as plain string
+        # equality); see #1239.
+        for marker in ("os_name === 'posix'", "sys_platform === 'linux'"):
+            with pytest.raises(UndefinedComparison):
+                Marker(marker).evaluate()
+
     def test_allows_prerelease(self) -> None:
         assert Marker('python_full_version > "3.6.2"').evaluate(
             {"python_full_version": "3.11.0a5"}


### PR DESCRIPTION
#1239 decide-item: `===` (arbitrary equality) on a non-version marker key is untested. #939 silently changed it from string-equality (packaging ≤ 25.0) to raising `UndefinedComparison`, since `===` has no entry in `_operators` and only `MARKERS_REQUIRING_VERSION` keys take the specifier path. This adds a regression test pinning the current (post-#939) behavior.

If you would rather restore the ≤ 25.0 string-equality semantics for `===` on non-version keys (treat it as exact-match), I will flip the test and add the `markers.py` change — just say which way.