### PR TITLE
refactor: small cleanups from the #1239 review

### DIFF
--- a/src/packaging/_elffile.py
+++ b/src/packaging/_elffile.py
@@ -34,7 +34,7 @@ class EMachine(enum.IntEnum):
     S390 = 22
     Arm = 40
     X8664 = 62
-    AArc64 = 183
+    AArch64 = 183
 
 
 class ELFFile:
@@ -57,8 +57,8 @@ class ELFFile:
         self.encoding = ident[5]  # Data structure encoding (endianness).
 
         try:
-            # e_fmt: Format for program header.
-            # p_fmt: Format for section header.
+            # e_fmt: Format for the ELF header.
+            # p_fmt: Format for a program header.
             # p_idx: Indexes to find p_type, p_offset, and p_filesz.
             e_fmt, self._p_fmt, self._p_idx = {
                 (1, 1): ("<HHIIIIIHHH", "<IIIIIIII", (0, 1, 4)),  # 32-bit LSB.
@@ -81,8 +81,8 @@ class ELFFile:
                 _,
                 self.flags,  # Processor-specific flags.
                 _,
-                self._e_phentsize,  # Size of section.
-                self._e_phnum,  # Number of sections.
+                self._e_phentsize,  # Size of a program header entry.
+                self._e_phnum,  # Number of program headers.
             ) = self._read(e_fmt)
         except struct.error as e:
             raise ELFInvalid("unable to parse machine and section information") from e

--- a/src/packaging/_manylinux.py
+++ b/src/packaging/_manylinux.py
@@ -140,11 +140,11 @@ def _glibc_version_string_ctypes() -> str | None:
         # glibc.
         return None
 
-    # Call gnu_get_libc_version, which returns a string like "2.5"
+    # Call gnu_get_libc_version, which returns a string like "2.5".
     gnu_get_libc_version.restype = ctypes.c_char_p
-    version_str: str = gnu_get_libc_version()
-    # py2 / py3 compatibility:
-    if not isinstance(version_str, str):
+    # A c_char_p restype comes back as bytes, so decode to text.
+    version_str: str | bytes = gnu_get_libc_version()
+    if isinstance(version_str, bytes):
         version_str = version_str.decode("ascii")
 
     return version_str

--- a/src/packaging/_tokenizer.py
+++ b/src/packaging/_tokenizer.py
@@ -142,7 +142,7 @@ class Tokenizer:
     def expect(self, name: str, *, expected: str) -> Token:
         """Expect a certain token name next, failing with a syntax error otherwise.
 
-        The token is *not* read.
+        The token is read and returned.
         """
         if not self.check(name):
             raise self.raise_syntax_error(f"Expected {expected}")

--- a/src/packaging/metadata.py
+++ b/src/packaging/metadata.py
@@ -661,7 +661,8 @@ class _Validator(Generic[T]):
         return value
 
     def _process_dynamic(self, value: list[str]) -> list[str]:
-        for dynamic_field in map(str.lower, value):
+        dynamic_fields = list(map(str.lower, value))
+        for dynamic_field in dynamic_fields:
             if dynamic_field in {"name", "version", "metadata-version"}:
                 raise self._invalid_metadata(
                     f"{dynamic_field!r} is not allowed as a dynamic field"
@@ -670,7 +671,7 @@ class _Validator(Generic[T]):
                 raise self._invalid_metadata(
                     f"{dynamic_field!r} is not a valid dynamic field"
                 )
-        return list(map(str.lower, value))
+        return dynamic_fields
 
     def _process_provides_extra(
         self,

--- a/src/packaging/requirements.py
+++ b/src/packaging/requirements.py
@@ -67,7 +67,7 @@ class Requirement:
 
         self.name: str = parsed.name
         self.url: str | None = parsed.url or None
-        self.extras: set[str] = set(parsed.extras or [])
+        self.extras: set[str] = set(parsed.extras)
         self.specifier: SpecifierSet = SpecifierSet(parsed.specifier)
         self.marker: Marker | None = None
         if parsed.marker is not None:

--- a/src/packaging/tags.py
+++ b/src/packaging/tags.py
@@ -668,7 +668,6 @@ def mac_platforms(
             for binary_format in binary_formats:
                 yield f"macosx_{major_version}_{minor_version}_{binary_format}"
 
-    if version >= (11, 0):
         # Mac OS 11 on x86_64 is compatible with binaries from previous releases.
         # Arm64 support was introduced in 11.0, so no Arm binaries from previous
         # releases exist.

--- a/tests/test_elffile.py
+++ b/tests/test_elffile.py
@@ -41,7 +41,7 @@ def test_elffile_glibc(
             "aarch64",
             EIClass.C64,
             EIData.Lsb,
-            EMachine.AArc64,
+            EMachine.AArch64,
             "aarch64",
         ),
         ("i386", EIClass.C32, EIData.Lsb, EMachine.I386, "i386"),


### PR DESCRIPTION
Several small cleanups from the review, batched.

I manually checked the arch to make sure it's not an intentional misspelling: https://en.wikipedia.org/wiki/Executable_and_Linkable_Format

I can break it up as desired if that's better.


:robot: _AI text below_ :robot:

Picks up the "smaller" simplifications from the [#1239](https://github.com/pypa/packaging/issues/1239) review. All are comment/typo/redundancy cleanups with no behavior change.

## Changes

- **`tags.py`** — `mac_platforms` had two adjacent `if version >= (11, 0):` blocks; merged into one.
- **`requirements.py`** — `_parse_extras` always returns a `list`, so `set(parsed.extras or [])` → `set(parsed.extras)`.
- **`metadata.py`** — `_process_dynamic` mapped `str.lower` over the value twice (once to validate, once to return); compute it once.
- **`_elffile.py`** — the `e_fmt`/`p_fmt` struct-format comments were swapped (labeled "program header"/"section header" instead of "ELF header"/"program header"), and `_e_phentsize`/`_e_phnum` were commented as "section" rather than "program header". Also fixed the `EMachine.AArc64` → `AArch64` typo (and its one reference in `tests/test_elffile.py`).
- **`_tokenizer.py`** — `expect()` returns `self.read()`, but its docstring claimed "The token is *not* read."

## Flagged false positives (left as-is)

Two items from that list turned out **not** to be dead code; the test suite exercises both paths:

- `_manylinux._glibc_version_string_ctypes` — the `isinstance` decode guard: with a `c_char_p` restype the real ctypes result is `bytes`, while the test stub returns `str`, so both branches are reachable. Kept the guard; only corrected the misleading `# py2 / py3` comment and the wrong `version_str: str` annotation.
- `_manylinux.platform_tags` — `_GLibCVersion(*_get_glibc_version())`: several `test_tags` cases monkeypatch `_get_glibc_version` to return a plain tuple, and the re-wrap normalizes it. Left untouched.

## Tests

- `uv run python -m pytest -q` — full suite passes.
- `prek -a --quiet` — clean.

Refs #1239.
