### PR TITLE
fix(tags): raise SystemError for malformed cpython EXT_SUFFIX in _generic_abi

### DIFF
--- a/src/packaging/tags.py
+++ b/src/packaging/tags.py
@@ -450,7 +450,10 @@ def _generic_abi() -> list[str]:
     soabi = parts[1]
     if soabi.startswith("cpython"):
         # non-windows
-        abi = "cp" + soabi.split("-")[1]
+        cpython_parts = soabi.split("-")
+        if len(cpython_parts) < 2 or not cpython_parts[1]:
+            raise SystemError("invalid sysconfig.get_config_var('EXT_SUFFIX')")
+        abi = "cp" + cpython_parts[1]
     elif soabi.startswith("cp"):
         # windows
         abi = soabi.split("-")[0]

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -1357,6 +1357,20 @@ class TestGenericTags:
             tags._generic_abi()
         assert "EXT_SUFFIX" in str(e.value)
 
+    # ".cpython.so" has no version component at all (would raise IndexError);
+    # ".cpython-.so" has a dash but an empty version (would build an invalid
+    # "cp" ABI). Both are malformed cpython soabis that should surface the same
+    # actionable SystemError as the other malformed EXT_SUFFIX cases.
+    @pytest.mark.parametrize("ext_suffix", [".cpython.so", ".cpython-.so"])
+    def test__generic_abi_cpython_missing_version(
+        self, ext_suffix: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        config = {"EXT_SUFFIX": ext_suffix}
+        monkeypatch.setattr(sysconfig, "get_config_var", config.__getitem__)
+        with pytest.raises(SystemError) as e:
+            tags._generic_abi()
+        assert "EXT_SUFFIX" in str(e.value)
+
     def test__generic_abi_linux_pypy(self, monkeypatch: pytest.MonkeyPatch) -> None:
         # issue gh-606
         config = {


### PR DESCRIPTION
Follow-up to #1271. `_generic_abi()` still leaks an opaque `IndexError` (instead of the documented `SystemError`) from the public `generic_tags()` / `sys_tags()` API for a malformed cpython `EXT_SUFFIX`.

#1271 fixed the top-of-function guard for an empty `EXT_SUFFIX`, but the cpython branch a few lines down does `soabi.split("-")[1]`:

- `EXT_SUFFIX = ".cpython.so"` → `soabi = "cpython"` → `split("-") == ["cpython"]` → `[1]` raises `IndexError: list index out of range`.
- `EXT_SUFFIX = ".cpython-.so"` → `soabi = "cpython-"` → empty version component → silently builds an invalid `"cp"` ABI.

Every other interpreter branch uses `split("-")[0]` or a slice and never over-indexes, so only the cpython branch is affected. This guards the split and raises the same `SystemError("invalid sysconfig.get_config_var('EXT_SUFFIX')")` for both cases — the same wrong-exception-leak class fixed in #1271 / #1264 — plus a parametrized regression test.
