### PR TITLE
docs(requirements): note normalized Requirement comparisons

### DIFF
--- a/docs/requirements.rst
+++ b/docs/requirements.rst
@@ -51,6 +51,10 @@ Usage
     >>> # You can do simple comparisons between requirement objects:
     >>> Requirement("packaging") == Requirement("packaging")
     True
+    >>> Requirement("my_pkg[foo_bar] == 1.0") == Requirement("my-pkg[foo-bar] == 1.0.0")
+    True
+    >>> str(Requirement("my_pkg[foo_bar] == 1.0"))
+    'my_pkg[foo_bar]==1.0'
     >>> # You can also perform simple comparisons between sets of requirements:
     >>> requirements1 = {Requirement("packaging"), Requirement("pip")}
     >>> requirements2 = {Requirement("pip"), Requirement("packaging")}
@@ -88,6 +92,10 @@ Reference
         The dedicated pickle support introduced in 26.2 did not preserve the
         specifier's explicit :attr:`~packaging.specifiers.SpecifierSet.prereleases`
         override; it is now included again.
+
+        Equality and hashing normalize requirement names, extras, and
+        equivalent specifiers. The string representation still preserves the
+        parsed name and extras spelling.
 
     :param str requirement_string: The string representation of a requirement.
     :raises InvalidRequirement: If the given ``requirement_string`` is not parseable,

--- a/src/packaging/requirements.py
+++ b/src/packaging/requirements.py
@@ -52,6 +52,10 @@ class Requirement:
         The dedicated pickle support introduced in 26.2 did not preserve the
         specifier's explicit :attr:`~packaging.specifiers.SpecifierSet.prereleases`
         override; it is now included again.
+
+        Equality and hashing normalize requirement names, extras, and
+        equivalent specifiers. The string representation still preserves the
+        parsed name and extras spelling.
     """
 
     # TODO: Can we test whether something is contained within a requirement?


### PR DESCRIPTION
## Summary
- document that `Requirement` equality and hashing normalize names, extras, and equivalent specifiers
- add a small doctest example showing the distinction between comparison semantics and string preservation
- mirror the note in the `Requirement` class docstring for generated/reference readers

## Why
#1278 made requested extras participate in normalized `Requirement` equality and hashing. The current requirements docs still only show exact-string equality, which makes the new behavior discoverable only from the implementation and tests.

This keeps the note narrow: `str(Requirement(...))` still preserves the parsed requirement spelling, while comparison and hashing use normalized names/extras/specifiers.

## Checks
- `uv run python -m doctest docs/requirements.rst`
- `uv run ruff format --check src/packaging/requirements.py`
- `uv run ruff check src/packaging/requirements.py`
- `uv run pytest tests/test_requirements.py -q -k 'equal_hashes or equivalent_reqs'`
- `git diff --check`
