### PR TITLE
fix(ranges): preserve autodetected prerelease policy when union collapses to full

### DIFF
--- a/src/packaging/ranges.py
+++ b/src/packaging/ranges.py
@@ -584,38 +584,27 @@ class VersionRange:
         """
         self._check_policy_compat(other)
 
+        # The merged pre-release policy rides along in (resolved, configured).
         resolved, configured = self._combined_policy(other)
         new_bounds = tuple(_union_ranges(self._bounds, other._bounds))
         combined_arb = self._admit_arbitrary or other._admit_arbitrary
         if not self._has_literals() and not other._has_literals():
-            result = self._build(
+            return self._build(
                 new_bounds,
                 admit_arbitrary=combined_arb,
                 prereleases=resolved,
                 prereleases_configured=configured,
             )
-        else:
-            result = self._combine_literals(
-                other,
-                new_bounds,
-                intersect=False,
-                admit_arbitrary=combined_arb,
-                prereleases=resolved,
-                prereleases_configured=configured,
-            )
 
-        # ``r | full()`` collapses to the canonical universal range only when
-        # both sides carry the autodetect default; an explicit policy survives.
-        if (
-            result._bounds == FULL_RANGE
-            and result._admit_arbitrary
-            and not result._has_literals()
-            and resolved is None
-            and configured is None
-        ):
-            return self.full()
-
-        return result
+        # One side carries ``===`` literals; resolve admit/reject per literal.
+        return self._combine_literals(
+            other,
+            new_bounds,
+            intersect=False,
+            admit_arbitrary=combined_arb,
+            prereleases=resolved,
+            prereleases_configured=configured,
+        )
 
     def complement(self) -> VersionRange:
         """Range containing every version not in self.

--- a/src/packaging/ranges.py
+++ b/src/packaging/ranges.py
@@ -610,7 +610,8 @@ class VersionRange:
             result._bounds == FULL_RANGE
             and result._admit_arbitrary
             and not result._has_literals()
-            and self._prereleases_configured is None
+            and resolved is None
+            and configured is None
         ):
             return self.full()
 

--- a/tests/test_ranges.py
+++ b/tests/test_ranges.py
@@ -200,6 +200,19 @@ class TestSetAlgebra:
         collapsed = r | VersionRange.full(prereleases=True)
         assert collapsed._prereleases_configured is True
 
+    def test_union_full_preserves_autodetected_prerelease_policy(self) -> None:
+        r = vr(">=1.0a1")
+        assert list(r.filter(["1.3", "1.5a1"])) == ["1.3", "1.5a1"]
+
+        assert list((r | VersionRange.full()).filter(["1.3", "1.5a1"])) == [
+            "1.3",
+            "1.5a1",
+        ]
+        assert list((VersionRange.full() | r).filter(["1.3", "1.5a1"])) == [
+            "1.3",
+            "1.5a1",
+        ]
+
     def test_arbitrary_flag_distinguishes_full(self) -> None:
         # nab contract: SpecifierSet("")-full differs from algebra-built full.
         flagged_full = SpecifierSet("").to_range()

--- a/tests/test_ranges.py
+++ b/tests/test_ranges.py
@@ -204,6 +204,10 @@ class TestSetAlgebra:
         r = vr(">=1.0a1")
         assert list(r.filter(["1.3", "1.5a1"])) == ["1.3", "1.5a1"]
 
+        # Both orders keep the autodetected pre-release policy.
+        assert (r | VersionRange.full())._prereleases is True
+        assert (VersionRange.full() | r)._prereleases is True
+
         assert list((r | VersionRange.full()).filter(["1.3", "1.5a1"])) == [
             "1.3",
             "1.5a1",


### PR DESCRIPTION
Follow-up to #1267.

`VersionRange.union()` already carries the combined prerelease policy through `_combined_policy()`, but the final full-range collapse still returned `VersionRange.full()` whenever the current range did not have an explicitly configured prerelease policy.

That drops an autodetected prerelease policy from the other operand:

```py
r = SpecifierSet(">=1.0a1").to_range()
r.filter(["1.3", "1.5a1"])                  # includes 1.5a1
(r | VersionRange.full()).filter([...])       # should behave the same
```

This changes the collapse to only use the default full range when neither resolved nor configured prerelease policy is present, and adds a regression covering both operand orders.

Tests:

```bash
uv run pytest tests/test_ranges.py -q
```
