### PR TITLE
docs(ranges): add `.. versionadded:: 26.3` to the public VersionRange class

### DIFF
--- a/src/packaging/ranges.py
+++ b/src/packaging/ranges.py
@@ -336,6 +336,8 @@ class VersionRange:
     (case-insensitive) rather than a set of versions. Ranges built from
     ``===`` specifiers still support membership and set operations; matching
     follows the literal-equality rule.
+
+    .. versionadded:: 26.3
     """
 
     __slots__ = (


### PR DESCRIPTION
The public `VersionRange` class (the whole `src/packaging/ranges.py` module, shipped in #1267 and extended in #1298) carries no version directive, while the method that produces it — `SpecifierSet.to_range()` — already declares `.. versionadded:: 26.3` (`specifiers.py:1129`). The other recently-added public classes carry a class-level directive as well: `Version` has `.. versionadded:: 26.0` and `Marker` has `.. versionchanged:: 26.2`.

This adds `.. versionadded:: 26.3` to the `VersionRange` class docstring, placed as the last docstring element to match `to_range`/`Version`. `docs/ranges.rst` renders it through `.. automodule:: packaging.ranges`, so readers of the reference learn which release first ships the API.

Pure docs — no code change. No changelog entry, since the feature is already recorded under `:pull:`1267``.
