### PR TITLE
fix(_musllinux): pass archs as a list in the __main__ debug block

### DIFF
--- a/src/packaging/_manylinux.py
+++ b/src/packaging/_manylinux.py
@@ -30,8 +30,6 @@ _ALLOWED_ARCHS = {
 }
 
 
-# `os.PathLike` not a generic type until Python 3.9, so sticking with `str`
-# as the type for `path` until then.
 @contextlib.contextmanager
 def _parse_elf(path: str) -> Generator[ELFFile | None, None, None]:
     try:

--- a/src/packaging/_musllinux.py
+++ b/src/packaging/_musllinux.py
@@ -84,5 +84,5 @@ if __name__ == "__main__":  # pragma: no cover
     print("plat:", plat)
     print("musl:", _get_musl_version(sys.executable))
     print("tags:", end=" ")
-    for t in platform_tags(re.sub(r"[.-]", "_", plat.split("-", 1)[-1])):
+    for t in platform_tags([re.sub(r"[.-]", "_", plat.split("-", 1)[-1])]):
         print(t, end="\n      ")


### PR DESCRIPTION
A few more tiny things from the review - a comment that doesn't matter (we always pass this as a string, even though we are on 3.9+ now), and a debug printout was expanding a string letter by letter.

:robot: _AI text below_ :robot:

Two small cleanups identified in the #1239 review, both in the Linux platform-tag probing modules.

**Fix 1 (`_musllinux.py`, line 87) — functional:** The `__main__` debug block passed a bare `str` to `platform_tags(archs: Sequence[str])`. A `str` is itself a `Sequence[str]`, so the loop iterated over individual characters and printed garbage tags. Wrapping the argument in a list fixes it:

```python
# before
for t in platform_tags(re.sub(r"[.-]", "_", plat.split("-", 1)[-1])):
# after
for t in platform_tags([re.sub(r"[.-]", "_", plat.split("-", 1)[-1])]):
```

**Fix 2 (`_manylinux.py`, line 31–32) — stale comment removal:** The comment just above `_parse_elf()` said `os.PathLike` was not a generic type until Python 3.9, explaining why `path` was typed as `str`. The project's minimum supported Python is now 3.9, making the comment false. The `path: str` annotation is kept as-is (the function is private and always called with `str`); only the now-incorrect comment is removed.

Both modules' test suites pass. Lint and mypy (strict) are clean via `prek -a --quiet`. The changelog will be updated in the next batch PR before release, as is this repo's convention (see e.g. #1247, #1271).

Refs #1239.