### PR TITLE
fix(dependency_groups): collect InvalidRequirement instead of leaking it

### DIFF
--- a/src/packaging/dependency_groups.py
+++ b/src/packaging/dependency_groups.py
@@ -242,9 +242,7 @@ class DependencyGroupResolver:
             if isinstance(item, str):
                 # packaging.requirements.Requirement parsing ensures that this is a
                 # valid PEP 508 Dependency Specifier. Collect InvalidRequirement
-                # like every other failure in this loop: raising it raw would
-                # escape the aggregated "...was malformed" error group and drop
-                # any sibling errors already collected for this group.
+                # if it throws that.
                 with errors.collect(InvalidRequirement):
                     elements.append(Requirement(item))
             elif isinstance(item, Mapping):

--- a/src/packaging/dependency_groups.py
+++ b/src/packaging/dependency_groups.py
@@ -4,7 +4,7 @@ import re
 from collections.abc import Mapping, Sequence
 
 from .errors import _ErrorCollector
-from .requirements import Requirement
+from .requirements import InvalidRequirement, Requirement
 
 __all__ = [
     "CyclicDependencyGroup",
@@ -241,9 +241,12 @@ class DependencyGroupResolver:
         for item in raw_group:
             if isinstance(item, str):
                 # packaging.requirements.Requirement parsing ensures that this is a
-                # valid PEP 508 Dependency Specifier
-                # raises InvalidRequirement on failure
-                elements.append(Requirement(item))
+                # valid PEP 508 Dependency Specifier. Collect InvalidRequirement
+                # like every other failure in this loop: raising it raw would
+                # escape the aggregated "...was malformed" error group and drop
+                # any sibling errors already collected for this group.
+                with errors.collect(InvalidRequirement):
+                    elements.append(Requirement(item))
             elif isinstance(item, Mapping):
                 if tuple(item.keys()) != ("include-group",):
                     errors.error(

--- a/tests/test_dependency_groups.py
+++ b/tests/test_dependency_groups.py
@@ -15,7 +15,7 @@ from packaging.dependency_groups import (
     resolve_dependency_groups,
 )
 from packaging.errors import ExceptionGroup
-from packaging.requirements import Requirement
+from packaging.requirements import InvalidRequirement, Requirement
 
 if TYPE_CHECKING:
     import sys
@@ -461,6 +461,30 @@ def test_non_unexpected_item_type() -> None:
 def test_dependency_group_include_repr() -> None:
     include = DependencyGroupInclude("test")
     assert repr(include) == "DependencyGroupInclude('test')"
+
+
+def test_resolution_collects_invalid_requirement_with_sibling_errors() -> None:
+    # A malformed PEP 508 requirement string used to raise InvalidRequirement
+    # raw, which both escaped the aggregated "...was malformed" error group and
+    # dropped any sibling errors already collected from the same group. It should
+    # now be collected like every other failure so co-occurring errors are all
+    # reported together.
+    groups: Any = {
+        "all": [
+            {},  # invalid object -> collected before the bad requirement string
+            "this is not a valid requirement!!!",
+        ],
+    }
+
+    with pytest.raises(
+        ExceptionGroup, match=r"\[dependency-groups\] data for 'all' was malformed"
+    ) as excinfo:
+        resolve_dependency_groups(groups, "all")
+
+    # the malformed requirement is aggregated rather than raised raw...
+    assert _group_contains(excinfo, InvalidRequirement)
+    # ...and the sibling error collected earlier in the same group is not dropped
+    assert _group_contains(excinfo, InvalidDependencyGroupObject)
 
 
 def test_resolution_can_capture_multiple_errors_at_once() -> None:


### PR DESCRIPTION
Follow-up to #1248. In `DependencyGroupResolver._parse_group`, the string-item branch builds `Requirement(item)` and lets `InvalidRequirement` propagate **raw** — the only branch in that loop that doesn't route through the error collector.

A single malformed PEP 508 requirement string therefore:

1. **drops sibling errors already collected for that group** — the raw raise short-circuits the loop, so the post-loop `if errors.errors: return ()` is never reached and any error collected earlier in the same loop (an invalid object `{}`, a non-string `include-group`, an unknown item type) is lost; and
2. escapes the documented aggregated `[dependency-groups] data for <group> was malformed` `ExceptionGroup` as a bare `InvalidRequirement`.

#1248 collected the adjacent include-group `TypeError` in the same loop but left this branch raw. The fix wraps the parse in `errors.collect(InvalidRequirement)` — the collector's own documented in-loop helper (`InvalidRequirement` subclasses `ValueError`, so it's collectible) — so all malformed-group diagnostics are uniform and complete.

`lookup()` / `resolve()` document the aggregated-`ExceptionGroup` contract (not `:raises InvalidRequirement`), so this aligns the string branch with the port's actual contract rather than changing it. The regression test asserts a bad requirement string is now reported together with a co-occurring sibling error instead of dropping it.
