### PR TITLE
Add set relations and difference to VersionRange

### DIFF
--- a/docs/ranges.rst
+++ b/docs/ranges.rst
@@ -5,9 +5,9 @@ Version Ranges
 
 A :class:`VersionRange` is the set of :class:`~packaging.version.Version`
 values accepted by a :class:`~packaging.specifiers.SpecifierSet`, viewed as
-intervals on the PEP 440 ordering. It supports intersection, union, and
-complement, so tooling that combines many requirements, such as a resolver,
-can work on the intervals directly.
+intervals on the PEP 440 ordering. It supports intersection, union,
+complement, and difference, so tooling that combines many requirements, such
+as a resolver, can work on the intervals directly.
 
 Usage
 -----
@@ -40,29 +40,50 @@ Usage
     >>> SpecifierSet(">=2.0,<1.0").to_range().is_empty
     True
 
+``a - b`` is set difference: the versions in ``a`` but not ``b``. On the version
+set it matches ``a & ~b``, but it keeps only ``a``'s pre-release policy, since
+``b`` is treated as an exclusion that grants no pre-release admission of its own.
+Subtracting a pre-release-naming range therefore does not let pre-releases into
+the result:
+
+.. doctest::
+
+    >>> base = SpecifierSet(">=1.0").to_range()
+    >>> excluded = SpecifierSet(">=2.0b1").to_range()
+    >>> list((base - excluded).filter(["1.9", "2.0a1"]))
+    ['1.9']
+    >>> list((base & ~excluded).filter(["1.9", "2.0a1"]))
+    ['1.9', '2.0a1']
+
 Comparing ranges
 ----------------
 
 Equality on a :class:`VersionRange` is structural: two ranges are equal only
 when they behave the same under :meth:`VersionRange.contains` and
 :meth:`VersionRange.filter`. Equality covers the pre-release policy and any
-``===`` admission, not only the versions matched. Intersection can change one
-of those without changing the version set, so the textbook subset test
-``a & b == a`` can report a false negative. Use the algebra and
-:attr:`VersionRange.is_empty` for set relations:
+``===`` admission, not only the versions matched.
+
+For set relations use :meth:`VersionRange.is_subset`,
+:meth:`VersionRange.is_superset`, and :meth:`VersionRange.is_disjoint` rather
+than comparing intersections by hand. Intersection can change the pre-release
+policy without changing the version set, so the textbook subset test
+``a & b == a`` can report a false negative. Each method compares the version
+sets directly, so it is not affected by that policy difference:
 
 .. doctest::
 
     >>> from packaging.specifiers import SpecifierSet
     >>> a = SpecifierSet(">=1.0").to_range()
     >>> b = SpecifierSet(">=1.0a1").to_range()
-    >>> # a is a subset of b (every version >=1.0 is also >=1.0a1), but b
+    >>> # Every version >=1.0 is also >=1.0a1, so a is a subset of b. But b
     >>> # admits pre-releases, so ``a & b`` and ``a`` differ only in policy:
     >>> a & b == a
     False
-    >>> (a & ~b).is_empty       # subset: a has no version outside b
+    >>> a.is_subset(b)
     True
-    >>> (a & b).is_empty        # disjoint: a and b share no version
+    >>> b.is_superset(a)
+    True
+    >>> a.is_disjoint(b)
     False
 
 Different specifiers for the same set of versions canonicalize to one form, so

--- a/docs/specifiers.rst
+++ b/docs/specifiers.rst
@@ -65,8 +65,8 @@ Usage
 
 The :meth:`~packaging.specifiers.SpecifierSet.to_range` method returns a
 :class:`~packaging.ranges.VersionRange`, a set-algebra view of the accepted
-versions that supports intersection, union, and complement. See :doc:`ranges`
-for details.
+versions that supports intersection, union, complement, and difference. See
+:doc:`ranges` for details.
 
 
 Reference

--- a/src/packaging/ranges.py
+++ b/src/packaging/ranges.py
@@ -17,6 +17,7 @@ originating specifier set.
 
 from __future__ import annotations
 
+import enum
 import typing
 from typing import (
     TYPE_CHECKING,
@@ -58,6 +59,14 @@ __all__ = ["VersionRange"]
 T = TypeVar("T")
 UnparsedVersion = Union[Version, str]
 UnparsedVersionVar = TypeVar("UnparsedVersionVar", bound=UnparsedVersion)
+
+
+class _SetOp(enum.Enum):
+    """The binary set operation ``_combine_literals`` resolves over ``===`` literals."""
+
+    INTERSECTION = enum.auto()
+    UNION = enum.auto()
+    DIFFERENCE = enum.auto()
 
 
 def __dir__() -> list[str]:
@@ -565,6 +574,7 @@ class VersionRange:
         resolved, configured = self._combined_policy(other)
         new_bounds = tuple(intersect_ranges(self._bounds, other._bounds))
         combined_arb = self._admit_arbitrary and other._admit_arbitrary
+
         if not self._has_literals() and not other._has_literals():
             return self._build(
                 new_bounds,
@@ -576,7 +586,7 @@ class VersionRange:
         return self._combine_literals(
             other,
             new_bounds,
-            intersect=True,
+            op=_SetOp.INTERSECTION,
             admit_arbitrary=combined_arb,
             prereleases=resolved,
             prereleases_configured=configured,
@@ -601,6 +611,7 @@ class VersionRange:
         resolved, configured = self._combined_policy(other)
         new_bounds = tuple(_union_ranges(self._bounds, other._bounds))
         combined_arb = self._admit_arbitrary or other._admit_arbitrary
+
         if not self._has_literals() and not other._has_literals():
             return self._build(
                 new_bounds,
@@ -609,11 +620,10 @@ class VersionRange:
                 prereleases_configured=configured,
             )
 
-        # One side carries ``===`` literals; resolve admit/reject per literal.
         return self._combine_literals(
             other,
             new_bounds,
-            intersect=False,
+            op=_SetOp.UNION,
             admit_arbitrary=combined_arb,
             prereleases=resolved,
             prereleases_configured=configured,
@@ -648,11 +658,13 @@ class VersionRange:
     def difference(self, other: VersionRange) -> VersionRange:
         """Range containing the versions in self but not in other.
 
-        Matches ``self & ~other`` on the version set, but the result carries
-        only ``self``'s pre-release policy; ``other`` is treated as an
-        exclusion and contributes no pre-release admission. Unlike
-        :meth:`intersection` and :meth:`union`, the operands need not share a
-        configured pre-release policy, since ``other``'s policy is discarded.
+        On the version set this matches ``self & ~other``, but the result keeps
+        only ``self``'s admissions and pre-release policy: a non-version string
+        or ``===`` literal is a member exactly when ``self`` admits it and
+        ``other`` does not. ``other`` is treated purely as an exclusion, so the
+        operands need not share a configured pre-release policy (unlike
+        :meth:`intersection` and :meth:`union`), and ``a - empty()`` returns a
+        range equal to ``a``.
 
         >>> a = SpecifierSet(">=1.0").to_range()
         >>> b = SpecifierSet(">=2.0").to_range()
@@ -660,16 +672,24 @@ class VersionRange:
         True
         >>> "2.0" in a.difference(b)
         False
+        >>> a.difference(VersionRange.empty()) == a
+        True
         """
         if not isinstance(other, VersionRange):
             raise TypeError(f"expected VersionRange, got {type(other).__name__}")
 
-        # Difference is intersection with ``other``'s complement, but the result
-        # keeps only ``self``'s policy; the excluded side contributes none.
-        complement = other.complement()
-        new_bounds = tuple(intersect_ranges(self._bounds, complement._bounds))
-        combined_arb = self._admit_arbitrary and complement._admit_arbitrary
-        if not self._has_literals() and not complement._has_literals():
+        # Bound complement is two-way, so subtracting other's versions is an
+        # intersection with its gaps.
+        new_bounds = tuple(
+            intersect_ranges(self._bounds, _complement_ranges(other._bounds))
+        )
+
+        # Complement is one-way for arbitrary strings and ``===`` literals, so
+        # read admission off other directly: a string survives when self admits
+        # it and other does not.
+        combined_arb = self._admit_arbitrary and not other._admit_arbitrary
+
+        if not self._has_literals() and not other._has_literals():
             return self._build(
                 new_bounds,
                 admit_arbitrary=combined_arb,
@@ -677,11 +697,10 @@ class VersionRange:
                 prereleases_configured=self._prereleases_configured,
             )
 
-        # One side carries ``===`` literals; resolve admit/reject per literal.
         return self._combine_literals(
-            complement,
+            other,
             new_bounds,
-            intersect=True,
+            op=_SetOp.DIFFERENCE,
             admit_arbitrary=combined_arb,
             prereleases=self._prereleases,
             prereleases_configured=self._prereleases_configured,
@@ -692,18 +711,28 @@ class VersionRange:
         other: VersionRange,
         new_bounds: tuple[_Interval, ...],
         *,
-        intersect: bool,
+        op: _SetOp,
         admit_arbitrary: bool,
         prereleases: bool | None,
         prereleases_configured: bool | None,
     ) -> VersionRange:
-        """Resolve admit/reject for ``self & other`` or ``self | other``."""
+        """Resolve admit/reject for ``self`` ``op`` ``other`` over their literals."""
         admits: set[str] = set()
         rejects: set[str] = set()
+
+        # Each literal is decided on its own: test it against both operands,
+        # then admit or reject it by the set operation.
         for literal in self._admit | self._reject | other._admit | other._reject:
             self_in = self._matches_literal(literal)
             other_in = other._matches_literal(literal)
-            want = (self_in and other_in) if intersect else (self_in or other_in)
+
+            if op is _SetOp.INTERSECTION:
+                want = self_in and other_in
+            elif op is _SetOp.UNION:
+                want = self_in or other_in
+            else:
+                want = self_in and not other_in
+
             if want:
                 admits.add(literal)
             else:

--- a/src/packaging/ranges.py
+++ b/src/packaging/ranges.py
@@ -5,8 +5,8 @@
 
 A set-algebra view of the versions accepted by a
 :class:`~packaging.specifiers.SpecifierSet`. Ranges support intersection,
-union, and complement; membership and filtering match the originating
-specifier set.
+union, complement, and difference; membership and filtering match the
+originating specifier set.
 
 .. testsetup::
 
@@ -303,14 +303,17 @@ class VersionRange:
 
     Construct via :meth:`~packaging.specifiers.SpecifierSet.to_range`, or with
     the :meth:`full`, :meth:`empty`, and :meth:`singleton` class methods.
-    Compose with :meth:`intersection`, :meth:`union`, and :meth:`complement`
-    (or the ``&`` / ``|`` / ``~`` operators). Test membership with ``in`` or
-    :meth:`contains`, filter an iterable with :meth:`filter`.
+    Compose with :meth:`intersection`, :meth:`union`, :meth:`complement`, and
+    :meth:`difference` (or the ``&`` / ``|`` / ``~`` / ``-`` operators). Test
+    membership with ``in`` or :meth:`contains`, filter an iterable with
+    :meth:`filter`.
 
     The configured pre-release policy of the originating specifier set carries
     onto the range and controls whether pre-releases are admitted under ``in``,
-    :meth:`contains`, and :meth:`filter`. :meth:`intersection` and
-    :meth:`union` require both operands to share the same policy.
+    :meth:`contains`, and :meth:`filter`. :meth:`intersection`,
+    :meth:`union`, and the :meth:`is_subset` / :meth:`is_superset` /
+    :meth:`is_disjoint` predicates require both operands to share the same
+    policy; set difference (``-``) does not.
 
     >>> r = SpecifierSet(">=1.0,<2.0").to_range()
     >>> "1.5" in r
@@ -424,6 +427,16 @@ class VersionRange:
         bounds; on narrower bounds it is metadata awaiting a later widening.
         """
         return self._admit_arbitrary and self._bounds == FULL_RANGE
+
+    def _is_plain(self) -> bool:
+        """True when membership is decided by ``_bounds`` alone, enabling the
+        bounds-only fast paths in :meth:`is_subset` and :meth:`is_disjoint`.
+        """
+        return (
+            not self._has_literals()
+            and not self._admit_arbitrary
+            and self._prereleases is not False
+        )
 
     def _check_policy_compat(self, other: VersionRange) -> None:
         """Refuse combining ranges with different pre-release policies."""
@@ -632,6 +645,48 @@ class VersionRange:
             prereleases_configured=self._prereleases_configured,
         )
 
+    def difference(self, other: VersionRange) -> VersionRange:
+        """Range containing the versions in self but not in other.
+
+        Matches ``self & ~other`` on the version set, but the result carries
+        only ``self``'s pre-release policy; ``other`` is treated as an
+        exclusion and contributes no pre-release admission. Unlike
+        :meth:`intersection` and :meth:`union`, the operands need not share a
+        configured pre-release policy, since ``other``'s policy is discarded.
+
+        >>> a = SpecifierSet(">=1.0").to_range()
+        >>> b = SpecifierSet(">=2.0").to_range()
+        >>> "1.5" in a.difference(b)
+        True
+        >>> "2.0" in a.difference(b)
+        False
+        """
+        if not isinstance(other, VersionRange):
+            raise TypeError(f"expected VersionRange, got {type(other).__name__}")
+
+        # Difference is intersection with ``other``'s complement, but the result
+        # keeps only ``self``'s policy; the excluded side contributes none.
+        complement = other.complement()
+        new_bounds = tuple(intersect_ranges(self._bounds, complement._bounds))
+        combined_arb = self._admit_arbitrary and complement._admit_arbitrary
+        if not self._has_literals() and not complement._has_literals():
+            return self._build(
+                new_bounds,
+                admit_arbitrary=combined_arb,
+                prereleases=self._prereleases,
+                prereleases_configured=self._prereleases_configured,
+            )
+
+        # One side carries ``===`` literals; resolve admit/reject per literal.
+        return self._combine_literals(
+            complement,
+            new_bounds,
+            intersect=True,
+            admit_arbitrary=combined_arb,
+            prereleases=self._prereleases,
+            prereleases_configured=self._prereleases_configured,
+        )
+
     def _combine_literals(
         self,
         other: VersionRange,
@@ -690,6 +745,77 @@ class VersionRange:
     def __invert__(self) -> VersionRange:
         """Operator alias for :meth:`complement`."""
         return self.complement()
+
+    def __sub__(self, other: object) -> VersionRange:
+        """Operator alias for :meth:`difference`."""
+        if not isinstance(other, VersionRange):
+            return NotImplemented
+        return self.difference(other)
+
+    def is_subset(self, other: VersionRange) -> bool:
+        """Return whether every member of self is also a member of other.
+
+        Equivalent to ``(self & ~other).is_empty``. For ``===`` ranges and the
+        arbitrary-admitting full range, complement is one-way, so the result
+        matches :meth:`contains` for versions but not for the non-version
+        strings those ranges admit.
+
+        Both operands must share the same configured pre-release policy;
+        otherwise :exc:`ValueError` is raised.
+
+        >>> inner = SpecifierSet(">=1.5,<1.8").to_range()
+        >>> outer = SpecifierSet(">=1.0,<2.0").to_range()
+        >>> inner.is_subset(outer)
+        True
+        >>> outer.is_subset(inner)
+        False
+        >>> VersionRange.empty().is_subset(outer)
+        True
+        """
+        self._check_policy_compat(other)
+
+        # Plain ranges: subset reduces to bounds containment, no algebra needed.
+        if self._is_plain() and other._is_plain():
+            return not intersect_ranges(self._bounds, _complement_ranges(other._bounds))
+        return self.intersection(other.complement()).is_empty
+
+    def is_superset(self, other: VersionRange) -> bool:
+        """Return whether every member of other is also a member of self.
+
+        The mirror of :meth:`is_subset`: ``a.is_superset(b)`` is
+        ``b.is_subset(a)``.
+
+        Both operands must share the same configured pre-release policy;
+        otherwise :exc:`ValueError` is raised.
+
+        >>> outer = SpecifierSet(">=1.0,<2.0").to_range()
+        >>> outer.is_superset(SpecifierSet(">=1.5,<1.8").to_range())
+        True
+        """
+        # Type-guards a non-VersionRange other before delegating to is_subset.
+        self._check_policy_compat(other)
+        return other.is_subset(self)
+
+    def is_disjoint(self, other: VersionRange) -> bool:
+        """Return whether self and other share no member.
+
+        Equivalent to ``(self & other).is_empty``.
+
+        Both operands must share the same configured pre-release policy;
+        otherwise :exc:`ValueError` is raised.
+
+        >>> a = SpecifierSet(">=1.0,<2.0").to_range()
+        >>> a.is_disjoint(SpecifierSet(">=2.0,<3.0").to_range())
+        True
+        >>> a.is_disjoint(SpecifierSet(">=1.5,<2.5").to_range())
+        False
+        """
+        self._check_policy_compat(other)
+
+        # Plain ranges: disjointness is an empty bounds intersection.
+        if self._is_plain() and other._is_plain():
+            return not intersect_ranges(self._bounds, other._bounds)
+        return self.intersection(other).is_empty
 
     @typing.overload
     def filter(

--- a/tests/property/test_ranges_pubgrub.py
+++ b/tests/property/test_ranges_pubgrub.py
@@ -37,7 +37,13 @@ from hypothesis import given
 
 from packaging.ranges import VersionRange
 
-from .strategies import SETTINGS, VERSION_POOL, pep440_versions, specifier_sets
+from .strategies import (
+    SETTINGS,
+    VERSION_POOL,
+    pep440_versions,
+    rich_specifier_sets,
+    specifier_sets,
+)
 
 if TYPE_CHECKING:
     from packaging.specifiers import SpecifierSet
@@ -131,6 +137,21 @@ class TestQuoteSetOperationExamples:
             in_a_not_b = v in ra and v not in rb
             assert (v in difference) == in_a_not_b
             assert (v in operator_difference) == in_a_not_b
+
+    @given(spec_set=rich_specifier_sets(include_arbitrary=True))
+    @SETTINGS
+    def test_difference_with_empty_is_identity(self, spec_set: SpecifierSet) -> None:
+        """``A \\ ∅ == A``, including the arbitrary-string and ``===`` admissions
+        that subtracting through ``A ∩ ~∅`` used to drop."""
+        ra = spec_set.to_range()
+        assert ra - VersionRange.empty() == ra
+
+    @given(spec_set=rich_specifier_sets(include_arbitrary=True))
+    @SETTINGS
+    def test_difference_with_self_is_empty(self, spec_set: SpecifierSet) -> None:
+        """``A \\ A`` admits nothing, literals and arbitrary strings included."""
+        ra = spec_set.to_range()
+        assert (ra - ra).is_empty
 
     @given(a=specifier_sets(), b=specifier_sets())
     @SETTINGS

--- a/tests/property/test_ranges_pubgrub.py
+++ b/tests/property/test_ranges_pubgrub.py
@@ -123,11 +123,14 @@ class TestQuoteSetOperationExamples:
     def test_set_difference_equals_intersection_with_complement(
         self, a: SpecifierSet, b: SpecifierSet
     ) -> None:
-        """``A \\ B`` (versions in A but not B) equals ``A ∩ ~B``."""
+        """``A \\ B`` (versions in A but not B) equals both ``A - B`` and ``A ∩ ~B``."""
         ra, rb = _to_range(a), _to_range(b)
         difference = ra & rb.complement()
+        operator_difference = ra - rb
         for v in VERSION_POOL:
-            assert (v in difference) == (v in ra and v not in rb)
+            in_a_not_b = v in ra and v not in rb
+            assert (v in difference) == in_a_not_b
+            assert (v in operator_difference) == in_a_not_b
 
     @given(a=specifier_sets(), b=specifier_sets())
     @SETTINGS

--- a/tests/property/test_ranges_set_relations.py
+++ b/tests/property/test_ranges_set_relations.py
@@ -1,0 +1,123 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+
+"""Property tests for ``is_subset`` / ``is_superset`` / ``is_disjoint``.
+
+Each relation is pinned to its set-algebra definition (the oracle the methods
+optimize): ``is_disjoint`` to ``(a & b).is_empty`` and ``is_subset`` to
+``(a & ~b).is_empty``. The plain strategy exercises the bounds-only fast path;
+the ``===`` strategy forces the algebra fallback, so the same oracle guards
+both code paths. Pointwise-membership and symmetry round out the checks.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from hypothesis import given
+
+from packaging.ranges import VersionRange
+
+from .strategies import (
+    SETTINGS,
+    VERSION_POOL,
+    rich_specifier_sets,
+    specifier_sets,
+)
+
+if TYPE_CHECKING:
+    from packaging.specifiers import SpecifierSet
+
+pytestmark = pytest.mark.property
+
+
+@given(a=specifier_sets(), b=specifier_sets())
+@SETTINGS
+def test_disjoint_matches_algebra_plain(a: SpecifierSet, b: SpecifierSet) -> None:
+    ra, rb = a.to_range(), b.to_range()
+    assert ra.is_disjoint(rb) == (ra & rb).is_empty
+
+
+@given(a=specifier_sets(), b=specifier_sets())
+@SETTINGS
+def test_subset_matches_algebra_plain(a: SpecifierSet, b: SpecifierSet) -> None:
+    ra, rb = a.to_range(), b.to_range()
+    assert ra.is_subset(rb) == (ra & ~rb).is_empty
+
+
+@given(
+    a=rich_specifier_sets(include_arbitrary=True),
+    b=rich_specifier_sets(include_arbitrary=True),
+)
+@SETTINGS
+def test_disjoint_matches_algebra_rich(a: SpecifierSet, b: SpecifierSet) -> None:
+    """``===`` ranges defer to the algebra; ``_is_plain`` must gate them out."""
+    ra, rb = a.to_range(), b.to_range()
+    assert ra.is_disjoint(rb) == (ra & rb).is_empty
+
+
+@given(
+    a=rich_specifier_sets(include_arbitrary=True),
+    b=rich_specifier_sets(include_arbitrary=True),
+)
+@SETTINGS
+def test_subset_matches_algebra_rich(a: SpecifierSet, b: SpecifierSet) -> None:
+    """``===`` ranges defer to the algebra; ``_is_plain`` must gate them out."""
+    ra, rb = a.to_range(), b.to_range()
+    assert ra.is_subset(rb) == (ra & ~rb).is_empty
+
+
+@given(a=specifier_sets(), b=specifier_sets())
+@SETTINGS
+def test_superset_is_subset_mirror(a: SpecifierSet, b: SpecifierSet) -> None:
+    ra, rb = a.to_range(), b.to_range()
+    assert ra.is_superset(rb) == rb.is_subset(ra)
+
+
+@given(a=specifier_sets(), b=specifier_sets())
+@SETTINGS
+def test_disjoint_symmetric(a: SpecifierSet, b: SpecifierSet) -> None:
+    ra, rb = a.to_range(), b.to_range()
+    assert ra.is_disjoint(rb) == rb.is_disjoint(ra)
+
+
+@given(spec_set=specifier_sets())
+@SETTINGS
+def test_subset_and_superset_reflexive(spec_set: SpecifierSet) -> None:
+    r = spec_set.to_range()
+    assert r.is_subset(r)
+    assert r.is_superset(r)
+
+
+@given(a=specifier_sets(), b=specifier_sets())
+@SETTINGS
+def test_intersection_is_subset_and_pointwise(a: SpecifierSet, b: SpecifierSet) -> None:
+    """``a & b`` is a subset of each operand, with consistent membership.
+
+    Two independently drawn ranges are rarely a subset pair, so the
+    intersection (always contained in each operand) drives the True branch
+    in every example. Pointwise membership over the pool must agree.
+    """
+    ra, rb = a.to_range(), b.to_range()
+    inter = ra & rb
+    assert inter.is_subset(ra)
+    assert inter.is_subset(rb)
+    assert all(v in ra and v in rb for v in VERSION_POOL if v in inter)
+
+
+@given(a=specifier_sets(), b=specifier_sets())
+@SETTINGS
+def test_disjoint_implies_no_shared_member(a: SpecifierSet, b: SpecifierSet) -> None:
+    ra, rb = a.to_range(), b.to_range()
+    if ra.is_disjoint(rb):
+        assert not any(v in ra and v in rb for v in VERSION_POOL)
+
+
+@given(spec_set=specifier_sets())
+@SETTINGS
+def test_empty_is_subset_and_disjoint(spec_set: SpecifierSet) -> None:
+    r = spec_set.to_range()
+    assert VersionRange.empty().is_subset(r)
+    assert VersionRange.empty().is_disjoint(r)

--- a/tests/test_ranges.py
+++ b/tests/test_ranges.py
@@ -251,10 +251,168 @@ class TestSetAlgebra:
     def test_operator_wrong_type(self) -> None:
         assert vr(">=1.0").__and__("x") is NotImplemented
         assert vr(">=1.0").__or__("x") is NotImplemented
+        assert vr(">=1.0").__sub__("x") is NotImplemented
 
     def test_intersection_wrong_type_raises(self) -> None:
         with pytest.raises(TypeError, match="expected VersionRange"):
             vr(">=1.0").intersection("x")  # type: ignore[arg-type]
+
+    def test_difference_wrong_type_raises(self) -> None:
+        with pytest.raises(TypeError, match="expected VersionRange"):
+            vr(">=1.0").difference("x")  # type: ignore[arg-type]
+
+    def test_difference(self) -> None:
+        d = vr(">=1.0") - vr(">=2.0")
+        assert Version("1.5") in d
+        assert Version("1.0") in d
+        assert Version("2.0") not in d
+        assert d == vr(">=1.0") & ~vr(">=2.0")
+
+    def test_difference_method_matches_operator(self) -> None:
+        assert vr(">=1.0").difference(vr(">=2.0")) == vr(">=1.0") - vr(">=2.0")
+
+    def test_difference_with_empty_is_self(self) -> None:
+        r = vr(">=1.0,<2.0")
+        assert (r - VersionRange.empty()) == r
+
+    def test_difference_with_full_is_empty(self) -> None:
+        assert (vr(">=1.0") - VersionRange.full()).is_empty
+
+    def test_difference_keeps_minuend_prerelease_policy(self) -> None:
+        # ``>=1.0`` admits no pre-releases; subtracting a pre-release-naming
+        # range must not grant pre-release admission.
+        no_pre = vr(">=1.0") - vr(">=2.0b1")
+        assert list(no_pre.filter(["2.0b1", "1.5a1", "1.0"])) == ["1.0"]
+        # A pre-release-admitting minuend keeps admitting its pre-releases.
+        keep = vr(">=2.0b1") - vr(">=3.0")
+        assert list(keep.filter(["2.5", "2.0b1"])) == ["2.5", "2.0b1"]
+
+    def test_difference_allows_mismatched_policy(self) -> None:
+        # Unlike intersection, difference discards the subtrahend's policy, so
+        # the operands need not share a configured policy.
+        d = vr(">=1.0") - vr(">=2.0", prereleases=True)
+        assert list(d.filter(["2.0b1", "1.5a1", "1.0"])) == ["1.0"]
+
+    def test_difference_punches_hole(self) -> None:
+        # Subtracting an interior range leaves two intervals.
+        d = vr(">=1.0") - vr(">=2.0,<3.0")
+        assert Version("1.5") in d
+        assert Version("2.5") not in d
+        assert Version("3.5") in d
+
+    def test_difference_with_literals(self) -> None:
+        # ``===`` literal ranges route through the literal-combining branch.
+        assert Version("1.0") in (vr("===1.0") - vr("===2.0"))
+        assert Version("2.0") not in (vr("===1.0") - vr("===2.0"))
+        assert Version("1.0") in (vr("===1.0") - vr(">=2.0"))
+
+
+class TestSetRelations:
+    def test_disjoint_false(self) -> None:
+        assert not vr(">=1.0,<2.0").is_disjoint(vr(">=1.5,<2.5"))
+
+    def test_disjoint_higher_range_on_left(self) -> None:
+        # The receiver sits entirely above the argument, including when the
+        # argument spans several intervals.
+        assert vr(">=2.0,<3.0").is_disjoint(vr(">=1.0,<1.5"))
+        assert vr(">=5.0,<6.0").is_disjoint(vr(">=1.0,<2.0") | vr(">=3.0,<4.0"))
+
+    def test_disjoint_shared_inclusive_endpoint(self) -> None:
+        # ``[1, 2)`` and ``[2, 3)`` touch but share no version.
+        assert vr(">=1.0,<2.0").is_disjoint(vr(">=2.0,<3.0"))
+        # ``[1, 2]`` and ``[2, 3)`` both admit 2.0.
+        assert not vr(">=1.0,<=2.0").is_disjoint(vr(">=2.0,<3.0"))
+
+    def test_subset_true(self) -> None:
+        assert vr(">=1.5,<1.8").is_subset(vr(">=1.0,<2.0"))
+
+    def test_subset_false(self) -> None:
+        assert not vr(">=1.0,<2.0").is_subset(vr(">=1.5,<1.8"))
+
+    def test_subset_partial_overlap_false(self) -> None:
+        assert not vr(">=1.0,<2.0").is_subset(vr(">=1.5,<2.5"))
+
+    def test_subset_reflexive(self) -> None:
+        r = vr(">=1.0,<2.0")
+        assert r.is_subset(r)
+
+    def test_empty_is_subset_of_everything(self) -> None:
+        assert VersionRange.empty().is_subset(vr(">=1.0"))
+        assert VersionRange.empty().is_subset(VersionRange.empty())
+        assert VersionRange.empty().is_disjoint(vr(">=1.0"))
+
+    def test_nonempty_not_subset_of_empty(self) -> None:
+        assert not vr(">=1.0").is_subset(VersionRange.empty())
+
+    def test_everything_is_subset_of_full(self) -> None:
+        assert vr(">=1.0,<2.0").is_subset(VersionRange.full())
+
+    def test_superset_mirrors_subset(self) -> None:
+        outer, inner = vr(">=1.0,<2.0"), vr(">=1.5,<1.8")
+        assert outer.is_superset(inner)
+        assert not inner.is_superset(outer)
+        assert outer.is_superset(inner) == inner.is_subset(outer)
+
+    def test_multi_interval_subset(self) -> None:
+        # ``!=1.5`` splits ``[1, 2)`` into two pieces, still inside ``[1, 2)``.
+        gapped = vr(">=1.0,<2.0,!=1.5")
+        whole = vr(">=1.0,<2.0")
+        assert gapped.is_subset(whole)
+        assert not whole.is_subset(gapped)
+        assert not gapped.is_disjoint(whole)
+
+    def test_disjoint_nonempty_excludes_subset(self) -> None:
+        a, b = vr(">=1.0,<2.0"), vr(">=3.0,<4.0")
+        assert a.is_disjoint(b)
+        assert not a.is_subset(b)
+
+    def test_literal_ranges_disjoint(self) -> None:
+        assert vr("===a").is_disjoint(vr("===b"))
+        assert not vr("===a").is_disjoint(vr("===a"))
+
+    def test_literal_range_subset_matches_algebra(self) -> None:
+        # ``===`` ranges take the fallback path; it equals the set algebra.
+        a, b = vr("===a"), vr("===a") | vr("===b")
+        assert a.is_subset(b) == (a & ~b).is_empty
+        assert a.is_subset(b)
+
+    def test_full_arbitrary_matches_algebra(self) -> None:
+        # ``full()`` carries the arbitrary-string flag, so it is not plain and
+        # both relations defer to the algebra.
+        f, b = VersionRange.full(), vr(">=1.0")
+        assert f.is_subset(b) == (f & ~b).is_empty
+        assert f.is_disjoint(b) == (f & b).is_empty
+        assert b.is_subset(f)
+
+    def test_prerelease_excluding_policy_matches_algebra(self) -> None:
+        # ``prereleases=False`` ranges are not plain, so both relations take
+        # the algebra fallback; pin concrete non-trivial answers there.
+        inner = vr(">=1.2,<1.8", prereleases=False)
+        outer = vr(">=1.0,<2.0", prereleases=False)
+        far = vr(">=5.0,<6.0", prereleases=False)
+        assert inner.is_subset(outer)
+        assert not outer.is_subset(inner)
+        assert inner.is_disjoint(far)
+        assert not inner.is_disjoint(outer)
+        for a, b in [(inner, outer), (outer, inner), (inner, far)]:
+            assert a.is_subset(b) == (a & ~b).is_empty
+            assert a.is_disjoint(b) == (a & b).is_empty
+
+    def test_policy_mismatch_raises(self) -> None:
+        with pytest.raises(ValueError, match="different"):
+            vr(">=1.0", prereleases=True).is_subset(vr("<2.0", prereleases=False))
+        with pytest.raises(ValueError, match="different"):
+            vr(">=1.0", prereleases=True).is_disjoint(vr("<2.0", prereleases=False))
+        with pytest.raises(ValueError, match="different"):
+            vr(">=1.0", prereleases=True).is_superset(vr("<2.0", prereleases=False))
+
+    def test_wrong_type_raises(self) -> None:
+        with pytest.raises(TypeError, match="expected VersionRange"):
+            vr(">=1.0").is_subset("x")  # type: ignore[arg-type]
+        with pytest.raises(TypeError, match="expected VersionRange"):
+            vr(">=1.0").is_disjoint("x")  # type: ignore[arg-type]
+        with pytest.raises(TypeError, match="expected VersionRange"):
+            vr(">=1.0").is_superset("x")  # type: ignore[arg-type]
 
 
 class TestFilter:

--- a/tests/test_ranges.py
+++ b/tests/test_ranges.py
@@ -306,6 +306,43 @@ class TestSetAlgebra:
         assert Version("2.0") not in (vr("===1.0") - vr("===2.0"))
         assert Version("1.0") in (vr("===1.0") - vr(">=2.0"))
 
+    def test_difference_with_empty_preserves_arbitrary(self) -> None:
+        # Regression: difference once routed through ``other.complement()``,
+        # which dropped the minuend's arbitrary-string admission even when
+        # nothing was subtracted. ``a - empty`` must round-trip the full range.
+        full = VersionRange.full()
+        assert (full - VersionRange.empty()) == full
+        assert "garbage" in (full - VersionRange.empty())
+
+    def test_difference_with_empty_preserves_literals(self) -> None:
+        # The same regression for ``===`` admission: a literal range minus the
+        # empty range keeps its literal.
+        wat = vr("===wat")
+        assert (wat - VersionRange.empty()) == wat
+        assert "wat" in (wat - VersionRange.empty())
+
+    def test_difference_excludes_only_named_literal(self) -> None:
+        # full() minus a ``===`` literal keeps every version and every other
+        # arbitrary string, dropping only the excluded literal.
+        d = VersionRange.full() - vr("===wat")
+        assert "wat" not in d
+        assert "garbage" in d
+        assert Version("1.0") in d
+
+    def test_difference_with_self_is_empty(self) -> None:
+        # ``a - a`` is empty for arbitrary-admitting and ``===`` ranges too.
+        assert (vr("===wat") - vr("===wat")).is_empty
+        assert (VersionRange.full() - VersionRange.full()).is_empty
+
+    def test_difference_minuend_with_reject_literal(self) -> None:
+        # Complementing a ``===`` range leaves a reject literal on the minuend;
+        # difference keeps honoring it through the literal-combining branch.
+        minuend = ~vr("===1.0")
+        d = minuend - vr("===2.0")
+        assert Version("3.0") in d
+        assert Version("1.0") not in d
+        assert Version("2.0") not in d
+
 
 class TestSetRelations:
     def test_disjoint_false(self) -> None:


### PR DESCRIPTION
Trying to adapt `VersionRange` to my pubgrub-based resolver [nab](https://github.com/notatallshaw/nab) I found two issues:

1. In a few places I had incorrectly implemented subset and disjoint checks

Solved by adding direct helper methods to avoid the footgun of implementing them wrong

2. Excluding a range using `a & ~b` introduced an unwanted pre-release policy: `a` didn't imply pre-releases but `b` did

This needs *some* new method. My proposal is the set operation `difference` where `a - b` will take the pre-release policy of `a` and discard `b`'s.

This could also be solved with something like `with_prerelease(prerelease)`, a class method that returns a new `VersionRange` object, but this pushes handling of PEP 440 pre-release policy logic up to the user, which is exactly what I'm trying to avoid with `VersionRange`.

Here's a worked example of the problem:

```python
# foo is required >=1.0; a rejected branch that needed foo >=2.0b1 left behind
# a negative term excluding >=2.0b1. Available: foo 1.9 (final), 2.0a1 (pre-release).
required = SpecifierSet(">=1.0").to_range()
excluded = SpecifierSet(">=2.0b1").to_range()

list((required - excluded).filter(["1.9", "2.0a1"]))    # ['1.9']
list((required & ~excluded).filter(["1.9", "2.0a1"]))   # ['1.9', '2.0a1']
```

Changing `A & ~B`'s policy instead of adding `-` would not work: `&` and `~` have their own correct behavior. Intersection must combine two requirements' policies (folding one as `full() & req` keeps its policy), and complement must stay an involution (`~~r == r`). Neither knows it is part of a difference, so `-` is the operation that treats `B` as a bare exclusion.
