### PR TITLE
fix(direct_url): require absolute file URLs for local directories

### DIFF
--- a/src/packaging/direct_url.py
+++ b/src/packaging/direct_url.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any, Protocol, TypeVar
 if TYPE_CHECKING:  # pragma: no cover
     import sys
     from collections.abc import Collection
+    from urllib.parse import SplitResult
 
     if sys.version_info >= (3, 11):
         from typing import Self
@@ -109,9 +110,8 @@ def _strip_url(url: str, safe_user_passwords: Collection[str]) -> str:
     )
 
 
-def _file_url_has_absolute_path(url: str) -> bool:
-    parsed = urllib.parse.urlsplit(url)
-    return parsed.path.startswith("/")
+def _file_url_has_absolute_path(parsed_url: SplitResult) -> bool:
+    return parsed_url.path.startswith("/")
 
 
 class DirectUrlValidationError(Exception):
@@ -295,12 +295,13 @@ class DirectUrl:
                 "Exactly one of vcs_info, archive_info, dir_info must be present"
             )
         if direct_url.dir_info is not None:
-            if urllib.parse.urlsplit(direct_url.url).scheme != "file":
+            parsed_url = urllib.parse.urlsplit(direct_url.url)
+            if parsed_url.scheme != "file":
                 raise DirectUrlValidationError(
                     "URL scheme must be file:// when dir_info is present",
                     context="url",
                 )
-            if not _file_url_has_absolute_path(direct_url.url):
+            if not _file_url_has_absolute_path(parsed_url):
                 raise DirectUrlValidationError(
                     "URL must be an absolute file URL when dir_info is present",
                     context="url",

--- a/src/packaging/direct_url.py
+++ b/src/packaging/direct_url.py
@@ -109,6 +109,11 @@ def _strip_url(url: str, safe_user_passwords: Collection[str]) -> str:
     )
 
 
+def _file_url_has_absolute_path(url: str) -> bool:
+    parsed = urllib.parse.urlsplit(url)
+    return parsed.path.startswith("/")
+
+
 class DirectUrlValidationError(Exception):
     """Raised when when input data is not spec-compliant.
 
@@ -289,14 +294,17 @@ class DirectUrl:
             raise DirectUrlValidationError(
                 "Exactly one of vcs_info, archive_info, dir_info must be present"
             )
-        if (
-            direct_url.dir_info is not None
-            and urllib.parse.urlsplit(direct_url.url).scheme != "file"
-        ):
-            raise DirectUrlValidationError(
-                "URL scheme must be file:// when dir_info is present",
-                context="url",
-            )
+        if direct_url.dir_info is not None:
+            if urllib.parse.urlsplit(direct_url.url).scheme != "file":
+                raise DirectUrlValidationError(
+                    "URL scheme must be file:// when dir_info is present",
+                    context="url",
+                )
+            if not _file_url_has_absolute_path(direct_url.url):
+                raise DirectUrlValidationError(
+                    "URL must be an absolute file URL when dir_info is present",
+                    context="url",
+                )
         # XXX subdirectory must be relative, can we, should we validate that here?
         return direct_url
 

--- a/src/packaging/direct_url.py
+++ b/src/packaging/direct_url.py
@@ -303,7 +303,7 @@ class DirectUrl:
                 )
             if not _file_url_has_absolute_path(parsed_url):
                 raise DirectUrlValidationError(
-                    "URL must be an absolute file URL when dir_info is present",
+                    "File URL must be absolute when dir_info is present",
                     context="url",
                 )
         # XXX subdirectory must be relative, can we, should we validate that here?

--- a/tests/test_direct_url.py
+++ b/tests/test_direct_url.py
@@ -225,12 +225,31 @@ def test_dir_info_url_scheme_file() -> None:
         "FILE:///home/myproject",
         "File:///home/myproject",
         "file:/home/myproject",
+        "file://localhost/home/myproject",
     ],
 )
-def test_dir_info_url_scheme_file_case_insensitive(url: str) -> None:
+def test_dir_info_url_file_absolute_case_insensitive(url: str) -> None:
     """Per RFC 3986 §3.1, URL schemes are case-insensitive; all variants of
-    the file scheme must be accepted when dir_info is present."""
+    absolute file URLs must be accepted when dir_info is present."""
     DirectUrl.from_dict({"url": url, "dir_info": {}})
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "file:relative",
+        "file:./relative",
+        "file:",
+        "file://relative",
+        "file://localhost",
+    ],
+)
+def test_dir_info_url_requires_absolute_file_url(url: str) -> None:
+    with pytest.raises(
+        DirectUrlValidationError,
+        match=r"URL must be an absolute file URL when dir_info is present",
+    ):
+        DirectUrl.from_dict({"url": url, "dir_info": {}})
 
 
 def test_missing_url() -> None:

--- a/tests/test_direct_url.py
+++ b/tests/test_direct_url.py
@@ -247,7 +247,7 @@ def test_dir_info_url_file_absolute_case_insensitive(url: str) -> None:
 def test_dir_info_url_requires_absolute_file_url(url: str) -> None:
     with pytest.raises(
         DirectUrlValidationError,
-        match=r"URL must be an absolute file URL when dir_info is present",
+        match=r"File URL must be absolute when dir_info is present",
     ):
         DirectUrl.from_dict({"url": url, "dir_info": {}})
 


### PR DESCRIPTION
Follow-up to #1240.

`DirectUrl.from_dict()` now accepts case-insensitive file schemes via `urlsplit(...).scheme`, but local-directory `dir_info` entries still accepted relative `file:` URLs such as `file:relative` and `file:./relative`.

This keeps the existing non-file-scheme validation message, adds a separate absolute-file-URL error for file URLs without an absolute path, and covers authority-only forms such as `file://relative` and `file://localhost`.

Tests:
- `uv run pytest tests/test_direct_url.py -q`
