### PR TITLE
fix(requirements): clarify post-release prefix wildcard errors

### DIFF
--- a/src/packaging/_parser.py
+++ b/src/packaging/_parser.py
@@ -265,10 +265,19 @@ def _parse_version_many(tokenizer: Tokenizer) -> str:
     parsed_specifiers = ""
     while tokenizer.check("SPECIFIER"):
         span_start = tokenizer.position
-        parsed_specifiers += tokenizer.read().text
+        specifier = tokenizer.read().text
+        parsed_specifiers += specifier
         if tokenizer.check("VERSION_PREFIX_TRAIL", peek=True):
+            message = ".* suffix can only be used with `==` or `!=` operators"
+            if specifier.startswith("!=") or (
+                specifier.startswith("==") and not specifier.startswith("===")
+            ):
+                message = (
+                    ".* suffix cannot be used with pre-release, post-release, "
+                    "dev or local versions"
+                )
             tokenizer.raise_syntax_error(
-                ".* suffix can only be used with `==` or `!=` operators",
+                message,
                 span_start=span_start,
                 span_end=tokenizer.position + 1,
             )

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -343,9 +343,7 @@ class TestRequirementParsing:
         )
 
     @pytest.mark.parametrize("operator", ["==", "!="])
-    def test_error_when_prefix_match_uses_post_release(
-        self, operator: str
-    ) -> None:
+    def test_error_when_prefix_match_uses_post_release(self, operator: str) -> None:
         # GIVEN
         to_parse = f"name {operator} 1.2.3.post4.*"
         op_tilde = len(operator) * "~"

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -342,6 +342,46 @@ class TestRequirementParsing:
             "           ~~~~~^"
         )
 
+    @pytest.mark.parametrize("operator", ["==", "!="])
+    def test_error_when_prefix_match_uses_post_release(
+        self, operator: str
+    ) -> None:
+        # GIVEN
+        to_parse = f"name {operator} 1.2.3.post4.*"
+        op_tilde = len(operator) * "~"
+
+        # WHEN
+        with pytest.raises(InvalidRequirement) as ctx:
+            Requirement(to_parse)
+
+        # THEN
+        assert ctx.exconly() == (
+            "packaging.requirements.InvalidRequirement: "
+            ".* suffix cannot be used with pre-release, post-release, "
+            "dev or local versions\n"
+            f"    name {operator} 1.2.3.post4.*\n"
+            f"         {op_tilde}~~~~~~~~~~~~~^"
+        )
+
+    def test_error_when_prefix_match_uses_post_release_without_spaces(
+        self,
+    ) -> None:
+        # GIVEN
+        to_parse = "name==1.2.3.post4.*"
+
+        # WHEN
+        with pytest.raises(InvalidRequirement) as ctx:
+            Requirement(to_parse)
+
+        # THEN
+        assert ctx.exconly() == (
+            "packaging.requirements.InvalidRequirement: "
+            ".* suffix cannot be used with pre-release, post-release, "
+            "dev or local versions\n"
+            "    name==1.2.3.post4.*\n"
+            "        ~~~~~~~~~~~~~~^"
+        )
+
     @pytest.mark.parametrize("operator", [">=", "<=", ">", "<", "~="])
     def test_error_when_local_version_label_is_used_incorrectly(
         self, operator: str


### PR DESCRIPTION
Fixes #831.

`Requirement("a==1.2.3.post4.*")` currently reports:

```text
.* suffix can only be used with `==` or `!=` operators
```

The operator is already `==`, so that points users at the wrong problem. This keeps the existing validation behavior, but uses the more specific prefix-matching diagnostic when `.*` follows a `==` or `!=` specifier whose version includes a pre-release, post-release, dev, or local segment.

The existing non-prefix operators, such as `>=20.*`, still use the operator-focused message.

Tests:
- `uv run pytest tests/test_requirements.py -q -k 'prefix_match'`
- `uv run ruff check src/packaging/_parser.py tests/test_requirements.py`
