### PR TITLE
Scope VersionRange filter of pre-releases to a region so it complies with set algebra

### DIFF
--- a/docs/ranges.rst
+++ b/docs/ranges.rst
@@ -30,6 +30,12 @@ Usage
     >>> b = SpecifierSet("<2.0").to_range()
     >>> a & b == r
     True
+    >>> # The union covers either side, leaving any gap between them
+    >>> u = SpecifierSet("<1.0").to_range() | SpecifierSet(">=2.0").to_range()
+    >>> Version("0.5") in u
+    True
+    >>> Version("1.5") in u
+    False
     >>> # The complement is every other version
     >>> Version("0.5") in ~r
     True
@@ -40,11 +46,30 @@ Usage
     >>> SpecifierSet(">=2.0,<1.0").to_range().is_empty
     True
 
-``a - b`` is set difference: the versions in ``a`` but not ``b``. On the version
-set it matches ``a & ~b``, but it keeps only ``a``'s pre-release policy, since
-``b`` is treated as an exclusion that grants no pre-release admission of its own.
-Subtracting a pre-release-naming range therefore does not let pre-releases into
-the result:
+Pre-releases
+------------
+
+A specifier that names a pre-release, such as ``>=2.0b1``, opts in pre-releases
+only for the versions it asks for. That opt-in region is carried as ranges are
+combined, so a union with a plain range keeps the pre-releases it named without
+admitting every pre-release below them:
+
+.. doctest::
+
+    >>> a = SpecifierSet(">=1.0").to_range()
+    >>> b = SpecifierSet(">=2.0b1").to_range()
+    >>> list((a | b).filter(["1.5b1", "2.0b1", "2.5"]))
+    ['2.0b1', '2.5']
+
+``2.0b1`` is admitted because ``>=2.0b1`` asked for it; ``1.5b1`` is not, since
+the opt-in never came from ``>=1.0``.
+
+Set difference
+--------------
+
+``a - b`` is set difference: the versions in ``a`` but not ``b``. It agrees with
+``a & ~b`` on the version set and the opt-in region, so subtracting a
+pre-release-naming range does not leak its pre-releases into the result:
 
 .. doctest::
 
@@ -52,23 +77,24 @@ the result:
     >>> excluded = SpecifierSet(">=2.0b1").to_range()
     >>> list((base - excluded).filter(["1.9", "2.0a1"]))
     ['1.9']
-    >>> list((base & ~excluded).filter(["1.9", "2.0a1"]))
-    ['1.9', '2.0a1']
+    >>> (base - excluded) == (base & ~excluded)
+    True
 
 Comparing ranges
 ----------------
 
-Equality on a :class:`VersionRange` is structural: two ranges are equal only
-when they behave the same under :meth:`VersionRange.contains` and
-:meth:`VersionRange.filter`. Equality covers the pre-release policy and any
-``===`` admission, not only the versions matched.
+Equality on a :class:`VersionRange` is structural: it compares the bounds, the
+``===`` admit/reject literals, the arbitrary-string flag, the configured
+pre-release policy, and the opt-in region, not only the version set. Equal
+ranges therefore behave identically under :meth:`VersionRange.contains` and
+:meth:`VersionRange.filter`.
 
 For set relations use :meth:`VersionRange.is_subset`,
 :meth:`VersionRange.is_superset`, and :meth:`VersionRange.is_disjoint` rather
-than comparing intersections by hand. Intersection can change the pre-release
-policy without changing the version set, so the textbook subset test
+than comparing intersections by hand. Intersection can change the opt-in
+region without changing the version set, so the textbook subset test
 ``a & b == a`` can report a false negative. Each method compares the version
-sets directly, so it is not affected by that policy difference:
+sets directly, so it is not affected by that opt-in difference:
 
 .. doctest::
 
@@ -76,7 +102,7 @@ sets directly, so it is not affected by that policy difference:
     >>> a = SpecifierSet(">=1.0").to_range()
     >>> b = SpecifierSet(">=1.0a1").to_range()
     >>> # Every version >=1.0 is also >=1.0a1, so a is a subset of b. But b
-    >>> # admits pre-releases, so ``a & b`` and ``a`` differ only in policy:
+    >>> # opts pre-releases in, so ``a & b`` and ``a`` differ in the opt-in region:
     >>> a & b == a
     False
     >>> a.is_subset(b)
@@ -85,20 +111,37 @@ sets directly, so it is not affected by that policy difference:
     True
     >>> a.is_disjoint(b)
     False
+    >>> # The opt-in difference is observable: a & b force-admits pre-releases
+    >>> # in b's region that plain a filters out
+    >>> list(a.filter(["2.0a1", "2.5"]))
+    ['2.5']
+    >>> list((a & b).filter(["2.0a1", "2.5"]))
+    ['2.0a1', '2.5']
 
-Different specifiers for the same set of versions canonicalize to one form, so
-they compare equal. ``>1.0a1`` excludes ``1.0a1``'s post-releases per PEP 440,
-so its smallest member is ``1.0a2.dev0``, exactly the set of ``>=1.0a2.dev0``:
+Like :meth:`VersionRange.intersection` and :meth:`VersionRange.union`, these
+predicates require both operands to share the same configured pre-release policy
+and raise :exc:`ValueError` otherwise; only :meth:`VersionRange.difference` is
+exempt.
+
+Different specifiers that denote the same range, opt-in region included,
+canonicalize to one form, so they compare equal. ``>1.0a1`` excludes
+``1.0a1``'s post-releases per PEP 440, so its smallest member is ``1.0a2.dev0``,
+exactly the set of ``>=1.0a2.dev0``:
 
 .. doctest::
 
-    >>> SpecifierSet(">1.0a1").to_range() == SpecifierSet(">=1.0a2.dev0").to_range()
+    >>> r1 = SpecifierSet(">1.0a1").to_range()
+    >>> r2 = SpecifierSet(">=1.0a2.dev0").to_range()
+    >>> r1 == r2
+    True
+    >>> third = SpecifierSet("<2.0").to_range()
+    >>> (r1 & third) == (r2 & third)
     True
 
-The pre-release policy is still part of equality. ``<1.0.post0.dev0`` and
-``<=1.0`` cover the same versions, but the first admits pre-releases by default
-(its bound is a ``.dev`` release) while the second does not, so they are not
-substitutable and compare unequal:
+The opt-in region is also part of equality. ``<1.0.post0.dev0`` and
+``<=1.0`` cover the same versions, but the first autodetects an opt-in
+region from its ``.dev`` bound, so it admits pre-releases by default,
+while the second does not; they are not substitutable and compare unequal:
 
 .. doctest::
 

--- a/src/packaging/_ranges.py
+++ b/src/packaging/_ranges.py
@@ -531,20 +531,23 @@ def filter_by_ranges(
     iterable: Iterable[Any],
     key: Callable[[Any], Version | str] | None,
     prereleases: bool | None,
+    region: Sequence[VersionRange] = (),
 ) -> Iterator[Any]:
     """Filter *iterable* against precomputed version *ranges*.
 
-    With ``prereleases=None``, the PEP 440 default applies: pre-releases
-    are excluded unless no final matches, in which case buffered
-    pre-releases come out at the end.
+    With ``prereleases=None``, the PEP 440 default applies: pre-releases are
+    excluded unless no final matches, in which case buffered pre-releases come
+    out at the end. A pre-release inside the opt-in ``region`` is the exception:
+    it is force-admitted in place, as ``prereleases=True`` would yield it. A
+    force-admitted pre-release is not a final, so it never suppresses the buffer.
     """
     if prereleases is None:
-        # PEP 440 default: yield finals immediately; buffer
-        # pre-releases until at least one final has been emitted.
         prerelease_buffer: list[Any] = []
         found_final = False
 
         if len(ranges) == 1:
+            # Hot path: most specifiers and small SpecifierSets reduce to
+            # a single contiguous range.
             lower, upper = ranges[0]
             above = lower._above
             below = upper._below
@@ -556,12 +559,13 @@ def filter_by_ranges(
                     continue
                 if below is not None and not below(parsed):
                     continue
-                if parsed.is_prerelease:
-                    if not found_final:
-                        prerelease_buffer.append(item)
-                else:
+                if not parsed.is_prerelease:
                     found_final = True
                     yield item
+                elif region and matches_bounds_only(region, parsed):
+                    yield item
+                elif not found_final:
+                    prerelease_buffer.append(item)
             if not found_final:
                 yield from prerelease_buffer
             return
@@ -576,12 +580,13 @@ def filter_by_ranges(
                     break
                 below = upper._below
                 if below is None or below(parsed):
-                    if parsed.is_prerelease:
-                        if not found_final:
-                            prerelease_buffer.append(item)
-                    else:
+                    if not parsed.is_prerelease:
                         found_final = True
                         yield item
+                    elif region and matches_bounds_only(region, parsed):
+                        yield item
+                    elif not found_final:
+                        prerelease_buffer.append(item)
                     break
         if not found_final:
             yield from prerelease_buffer

--- a/src/packaging/ranges.py
+++ b/src/packaging/ranges.py
@@ -306,6 +306,13 @@ def _format_upper(bound: UpperBound) -> str:
     return f"{_bound_version_str(bound.version)}{bracket}"
 
 
+def _format_intervals(intervals: Sequence[_Interval]) -> str:
+    """Render a sorted interval list as ``lower, upper | lower, upper``."""
+    return " | ".join(
+        f"{_format_lower(lower)}, {_format_upper(upper)}" for lower, upper in intervals
+    )
+
+
 class VersionRange:
     """A set of :class:`~packaging.version.Version` values accepted by a
     :class:`~packaging.specifiers.SpecifierSet`.
@@ -319,10 +326,15 @@ class VersionRange:
 
     The configured pre-release policy of the originating specifier set carries
     onto the range and controls whether pre-releases are admitted under ``in``,
-    :meth:`contains`, and :meth:`filter`. :meth:`intersection`,
-    :meth:`union`, and the :meth:`is_subset` / :meth:`is_superset` /
-    :meth:`is_disjoint` predicates require both operands to share the same
-    policy; set difference (``-``) does not.
+    :meth:`contains`, and :meth:`filter`. With no configured policy,
+    :meth:`filter` also admits pre-releases in the autodetected opt-in region
+    (the versions a pre-release-naming specifier asked for). Set algebra keeps
+    that opt-in scoped to those versions, so unrelated pre-releases are not
+    admitted wholesale.
+
+    :meth:`intersection`, :meth:`union`, and the :meth:`is_subset` /
+    :meth:`is_superset` / :meth:`is_disjoint` predicates require both operands
+    to share the same configured policy.
 
     >>> r = SpecifierSet(">=1.0,<2.0").to_range()
     >>> "1.5" in r
@@ -335,7 +347,9 @@ class VersionRange:
     PEP 440's ``===`` operator matches a candidate string verbatim
     (case-insensitive) rather than a set of versions. Ranges built from
     ``===`` specifiers still support membership and set operations; matching
-    follows the literal-equality rule.
+    follows the literal-equality rule. A ``===`` literal that names a
+    pre-release is admitted under the default policy by both :meth:`contains`
+    and :meth:`filter`, since it was named outright.
 
     .. versionadded:: 26.3
     """
@@ -344,7 +358,7 @@ class VersionRange:
         "_admit",
         "_admit_arbitrary",
         "_bounds",
-        "_prereleases",
+        "_pre_region",
         "_prereleases_configured",
         "_reject",
     )
@@ -353,9 +367,11 @@ class VersionRange:
     _bounds: tuple[_Interval, ...]
 
     #: Whether this range matches non-version strings as well as versions.
-    #: True only by construction on ``SpecifierSet("")`` / :meth:`full`. Set
-    #: algebra ANDs on intersection, ORs on union, and preserves on complement.
-    #: Part of equality, since membership reads it.
+    #: True only by construction on ``SpecifierSet("")`` / :meth:`full`. The flag
+    #: rides set algebra but is inert except at full bounds (see
+    #: :meth:`_arbitrary_active`). A binary op that empties out drops it
+    #: (``full() & ~full()`` is plain empty); :meth:`complement` keeps it, so
+    #: ``~~full() == full()``. Part of equality, since membership reads it.
     _admit_arbitrary: bool
 
     #: Case-folded strings the range admits in addition to its bounds.
@@ -363,17 +379,25 @@ class VersionRange:
     _admit: frozenset[str]
 
     #: Case-folded strings the range rejects (overrides ``_admit`` and the
-    #: bounds). Populated only by :meth:`complement` of an admit-bearing range.
+    #: bounds). Populated by :meth:`complement` of an admit-bearing range and by
+    #: literal resolution in :meth:`_combine_literals`.
     _reject: frozenset[str]
 
-    #: Resolved pre-release policy used by :meth:`filter` and :meth:`contains`
-    #: when their ``prereleases`` argument is ``None``. Part of equality, so
-    #: two ranges that compare equal always filter the same versions.
-    _prereleases: bool | None
+    #: Sorted, disjoint intervals where pre-releases are force-admitted under
+    #: the PEP 440 default policy (a ``None`` ``prereleases`` argument and no
+    #: configured override). Set algebra (:meth:`union`, :meth:`intersection`,
+    #: :meth:`difference`) accumulates this autodetected opt-in raw (not clipped
+    #: to the result bounds), which keeps it distributive. It may reach past the
+    #: bounds, but :meth:`filter` only force-admits a pre-release that already
+    #: passed the bounds check, so the out-of-bounds part never fires. Equality
+    #: keys on the raw region, so it stays a congruence.
+    _pre_region: tuple[_Interval, ...]
 
-    #: Raw configured pre-release override of the originating specifier set.
-    #: Distinguishes autodetect-True from explicit-True. :meth:`intersection`
-    #: and :meth:`union` require it to match on both operands. Part of equality.
+    #: Raw configured pre-release override of the originating specifier set
+    #: (an explicit ``True`` / ``False``, else ``None``). When set, :meth:`_build`
+    #: forces ``_pre_region`` empty since the policy governs globally.
+    #: :meth:`intersection` and :meth:`union` require it to match on both
+    #: operands. Part of equality.
     _prereleases_configured: bool | None
 
     def __new__(cls, *args: object, **kwargs: object) -> VersionRange:  # noqa: PYI034
@@ -391,7 +415,7 @@ class VersionRange:
         reject: frozenset[str] = frozenset(),
         admit_arbitrary: bool = False,
         *,
-        prereleases: bool | None = None,
+        pre_region: tuple[_Interval, ...] = (),
         prereleases_configured: bool | None = None,
     ) -> VersionRange:
         """Internal factory; bypasses :meth:`__new__`.
@@ -399,10 +423,12 @@ class VersionRange:
         Canonicalizes the bounds so equal version sets share one representation,
         then drops admit literals the bounds already admit and reject literals
         the bounds do not match anyway. Reject wins over admit on overlap. The
-        pre-release policy is set here, so a built range never has its policy
-        reassigned afterwards.
+        pre-release policy is set here and never reassigned afterwards;
+        ``pre_region`` is canonicalized like the bounds (never clipped to them),
+        or dropped when a configured policy makes it inert.
         """
         bounds = _canonicalize(bounds)
+
         if admit and reject:
             admit = admit - reject
         if admit:
@@ -423,8 +449,15 @@ class VersionRange:
         instance._admit = admit
         instance._reject = reject
         instance._admit_arbitrary = admit_arbitrary
-        instance._prereleases = prereleases
         instance._prereleases_configured = prereleases_configured
+
+        # A configured policy makes the region inert, so drop it. Otherwise fold
+        # least-successor bounds (_from_specifier_set passes the region unfolded),
+        # so ``>1.0a1`` and ``>=1.0a2.dev0`` carry the same region.
+        if prereleases_configured is not None or not pre_region:
+            instance._pre_region = ()
+        else:
+            instance._pre_region = _canonicalize(pre_region)
 
         return instance
 
@@ -446,7 +479,7 @@ class VersionRange:
         return (
             not self._has_literals()
             and not self._admit_arbitrary
-            and self._prereleases is not False
+            and self._prereleases_configured is not False
         )
 
     def _check_policy_compat(self, other: VersionRange) -> None:
@@ -460,24 +493,27 @@ class VersionRange:
                 f"and {other._prereleases_configured!r}"
             )
 
-    def _combined_policy(self, other: VersionRange) -> tuple[bool | None, bool | None]:
-        """The ``(resolved, configured)`` pre-release policy for ``self`` combined
-        with ``other``, ready to feed into :meth:`_build`.
+    def _merged_region(self, other: VersionRange) -> tuple[_Interval, ...]:
+        """Union of ``self`` and ``other``'s opt-in regions, kept raw.
 
-        Both operands share a configured policy by the time this is called (see
-        :meth:`_check_policy_compat`).
+        The same OR ``SpecifierSet`` autodetect runs across its specifiers; see
+        the ``_pre_region`` slot for why the union stays unclipped. It does not
+        check policy compatibility, since a configured operand carries an empty
+        region, so :meth:`difference` may pass an ``other`` whose policy differs.
         """
-        configured = self._prereleases_configured
-        if configured is not None:
-            resolved: bool | None = configured
-        elif self._prereleases is True or other._prereleases is True:
-            resolved = True
-        else:
-            resolved = None
-        return resolved, configured
+        # Reuse an operand's canonical tuple when only one side has a region;
+        # an empty side contributes nothing to the union.
+        if not other._pre_region:
+            return self._pre_region
+        if not self._pre_region:
+            return other._pre_region
+
+        # Both sides carry a region; merge them. _build re-canonicalizes, so the
+        # raw union is fine here.
+        return tuple(_union_ranges(self._pre_region, other._pre_region))
 
     def _with_policy(
-        self, *, resolved: bool | None, configured: bool | None
+        self, *, pre_region: tuple[_Interval, ...], configured: bool | None
     ) -> VersionRange:
         """A structural copy of this range carrying the given pre-release policy."""
         return self._build(
@@ -485,7 +521,7 @@ class VersionRange:
             admit=self._admit,
             reject=self._reject,
             admit_arbitrary=self._admit_arbitrary,
-            prereleases=resolved,
+            pre_region=pre_region,
             prereleases_configured=configured,
         )
 
@@ -498,9 +534,7 @@ class VersionRange:
         >>> "1.0" in VersionRange.empty()
         False
         """
-        return cls._build(
-            (), prereleases=prereleases, prereleases_configured=prereleases
-        )
+        return cls._build((), prereleases_configured=prereleases)
 
     @classmethod
     def full(
@@ -524,7 +558,6 @@ class VersionRange:
         return cls._build(
             FULL_RANGE,
             admit_arbitrary=admit_arbitrary,
-            prereleases=prereleases,
             prereleases_configured=prereleases,
         )
 
@@ -556,7 +589,6 @@ class VersionRange:
         # ``0.dev0`` singleton is ``(-inf, 0.dev0]`` in canonical form.
         return cls._build(
             _canonical_floor(((lower, upper),)),
-            prereleases=prereleases,
             prereleases_configured=prereleases,
         )
 
@@ -573,15 +605,22 @@ class VersionRange:
         """
         self._check_policy_compat(other)
 
-        resolved, configured = self._combined_policy(other)
+        configured = self._prereleases_configured
         new_bounds = tuple(intersect_ranges(self._bounds, other._bounds))
-        combined_arb = self._admit_arbitrary and other._admit_arbitrary
+        new_region = self._merged_region(other)
+
+        # An empty intersection (e.g. ``full() & ~full()``) is the empty range,
+        # so it drops the arbitrary flag rather than keeping an inert one that a
+        # later union could revive.
+        combined_arb = (
+            self._admit_arbitrary and other._admit_arbitrary and bool(new_bounds)
+        )
 
         if not self._has_literals() and not other._has_literals():
             return self._build(
                 new_bounds,
                 admit_arbitrary=combined_arb,
-                prereleases=resolved,
+                pre_region=new_region,
                 prereleases_configured=configured,
             )
 
@@ -590,7 +629,7 @@ class VersionRange:
             new_bounds,
             op=_SetOp.INTERSECTION,
             admit_arbitrary=combined_arb,
-            prereleases=resolved,
+            pre_region=new_region,
             prereleases_configured=configured,
         )
 
@@ -609,16 +648,22 @@ class VersionRange:
         """
         self._check_policy_compat(other)
 
-        # The merged pre-release policy rides along in (resolved, configured).
-        resolved, configured = self._combined_policy(other)
+        configured = self._prereleases_configured
         new_bounds = tuple(_union_ranges(self._bounds, other._bounds))
-        combined_arb = self._admit_arbitrary or other._admit_arbitrary
+        new_region = self._merged_region(other)
+
+        # An empty-bounds operand (e.g. ``~full()``) carries an inert arbitrary
+        # flag only to keep complement an involution; it admits nothing, so it
+        # must not revive arbitrary admission as the union re-widens the bounds.
+        combined_arb = (self._admit_arbitrary and bool(self._bounds)) or (
+            other._admit_arbitrary and bool(other._bounds)
+        )
 
         if not self._has_literals() and not other._has_literals():
             return self._build(
                 new_bounds,
                 admit_arbitrary=combined_arb,
-                prereleases=resolved,
+                pre_region=new_region,
                 prereleases_configured=configured,
             )
 
@@ -627,16 +672,21 @@ class VersionRange:
             new_bounds,
             op=_SetOp.UNION,
             admit_arbitrary=combined_arb,
-            prereleases=resolved,
+            pre_region=new_region,
             prereleases_configured=configured,
         )
 
     def complement(self) -> VersionRange:
         """Range containing every version not in self.
 
-        Preserves the configured pre-release policy. Within the PEP 440
-        universe (no ``===`` literals and no arbitrary admission) double
-        negation holds; for ``===`` ranges complement is one-way.
+        Preserves the configured pre-release policy. Double negation holds for a
+        range with no ``===`` literals (the arbitrary-string flag round-trips, so
+        ``~~full() == full()``); for ``===`` ranges complement is one-way.
+
+        The opt-in region rides through unchanged, not clipped to the new bounds,
+        so complement stays an involution. It is inert outside the bounds (see the
+        ``_pre_region`` slot), which is what lets ``a & ~b`` shed ``b``'s in-bounds
+        opt-in.
 
         >>> r = SpecifierSet(">=1.0").to_range()
         >>> "0.5" in r.complement()
@@ -647,26 +697,24 @@ class VersionRange:
         True
         """
         # Complement swaps literal admission: what the range rejects, its
-        # complement admits, and vice versa.
+        # complement admits.
         return self._build(
             tuple(_complement_ranges(self._bounds)),
             admit=self._reject,
             reject=self._admit,
             admit_arbitrary=self._admit_arbitrary,
-            prereleases=self._prereleases,
+            pre_region=self._pre_region,
             prereleases_configured=self._prereleases_configured,
         )
 
     def difference(self, other: VersionRange) -> VersionRange:
         """Range containing the versions in self but not in other.
 
-        On the version set this matches ``self & ~other``, but the result keeps
-        only ``self``'s admissions and pre-release policy: a non-version string
-        or ``===`` literal is a member exactly when ``self`` admits it and
-        ``other`` does not. ``other`` is treated purely as an exclusion, so the
-        operands need not share a configured pre-release policy (unlike
-        :meth:`intersection` and :meth:`union`), and ``a - empty()`` returns a
-        range equal to ``a``.
+        Matches ``self & ~other`` on the version set and opt-in region. They part
+        only on non-version-string admission, whose complement is one-way: a
+        ``===`` literal stays when ``self`` admits it and ``other`` does not, and
+        the arbitrary-string flag is kept from ``self``. ``other`` acts as a
+        bounds-only exclusion.
 
         >>> a = SpecifierSet(">=1.0").to_range()
         >>> b = SpecifierSet(">=2.0").to_range()
@@ -680,22 +728,36 @@ class VersionRange:
         if not isinstance(other, VersionRange):
             raise TypeError(f"expected VersionRange, got {type(other).__name__}")
 
+        # Subtracting a nothing-admitting set is a no-op. Short-circuit so an
+        # empty-bounds self (e.g. ``~full()``) keeps its provenance flag, which
+        # the general path would drop. An empty-bounds ``other`` with a region is
+        # excluded: it must reach the merge so ``a - b`` keeps matching ``a & ~b``.
+        if not other._bounds and not other._admit and not other._pre_region:
+            return self
+
         # Bound complement is two-way, so subtracting other's versions is an
         # intersection with its gaps.
         new_bounds = tuple(
             intersect_ranges(self._bounds, _complement_ranges(other._bounds))
         )
 
-        # Complement is one-way for arbitrary strings and ``===`` literals, so
-        # read admission off other directly: a string survives when self admits
-        # it and other does not.
-        combined_arb = self._admit_arbitrary and not other._admit_arbitrary
+        # Same opt-in region ``self & ~other`` would build: ``other``'s region
+        # only force-admits within ``new_bounds``, where ``~other`` would have
+        # revived it. A configured self keeps no region, so skip the merge there.
+        new_region: tuple[_Interval, ...] = ()
+        if self._prereleases_configured is None:
+            new_region = self._merged_region(other)
+
+        # Keep self's arbitrary admission. Other only removes it at full bounds,
+        # where nothing survives, so the empty result drops it (as in
+        # :meth:`intersection`) with no separate other-side test.
+        combined_arb = self._admit_arbitrary and bool(new_bounds)
 
         if not self._has_literals() and not other._has_literals():
             return self._build(
                 new_bounds,
                 admit_arbitrary=combined_arb,
-                prereleases=self._prereleases,
+                pre_region=new_region,
                 prereleases_configured=self._prereleases_configured,
             )
 
@@ -704,7 +766,7 @@ class VersionRange:
             new_bounds,
             op=_SetOp.DIFFERENCE,
             admit_arbitrary=combined_arb,
-            prereleases=self._prereleases,
+            pre_region=new_region,
             prereleases_configured=self._prereleases_configured,
         )
 
@@ -715,15 +777,14 @@ class VersionRange:
         *,
         op: _SetOp,
         admit_arbitrary: bool,
-        prereleases: bool | None,
+        pre_region: tuple[_Interval, ...],
         prereleases_configured: bool | None,
     ) -> VersionRange:
         """Resolve admit/reject for ``self`` ``op`` ``other`` over their literals."""
         admits: set[str] = set()
         rejects: set[str] = set()
 
-        # Each literal is decided on its own: test it against both operands,
-        # then admit or reject it by the set operation.
+        # Each literal is decided independently of the others.
         for literal in self._admit | self._reject | other._admit | other._reject:
             self_in = self._matches_literal(literal)
             other_in = other._matches_literal(literal)
@@ -745,7 +806,7 @@ class VersionRange:
             admit=frozenset(admits),
             reject=frozenset(rejects),
             admit_arbitrary=admit_arbitrary,
-            prereleases=prereleases,
+            pre_region=pre_region,
             prereleases_configured=prereleases_configured,
         )
 
@@ -786,10 +847,10 @@ class VersionRange:
     def is_subset(self, other: VersionRange) -> bool:
         """Return whether every member of self is also a member of other.
 
-        Equivalent to ``(self & ~other).is_empty``. For ``===`` ranges and the
-        arbitrary-admitting full range, complement is one-way, so the result
-        matches :meth:`contains` for versions but not for the non-version
-        strings those ranges admit.
+        Equivalent to ``(self & ~other).is_empty``. Complement is one-way for
+        ``===`` ranges and the arbitrary-admitting full range, so the result
+        tracks :meth:`contains` on versions but not on the non-version strings
+        those ranges admit.
 
         Both operands must share the same configured pre-release policy;
         otherwise :exc:`ValueError` is raised.
@@ -873,7 +934,10 @@ class VersionRange:
         """Yield items from iterable whose version falls inside the range.
 
         With prereleases ``None`` the PEP 440 default applies: pre-releases are
-        buffered and only emitted if no final release in iterable is in range.
+        buffered and only emitted if no final release in iterable is in range,
+        except that a pre-release inside the autodetected opt-in region, or named
+        outright by a ``===`` literal, is force-admitted in place (as
+        ``prereleases=True`` would yield it).
 
         The signature mirrors
         :meth:`~packaging.specifiers.SpecifierSet.filter`.
@@ -882,13 +946,25 @@ class VersionRange:
         >>> list(r.filter(["0.9", "1.5", "2.0"]))
         ['1.5']
         """
+        region: tuple[_Interval, ...] = ()
         if prereleases is None:
-            prereleases = self._prereleases
+            # The region applies only under the autodetect default; a configured
+            # policy governs instead (and then ``_pre_region`` is already empty).
+            prereleases = self._prereleases_configured
+            region = self._pre_region
 
         arbitrary_active = self._arbitrary_active()
         if not self._admit and not self._reject and not arbitrary_active:
-            return filter_by_ranges(self._bounds, iterable, key, prereleases)
-        return self._filter_with_admission(iterable, key, prereleases, arbitrary_active)
+            # A region spanning the whole bounds force-admits every in-bounds
+            # pre-release, i.e. ``prereleases=True``; take the cheaper no-buffer
+            # path. (Confined to this branch: the admission path orders arbitrary
+            # strings differently under True than under the region.)
+            if region and region == self._bounds:
+                return filter_by_ranges(self._bounds, iterable, key, True)
+            return filter_by_ranges(self._bounds, iterable, key, prereleases, region)
+        return self._filter_with_admission(
+            iterable, key, prereleases, arbitrary_active, region
+        )
 
     def _filter_with_admission(
         self,
@@ -896,38 +972,40 @@ class VersionRange:
         key: Callable[[Any], Version | str] | None,
         prereleases: bool | None,
         arbitrary_active: bool,
+        region: tuple[_Interval, ...],
     ) -> Iterator[Any]:
         """Filter for ranges with admit/reject literals or live arbitrary
         admission (including the universal ``SpecifierSet("")`` range)."""
         admit_set = self._admit
         reject_set = self._reject
 
-        def admit(item: Any) -> tuple[bool, Version | None]:  # noqa: ANN401
+        def admit(item: Any) -> tuple[bool, Version | None, bool]:  # noqa: ANN401
             raw: Version | str = item if key is None else key(item)
             raw_lower = str(raw).lower()
 
             if reject_set and raw_lower in reject_set:
-                return False, None
+                return False, None, False
             if admit_set and raw_lower in admit_set:
-                return True, coerce_version(raw)
+                # An explicit ``===`` literal names this version outright.
+                return True, coerce_version(raw), True
 
             parsed = coerce_version(raw)
             if parsed is None:
-                return arbitrary_active, None
+                return arbitrary_active, None, False
             if not matches_bounds_only(self._bounds, parsed):
-                return False, None
-            return True, parsed
+                return False, None, False
+            return True, parsed, False
 
         if prereleases is True:
             for item in iterable:
-                ok, _ = admit(item)
+                ok, _, _ = admit(item)
                 if ok:
                     yield item
             return
 
         if prereleases is False:
             for item in iterable:
-                ok, parsed = admit(item)
+                ok, parsed, _ = admit(item)
                 if not ok:
                     continue
                 if parsed is not None and parsed.is_prerelease:
@@ -935,11 +1013,14 @@ class VersionRange:
                 yield item
             return
 
+        # PEP 440 default: emit finals eagerly and buffer the other pre-releases,
+        # releasing the buffer only if no final ever matches.
         all_nonfinal: list[Any] = []
         arbitrary_strings: list[Any] = []
         found_final = False
+
         for item in iterable:
-            ok, parsed = admit(item)
+            ok, parsed, by_literal = admit(item)
             if not ok:
                 continue
 
@@ -956,6 +1037,13 @@ class VersionRange:
                     yield from arbitrary_strings
                     arbitrary_strings.clear()
                     found_final = True
+                yield item
+                continue
+
+            # A pre-release is force-admitted when it is named outright by a
+            # ``===`` literal or falls in the opt-in region, as ``prereleases=True``
+            # would yield it; otherwise the PEP 440 default buffers it.
+            if by_literal or (region and matches_bounds_only(region, parsed)):
                 yield item
                 continue
 
@@ -993,8 +1081,19 @@ class VersionRange:
                     )
                 result = result.intersection(operand)
 
+        # Each pre-release-naming specifier opts its own versions in; their raw
+        # union is the region, the same value _merged_region accumulates (so a set
+        # built directly equals one built from its specifiers).
+        region: list[_Interval] = []
+        if specifier_set._prereleases is None:  # a configured policy has no region
+            for spec in specifier_set:
+                # ``===`` literals are not a range; filter force-admits them.
+                if spec.operator != "===" and spec.prereleases:
+                    spec_bounds = _canonical_floor(tuple(spec._to_ranges()))
+                    region = _union_ranges(region, spec_bounds)
+
         return result._with_policy(
-            resolved=specifier_set.prereleases,
+            pre_region=tuple(region),
             configured=specifier_set._prereleases,
         )
 
@@ -1018,8 +1117,9 @@ class VersionRange:
         if self._arbitrary_active():
             return False
 
+        excludes_prereleases = self._prereleases_configured is False
         for literal in self._admit:
-            if self._prereleases is False:
+            if excludes_prereleases:
                 parsed = coerce_version(literal)
                 if parsed is not None and parsed.is_prerelease:
                     continue
@@ -1028,7 +1128,7 @@ class VersionRange:
         if not self._bounds:
             return True
 
-        return self._prereleases is False and ranges_are_prerelease_only(self._bounds)
+        return excludes_prereleases and ranges_are_prerelease_only(self._bounds)
 
     def contains(
         self,
@@ -1043,6 +1143,11 @@ class VersionRange:
             uses the range's own policy.
         :param installed: when ``True``, accept a pre-release item even if the
             range would not otherwise allow it.
+
+        Unlike :meth:`filter`, this does not consult the autodetected pre-release
+        opt-in region; it reads only the configured policy. This mirrors
+        :meth:`~packaging.specifiers.SpecifierSet.contains` versus
+        :meth:`~packaging.specifiers.SpecifierSet.filter`.
 
         Unparsable strings do not match, except where the full
         ``SpecifierSet`` would also match: the full range admits any string,
@@ -1108,20 +1213,22 @@ class VersionRange:
     def __eq__(self, other: object) -> bool:
         """Structural equality.
 
-        Two ranges compare equal when every input to :meth:`contains` and
-        :meth:`filter` agrees: the bounds, the ``===`` admit/reject literals,
-        the arbitrary-string flag, and both the configured and resolved
-        pre-release policies. Equal ranges therefore filter identically.
+        Compares the bounds, the ``===`` admit/reject literals, the
+        arbitrary-string flag, the configured pre-release policy, and the raw
+        opt-in region, not just the version set. Keying on the raw region makes
+        equality a congruence (equal ranges stay equal under further operations),
+        so equal implies same :meth:`contains` and :meth:`filter`, but not the
+        converse: an empty range keeps the inert region and flag it was built
+        with, so two empty ranges need not be equal.
 
-        Different specifiers for the same set fold to one canonical bound form,
-        so they compare equal. ``>1.0a1`` excludes ``1.0a1``'s post-releases, so
-        its smallest member is ``1.0a2.dev0``, the same set as ``>=1.0a2.dev0``:
+        Different specifiers for the same range fold to one canonical form:
 
         >>> SpecifierSet(">1.0a1").to_range() == SpecifierSet(">=1.0a2.dev0").to_range()
         True
 
-        The pre-release policy is still part of equality, so two ranges with the
-        same versions but different policies stay unequal:
+        The opt-in region is part of equality, so ``<=1.0`` (no pre-releases) and
+        ``<1.0.post0.dev0`` (autodetects a ``.dev`` opt-in) cover the same
+        versions yet compare unequal:
 
         >>> le, lt = SpecifierSet("<=1.0"), SpecifierSet("<1.0.post0.dev0")
         >>> le.to_range() == lt.to_range()
@@ -1139,7 +1246,7 @@ class VersionRange:
             and self._reject == other._reject
             and self._admit_arbitrary == other._admit_arbitrary
             and self._prereleases_configured == other._prereleases_configured
-            and self._prereleases == other._prereleases
+            and self._pre_region == other._pre_region
         )
 
     def __hash__(self) -> int:
@@ -1150,7 +1257,7 @@ class VersionRange:
                 self._reject,
                 self._admit_arbitrary,
                 self._prereleases_configured,
-                self._prereleases,
+                self._pre_region,
             )
         )
 
@@ -1164,24 +1271,25 @@ class VersionRange:
         >>> SpecifierSet(">=2.0,<1.0").to_range()
         <VersionRange '(empty)'>
         """
+        # Body: the bounds and any ``===``-admitted literals.
         parts: list[str] = []
         if self._bounds:
-            parts.append(
-                " | ".join(
-                    f"{_format_lower(lower)}, {_format_upper(upper)}"
-                    for lower, upper in self._bounds
-                )
-            )
+            parts.append(_format_intervals(self._bounds))
         if self._admit:
             parts.append("{" + ", ".join(sorted(self._admit)) + "}")
-
         body = " | ".join(parts) if parts else "(empty)"
+
+        # Rejected literals subtract from the body.
         if self._reject:
             body = f"{body} \\ {{{', '.join(sorted(self._reject))}}}"
 
+        # Tail: the policy flags carried alongside the version set.
         tail = ""
         if self._admit_arbitrary:
             tail += " arbitrary"
         if self._prereleases_configured is not None:
             tail += f" pre={self._prereleases_configured}"
+        if self._pre_region:
+            tail += f" pre-region={_format_intervals(self._pre_region)!r}"
+
         return f"<{self.__class__.__name__} {body!r}{tail}>"

--- a/src/packaging/ranges.py
+++ b/src/packaging/ranges.py
@@ -385,12 +385,15 @@ class VersionRange:
 
     #: Sorted, disjoint intervals where pre-releases are force-admitted under
     #: the PEP 440 default policy (a ``None`` ``prereleases`` argument and no
-    #: configured override). Set algebra (:meth:`union`, :meth:`intersection`,
-    #: :meth:`difference`) accumulates this autodetected opt-in raw (not clipped
-    #: to the result bounds), which keeps it distributive. It may reach past the
-    #: bounds, but :meth:`filter` only force-admits a pre-release that already
-    #: passed the bounds check, so the out-of-bounds part never fires. Equality
-    #: keys on the raw region, so it stays a congruence.
+    #: configured override). The opt-in flows only from the pre-release-naming
+    #: specifiers that built the range. :meth:`union` and :meth:`intersection`
+    #: accumulate it raw (not clipped to the result bounds), which keeps it
+    #: distributive; :meth:`difference` keeps only the minuend's; and
+    #: :meth:`complement` drops it, since an exclusion grants no opt-in. The raw
+    #: union may reach past the bounds, but :meth:`filter` only force-admits a
+    #: pre-release that already passed the bounds check, so the out-of-bounds
+    #: part never fires. Equality keys on the raw region, so it stays a
+    #: congruence.
     _pre_region: tuple[_Interval, ...]
 
     #: Raw configured pre-release override of the originating specifier set
@@ -496,10 +499,9 @@ class VersionRange:
     def _merged_region(self, other: VersionRange) -> tuple[_Interval, ...]:
         """Union of ``self`` and ``other``'s opt-in regions, kept raw.
 
-        The same OR ``SpecifierSet`` autodetect runs across its specifiers; see
-        the ``_pre_region`` slot for why the union stays unclipped. It does not
-        check policy compatibility, since a configured operand carries an empty
-        region, so :meth:`difference` may pass an ``other`` whose policy differs.
+        Used by :meth:`union` and :meth:`intersection`; see the ``_pre_region``
+        slot for why the union stays unclipped. A configured operand carries an
+        empty region, so it contributes nothing to the merge.
         """
         # Reuse an operand's canonical tuple when only one side has a region;
         # an empty side contributes nothing to the union.
@@ -683,10 +685,12 @@ class VersionRange:
         range with no ``===`` literals (the arbitrary-string flag round-trips, so
         ``~~full() == full()``); for ``===`` ranges complement is one-way.
 
-        The opt-in region rides through unchanged, not clipped to the new bounds,
-        so complement stays an involution. It is inert outside the bounds (see the
-        ``_pre_region`` slot), which is what lets ``a & ~b`` shed ``b``'s in-bounds
-        opt-in.
+        The opt-in region is dropped: a complement is an exclusion, and an
+        exclusion expresses no pre-release preference. This is what lets
+        ``a & ~b`` shed ``b``'s opt-in, so an excluded ``b`` never force-admits a
+        pre-release into the result. Complement stays involutive on the version
+        set, but not on the opt-in region: ``~~r`` covers the same versions as
+        ``r`` yet force-admits none of its pre-releases.
 
         >>> r = SpecifierSet(">=1.0").to_range()
         >>> "0.5" in r.complement()
@@ -703,7 +707,7 @@ class VersionRange:
             admit=self._reject,
             reject=self._admit,
             admit_arbitrary=self._admit_arbitrary,
-            pre_region=self._pre_region,
+            pre_region=(),
             prereleases_configured=self._prereleases_configured,
         )
 
@@ -729,10 +733,9 @@ class VersionRange:
             raise TypeError(f"expected VersionRange, got {type(other).__name__}")
 
         # Subtracting a nothing-admitting set is a no-op. Short-circuit so an
-        # empty-bounds self (e.g. ``~full()``) keeps its provenance flag, which
-        # the general path would drop. An empty-bounds ``other`` with a region is
-        # excluded: it must reach the merge so ``a - b`` keeps matching ``a & ~b``.
-        if not other._bounds and not other._admit and not other._pre_region:
+        # empty-bounds self (e.g. ``~full()``) keeps its arbitrary-string flag,
+        # which the general path would drop.
+        if not other._bounds and not other._admit:
             return self
 
         # Bound complement is two-way, so subtracting other's versions is an
@@ -741,12 +744,12 @@ class VersionRange:
             intersect_ranges(self._bounds, _complement_ranges(other._bounds))
         )
 
-        # Same opt-in region ``self & ~other`` would build: ``other``'s region
-        # only force-admits within ``new_bounds``, where ``~other`` would have
-        # revived it. A configured self keeps no region, so skip the merge there.
+        # Match ``self & ~other`` on the opt-in region: a complement carries no
+        # opt-in, so only ``self``'s region survives. ``other`` acts as a
+        # bounds-only exclusion. A configured ``self`` keeps no region.
         new_region: tuple[_Interval, ...] = ()
         if self._prereleases_configured is None:
-            new_region = self._merged_region(other)
+            new_region = self._pre_region
 
         # Keep self's arbitrary admission. Other only removes it at full bounds,
         # where nothing survives, so the empty result drops it (as in

--- a/tests/property/strategies.py
+++ b/tests/property/strategies.py
@@ -17,15 +17,17 @@ if TYPE_CHECKING:
 
 
 def eq_versions_only(a: VersionRange, b: VersionRange) -> bool:
-    """Compare two ranges ignoring the arbitrary-string and pre-release
-    policy slots.
+    """Compare two ranges by bounds and ``===`` literals only, ignoring the
+    arbitrary-string flag and both pre-release slots.
 
     Complement preserves ``_admit_arbitrary`` (only the universal range
     admits non-version strings, never algebra), so ``r | ~r`` is never
     structurally equal to ``VersionRange.full()`` when neither ``r`` nor
-    ``~r`` is empty. The pre-release configured override mirrors
-    ``SpecifierSet.__and__`` rather than pure Boolean algebra. Use this
-    helper when the property is "same set of versions accepted".
+    ``~r`` is empty. The configured override mirrors ``SpecifierSet.__and__``
+    rather than pure Boolean algebra, and the opt-in region (``_pre_region``)
+    is carried raw, so ``==`` distinguishes ranges that accept the same
+    versions. Use this helper when the property is "same set of versions
+    accepted".
     """
     return a._bounds == b._bounds and a._admit == b._admit and a._reject == b._reject
 

--- a/tests/property/test_ranges_set_algebra.py
+++ b/tests/property/test_ranges_set_algebra.py
@@ -184,6 +184,10 @@ def test_lattice_laws_hold_with_pre_release_regions(
     pre-release-naming specifiers, so this runs the raw-region merge in
     ``_merged_region`` through commutativity, associativity, idempotence, double
     complement, De Morgan, and both distributive laws.
+
+    Double complement is involutive on the version set but not the opt-in region
+    (an exclusion grants no opt-in, so complement drops it), so it is checked
+    with ``eq_versions_only``. The other laws keep the region whole on both sides.
     """
     ra, rb, rc = a.to_range(), b.to_range(), c.to_range()
     assert ra | rb == rb | ra
@@ -192,7 +196,7 @@ def test_lattice_laws_hold_with_pre_release_regions(
     assert (ra & rb) & rc == ra & (rb & rc)
     assert ra | ra == ra
     assert ra & ra == ra
-    assert ~~ra == ra
+    assert eq_versions_only(~~ra, ra)
     assert ~(ra & rb) == ~ra | ~rb
     assert ~(ra | rb) == ~ra & ~rb
     assert ra.union(rb.intersection(rc)) == ra.union(rb).intersection(ra.union(rc))

--- a/tests/property/test_ranges_set_algebra.py
+++ b/tests/property/test_ranges_set_algebra.py
@@ -172,6 +172,76 @@ def test_union_distributes_over_intersect(
     assert lhs == rhs
 
 
+@given(a=rich_specifier_sets(), b=rich_specifier_sets(), c=rich_specifier_sets())
+@SETTINGS
+def test_lattice_laws_hold_with_pre_release_regions(
+    a: SpecifierSet, b: SpecifierSet, c: SpecifierSet
+) -> None:
+    """The Boolean lattice laws hold structurally when operands name pre-releases.
+
+    ``specifier_sets`` builds only ``major.minor`` bounds, so the laws above
+    never carry a non-empty opt-in region. ``rich_specifier_sets`` draws
+    pre-release-naming specifiers, so this runs the raw-region merge in
+    ``_merged_region`` through commutativity, associativity, idempotence, double
+    complement, De Morgan, and both distributive laws.
+    """
+    ra, rb, rc = a.to_range(), b.to_range(), c.to_range()
+    assert ra | rb == rb | ra
+    assert ra & rb == rb & ra
+    assert (ra | rb) | rc == ra | (rb | rc)
+    assert (ra & rb) & rc == ra & (rb & rc)
+    assert ra | ra == ra
+    assert ra & ra == ra
+    assert ~~ra == ra
+    assert ~(ra & rb) == ~ra | ~rb
+    assert ~(ra | rb) == ~ra & ~rb
+    assert ra.union(rb.intersection(rc)) == ra.union(rb).intersection(ra.union(rc))
+    assert ra.intersection(rb.union(rc)) == ra.intersection(rb).union(
+        ra.intersection(rc)
+    )
+
+
+@given(a=rich_specifier_sets(), b=rich_specifier_sets())
+@SETTINGS
+def test_difference_equals_intersect_complement(
+    a: SpecifierSet, b: SpecifierSet
+) -> None:
+    """``a - b == a & ~b`` over pre-release-naming pairs.
+
+    ``rich_specifier_sets`` draws pre/post/dev/local/epoch RHS versions (no
+    ``===`` and no configured policy), so the two agree on bounds and region.
+    They would diverge over ``===`` literals and the arbitrary-string flag, which
+    this strategy does not draw; the configured-policy mismatch that difference
+    tolerates is covered by
+    :func:`test_difference_tolerates_configured_policy_mismatch`.
+    """
+    ra, rb = a.to_range(), b.to_range()
+    intersect_complement = ra & ~rb
+    assert ra - rb == intersect_complement
+    assert list((ra - rb).filter(VERSION_POOL)) == list(
+        intersect_complement.filter(VERSION_POOL)
+    )
+
+
+@given(
+    a=specifier_sets(vary_prereleases=True),
+    b=specifier_sets(vary_prereleases=True),
+)
+@SETTINGS
+def test_difference_tolerates_configured_policy_mismatch(
+    a: SpecifierSet, b: SpecifierSet
+) -> None:
+    """``difference`` ignores ``other``'s configured policy, so it never raises
+    on a mismatch that ``intersection`` and ``union`` reject."""
+    ra, rb = a.to_range(), b.to_range()
+    difference = ra - rb  # never raises, whatever the configured policies are
+    if ra._prereleases_configured == rb._prereleases_configured:
+        assert difference == ra & ~rb
+    else:
+        with pytest.raises(ValueError, match="different"):
+            ra & rb
+
+
 @given(spec_set=specifier_sets())
 @SETTINGS
 def test_operator_aliases(spec_set: SpecifierSet) -> None:
@@ -272,10 +342,9 @@ def test_exact_equals_singleton_intersection(
 def test_full_range_is_identity_for_filter(spec_set: SpecifierSet) -> None:
     """``full()`` is the identity for ``&`` w.r.t. filtering.
 
-    Pre-release eligibility rides on ``_prereleases``, which ``==`` and
-    ``__contains__`` ignore by design, so the structural laws above can't see
-    it; only ``filter`` does. Folding ``full() & r1 & r2 & ...`` must never
-    erase a range's tag.
+    Pre-release eligibility rides on the opt-in region (``_pre_region``), which
+    ``__contains__`` ignores; only ``filter`` reads it. Folding
+    ``full() & r1 & r2 & ...`` must never erase a range's region.
     """
     r = spec_set.to_range()
     full = VersionRange.full()
@@ -289,15 +358,22 @@ def test_full_range_is_identity_for_filter(spec_set: SpecifierSet) -> None:
 def test_intersection_filter_matches_merged_set(
     a: SpecifierSet, b: SpecifierSet
 ) -> None:
-    """``to_range`` is a homomorphism w.r.t. filtering.
+    """``to_range`` is a homomorphism w.r.t. intersection.
 
-    ``(a.to_range() & b.to_range()).filter`` equals
-    ``(a & b).to_range().filter``, including pre-release eligibility (which
-    the structural ``==`` laws above cannot observe).
+    A set built directly and one built by combining its specifiers carry the
+    same opt-in region. The check is structural, not just today's filter output,
+    because only equal raw regions stay equal (and filter identically) under a
+    later widening union.
     """
-    composed = list((a.to_range() & b.to_range()).filter(VERSION_POOL))
-    merged = list((a & b).to_range().filter(VERSION_POOL))
+    composed = a.to_range() & b.to_range()
+    merged = (a & b).to_range()
     assert composed == merged
+    assert list(composed.filter(VERSION_POOL)) == list(merged.filter(VERSION_POOL))
+
+    wide = SpecifierSet(">=0").to_range()
+    assert list((composed | wide).filter(VERSION_POOL)) == list(
+        (merged | wide).filter(VERSION_POOL)
+    )
 
 
 @given(spec_set=rich_specifier_sets(include_arbitrary=True))
@@ -319,6 +395,23 @@ def test_to_range_filter_and_contains_mirror_specifier_set(
         )
     for item in pool:
         assert (item in r) == (item in spec_set)
+
+
+@given(spec_set=specifier_sets(vary_prereleases=True))
+@SETTINGS
+def test_configured_policy_mirrors_specifier_set(spec_set: SpecifierSet) -> None:
+    """A configured ``prereleases`` policy filters and contains the same on the
+    range as on the originating set.
+
+    ``rich_specifier_sets`` (used above) always autodetects, so the
+    ``prereleases = configured`` branch of ``filter`` and a configured
+    ``contains`` go uncovered there; ``vary_prereleases`` draws explicit
+    True/False/None policies to exercise them.
+    """
+    r = spec_set.to_range()
+    assert list(r.filter(VERSION_POOL)) == list(spec_set.filter(VERSION_POOL))
+    for v in VERSION_POOL:
+        assert r.contains(v) == (v in spec_set)
 
 
 @given(spec_set=rich_specifier_sets(include_arbitrary=True))

--- a/tests/property/test_ranges_set_relations.py
+++ b/tests/property/test_ranges_set_relations.py
@@ -8,7 +8,7 @@ Each relation is pinned to its set-algebra definition (the oracle the methods
 optimize): ``is_disjoint`` to ``(a & b).is_empty`` and ``is_subset`` to
 ``(a & ~b).is_empty``. The plain strategy exercises the bounds-only fast path;
 the ``===`` strategy forces the algebra fallback, so the same oracle guards
-both code paths. Pointwise-membership and symmetry round out the checks.
+both code paths. Pointwise-membership and symmetry are also checked.
 """
 
 from __future__ import annotations

--- a/tests/test_ranges.py
+++ b/tests/test_ranges.py
@@ -458,11 +458,16 @@ class TestPrereleaseRegion:
         assert list(u.filter(["1.5b1", "1.2a1"])) == ["1.5b1", "1.2a1"]
         assert list(u.filter(["1.5b1", "1.2a1", "1.3"])) == ["1.3"]
 
-    def test_double_complement_preserves_region_and_filtering(self) -> None:
+    def test_double_complement_drops_region_keeps_versions(self) -> None:
+        # A complement is an exclusion and carries no opt-in, so a double
+        # complement covers the same versions as the original yet force-admits
+        # none of its pre-releases.
         r = vr(">=2.0b1")
-        assert ~~r == r
+        assert (~~r)._bounds == r._bounds
+        assert (~~r)._pre_region == ()
         cand = ["1.5b1", "2.0b1", "2.5", "2.5b1"]
-        assert list((~~r).filter(cand)) == list(r.filter(cand))
+        assert list(r.filter(cand)) == ["2.0b1", "2.5", "2.5b1"]
+        assert list((~~r).filter(cand)) == ["2.5"]
 
     def test_difference_minuend_with_literal_and_region(self) -> None:
         # A minuend carrying both a ``===`` literal and an autodetected opt-in
@@ -1270,10 +1275,11 @@ class TestCoverageEdges:
         )
 
     def test_eq_full_region_mismatch(self) -> None:
-        # The floor shape that exposed the substitutability bug: same bounds,
-        # but ``>=0.dev0`` carries a full opt-in region and ``full()`` carries
-        # none, so the two must stay unequal.
-        b = ~~vr(">=0.dev0")
+        # Same bounds and arbitrary flag but a different opt-in region must stay
+        # unequal, so the two never substitute for each other. ``>=0.dev0`` names
+        # a pre-release across the whole line, so it carries a full opt-in region;
+        # ``full(admit_arbitrary=False)`` carries none.
+        b = vr(">=0.dev0")
         c = VersionRange.full(admit_arbitrary=False)
         assert b._bounds == c._bounds
         assert b._admit_arbitrary == c._admit_arbitrary

--- a/tests/test_ranges.py
+++ b/tests/test_ranges.py
@@ -142,8 +142,11 @@ class TestToRange:
         assert vr("===1.0,>=2.0").is_empty
 
     def test_prerelease_autodetect(self) -> None:
-        assert vr(">=1.0a1")._prereleases is True
-        assert vr(">=1.0")._prereleases is None
+        # Autodetected admission is stored as a region (the spec's own bounds);
+        # a non-pre-release spec leaves the region empty.
+        assert vr(">=1.0a1")._pre_region == vr(">=1.0a1")._bounds
+        assert vr(">=1.0a1")._pre_region
+        assert vr(">=1.0")._pre_region == ()
 
     def test_explicit_prereleases(self) -> None:
         r = vr(">=1.0", prereleases=False)
@@ -204,9 +207,11 @@ class TestSetAlgebra:
         r = vr(">=1.0a1")
         assert list(r.filter(["1.3", "1.5a1"])) == ["1.3", "1.5a1"]
 
-        # Both orders keep the autodetected pre-release policy.
-        assert (r | VersionRange.full())._prereleases is True
-        assert (VersionRange.full() | r)._prereleases is True
+        # Both orders keep the autodetected opt-in as a region (here r's own
+        # bounds), so only the pre-releases r named are admitted, not every
+        # pre-release.
+        assert (r | VersionRange.full())._pre_region == r._bounds
+        assert (VersionRange.full() | r)._pre_region == r._bounds
 
         assert list((r | VersionRange.full()).filter(["1.3", "1.5a1"])) == [
             "1.3",
@@ -216,6 +221,10 @@ class TestSetAlgebra:
             "1.3",
             "1.5a1",
         ]
+
+        # The opt-in region is [1.0a1, +inf): a pre-release that sorts below it
+        # is not force-admitted by the union.
+        assert list((r | VersionRange.full()).filter(["0.5a1", "1.0"])) == ["1.0"]
 
     def test_arbitrary_flag_distinguishes_full(self) -> None:
         # nab contract: SpecifierSet("")-full differs from algebra-built full.
@@ -243,6 +252,29 @@ class TestSetAlgebra:
         # nab complements root ranges built from ``===`` requirements.
         r = vr("===custom")
         assert not (~r).is_empty
+
+    def test_empty_does_not_revive_arbitrary_admission(self) -> None:
+        # ``~full()`` is empty yet keeps an inert arbitrary flag so that
+        # ``~~full() == full()``. That flag must not revive and admit arbitrary
+        # strings once a later operation widens the bounds back to full.
+        full = VersionRange.full()
+        plain = VersionRange.full(admit_arbitrary=False)
+        assert ~~full == full  # the inert flag round-trips through complement
+        assert (full & ~full) == VersionRange.empty()
+        # The empty operand must not revive the flag from either side of a union,
+        # nor through a difference that later complements back to full bounds.
+        assert not (~full | plain).contains("garbage")
+        assert not (plain | ~full).contains("garbage")
+        assert (full & ~full) - full == VersionRange.empty()
+        assert not (full - plain).complement().contains("garbage")
+
+    def test_difference_by_empty_keeps_arbitrary_admission(self) -> None:
+        # ``~full()`` admits nothing (empty bounds, no literal, no region), so the
+        # difference short-circuit returns self untouched, keeping full's
+        # arbitrary admission (``full() - ~full() == full()``).
+        full = VersionRange.full()
+        assert (full - ~full) == full
+        assert (full - ~full).contains("garbage")
 
     def test_policy_mismatch_raises(self) -> None:
         with pytest.raises(ValueError, match="different"):
@@ -342,6 +374,279 @@ class TestSetAlgebra:
         assert Version("3.0") in d
         assert Version("1.0") not in d
         assert Version("2.0") not in d
+
+
+class TestPrereleaseRegion:
+    """The autodetected pre-release opt-in is stored as a range (``_pre_region``)
+    so it stays attached to the versions it came from across set algebra."""
+
+    def test_union_keeps_opt_in_scoped_to_originating_range(self) -> None:
+        # ``>=1.0 | >=2.0b1``: the opt-in came only from the ``>=2.0b1`` side, so
+        # a pre-release below 2.0b1 is not force-admitted, while pre-releases at
+        # or above it are.
+        u = vr(">=1.0") | vr(">=2.0b1")
+        assert list(u.filter(["1.0", "1.5b1", "2.0b1", "2.5", "2.5b1"])) == [
+            "1.0",
+            "2.0b1",
+            "2.5",
+            "2.5b1",
+        ]
+        assert u._pre_region == vr(">=2.0b1")._bounds
+
+    def test_raw_region_survives_narrowing_and_reexpands(self) -> None:
+        # The opt-in is stored raw (unclipped), so a narrowing intersection
+        # keeps it for later: widening the bounds back over it re-expands what
+        # filter force-admits, while the narrowed range itself does not.
+        inter = vr(">=1.0a1") & vr("<1.5")
+        # The raw region is [1.0a1, +inf), wider than the narrowed bounds.
+        assert inter._pre_region == vr(">=1.0a1")._bounds
+        assert inter._pre_region != inter._bounds
+        assert list(inter.filter(["1.2a1", "2.0a1", "2.5"])) == ["1.2a1"]
+        wide = inter | vr("<3.0")
+        assert list(wide.filter(["1.2a1", "2.0a1", "2.5"])) == ["1.2a1", "2.0a1", "2.5"]
+
+    def test_region_distributes_at_filter_level(self) -> None:
+        # Union distributes over intersection for the opt-in region, not just
+        # the bounds: the force-admitted pre-releases agree on both groupings.
+        # (contains ignores the region, so this needs a filter-level check.)
+        a, b, c = vr(">=1.0a1"), vr(">=2.0b1,<4.0"), vr(">=1.5,<3.0")
+        lhs = a | (b & c)
+        rhs = (a | b) & (a | c)
+        assert lhs == rhs
+        cand = ["1.0a1", "1.5b1", "2.0b1", "2.5", "2.5b1", "3.5b1"]
+        assert list(lhs.filter(cand)) == list(rhs.filter(cand))
+
+    def test_difference_of_two_region_bearing_ranges(self) -> None:
+        # Both operands carry an opt-in region; a - b still equals a & ~b.
+        a, b = vr(">=1.0a1,<5.0"), vr(">=2.0b1")
+        cand = ["1.0a1", "1.5b1", "2.0b1", "2.5b1", "4.0"]
+        assert (a - b) == (a & ~b)
+        assert list((a - b).filter(cand)) == list((a & ~b).filter(cand))
+
+    def test_intersection_with_complement_equals_difference(self) -> None:
+        # With the opt-in stored as a range, ``a & ~b`` renders b's opt-in inert
+        # (carried raw but now outside the result bounds) just as ``a - b`` does,
+        # so the two agree even when b names a pre-release.
+        a, b = vr(">=1.0"), vr(">=2.0b1")
+        cand = ["1.0", "1.5b1", "2.0b1", "2.5", "2.5b1"]
+        assert (a & ~b) == (a - b)
+        assert list((a & ~b).filter(cand)) == list((a - b).filter(cand))
+        assert list((a & ~b).filter(cand)) == ["1.0"]
+
+    def test_full_intersection_keeps_operand_opt_in(self) -> None:
+        # ``full() & req`` must preserve req's own opt-in region.
+        req = vr(">=2.0b1")
+        assert (VersionRange.full() & req)._pre_region == req._bounds
+        assert list((VersionRange.full() & req).filter(["2.0b1", "2.5"])) == [
+            "2.0b1",
+            "2.5",
+        ]
+
+    def test_union_filter_buffers_as_one_set(self) -> None:
+        # The union is a single range: an in-range final makes PEP 440 buffer
+        # away a non-opted pre-release, even though one operand alone (with no
+        # final) would have emitted it. The opted-in pre-release still shows.
+        u = vr(">=1.0,<1.8") | vr(">=1.5b1,<2.0")
+        assert list(u.filter(["1.2a1", "1.7b1", "1.9"])) == ["1.7b1", "1.9"]
+
+    def test_union_filter_emits_buffered_prerelease_when_no_final(self) -> None:
+        # Region narrower than bounds: a pre-release in bounds but outside the
+        # opt-in region is buffered, then emitted because no in-bounds final
+        # appears (the PEP 440 "only available" fallback). An in-bounds final
+        # then suppresses the buffer.
+        u = vr(">=1.0") | vr(">=2.0b1")  # bounds [1.0, inf), region [2.0b1, inf)
+        assert list(u.filter(["1.5b1", "1.2a1"])) == ["1.5b1", "1.2a1"]
+        assert list(u.filter(["1.5b1", "1.2a1", "1.3"])) == ["1.3"]
+
+    def test_double_complement_preserves_region_and_filtering(self) -> None:
+        r = vr(">=2.0b1")
+        assert ~~r == r
+        cand = ["1.5b1", "2.0b1", "2.5", "2.5b1"]
+        assert list((~~r).filter(cand)) == list(r.filter(cand))
+
+    def test_difference_minuend_with_literal_and_region(self) -> None:
+        # A minuend carrying both a ``===`` literal and an autodetected opt-in
+        # region keeps the literal (self-admits-and-not-other) and the region.
+        minuend = vr("===wat") | vr(">=2.0b1")
+        d = minuend - vr(">=3.0")
+        assert "wat" in d
+        assert list(d.filter(["2.0b1", "2.5b1", "2.9", "3.0"])) == [
+            "2.0b1",
+            "2.5b1",
+            "2.9",
+        ]
+
+    def test_difference_minuend_with_configured_policy(self) -> None:
+        # When the minuend carries an explicit configured policy it governs
+        # globally, so the difference keeps no opt-in region.
+        d = vr(">=1.0", prereleases=False) - vr(">=2.0b1")
+        assert d._pre_region == ()
+        assert list(d.filter(["1.5b1", "1.0"])) == ["1.0"]
+
+    def test_difference_equals_intersect_complement_universally(self) -> None:
+        # ``a - b`` builds the same opt-in region as ``a & ~b``, so the two
+        # agree even when ``b`` is complement-derived and revives a region into
+        # the result window (where a region-discarding difference would differ).
+        a = vr("<5.0")
+        b = vr(">=2.0b1").complement()
+        left, right = a & ~b, a - b
+        assert left._pre_region == right._pre_region
+        assert left == right
+        cand = ["2.5b1", "3.0", "2.0b1", "4.0"]
+        assert list(left.filter(cand)) == list(right.filter(cand))
+
+    def test_construction_region_matches_algebra(self) -> None:
+        # A multi-specifier set built directly carries the same opt-in region
+        # as one built by combining its specifiers (the region is the raw, not
+        # bounds-clipped, union), so the two stay equal under a later widening.
+        direct = vr(">=1.0a1,<3.0")
+        composed = vr(">=1.0a1") & vr("<3.0")
+        assert direct._pre_region == composed._pre_region
+        assert direct == composed
+        pool = ["1.0a1", "2.0b1", "2.9", "3.0b1", "4.5"]
+        wide = vr(">=2.0,<5.0")
+        assert list((direct | wide).filter(pool)) == list(
+            (composed | wide).filter(pool)
+        )
+
+        # Same congruence on the ``===`` (arbitrary) build path.
+        direct_arb = vr("===2.0,>=1.0a1")
+        composed_arb = vr("===2.0") & vr(">=1.0a1")
+        assert direct_arb._pre_region == composed_arb._pre_region
+        assert direct_arb == composed_arb
+
+    def test_named_literal_prerelease_is_force_admitted(self) -> None:
+        # A ``===`` literal naming a pre-release force-admits it under the default
+        # policy even when a final release in the union would otherwise buffer it
+        # away. contains agrees, and an explicit prereleases=False still drops it.
+        u = vr("===1.0a1") | vr(">=3.0")
+        assert list(u.filter(["1.0a1", "3.0"])) == ["1.0a1", "3.0"]
+        assert u.contains("1.0a1")
+        assert list(u.filter(["1.0a1", "3.0"], prereleases=False)) == ["3.0"]
+
+    def test_difference_by_empty_preserves_empty_self(self) -> None:
+        # ``a - empty()`` returns a unchanged even when a is itself empty but
+        # carries provenance: ``~full()`` keeps its arbitrary flag for involution,
+        # so subtracting a nothing-admitting set must not drop it.
+        nf = ~VersionRange.full()
+        assert (nf - VersionRange.empty()) == nf
+        assert (nf - nf) == nf  # ~full() admits nothing, so this is a no-op too
+
+    def test_difference_excludes_other_by_bounds_ignoring_policy(self) -> None:
+        # difference treats other as a bounds-only exclusion and ignores its
+        # configured policy, so subtracting a prereleases=False range excises the
+        # versions in its bounds and agrees with a & ~b there.
+        a = SpecifierSet(">=1.0", prereleases=False).to_range()
+        b = SpecifierSet(">=1.5,<2.0", prereleases=False).to_range()
+        assert (a - b) == (a & ~b)
+        assert "1.2" in (a - b)
+        assert "1.6" not in (a - b)
+
+    def test_empty_bounds_range_keeps_region_for_congruence(self) -> None:
+        # An empty-bounds range still records its raw opt-in region, so it is not
+        # equal to empty() and re-admits those pre-releases after a re-widening
+        # union. This provenance is what makes the raw region a congruence.
+        empty_region = vr(">=2.0a1") & vr("<1.0")
+        assert empty_region.is_empty
+        assert empty_region._pre_region == vr(">=2.0a1")._bounds
+        assert empty_region != VersionRange.empty()
+        assert hash(empty_region) != hash(VersionRange.empty())
+        assert list((empty_region | vr(">=0")).filter(["2.0a1", "3.0"])) == [
+            "2.0a1",
+            "3.0",
+        ]
+        assert list((VersionRange.empty() | vr(">=0")).filter(["2.0a1", "3.0"])) == [
+            "3.0"
+        ]
+
+    def test_multi_interval_region_force_admits(self) -> None:
+        # Disjoint multi-interval bounds plus a raw opt-in region exercise the
+        # multi-range path of filter_by_ranges: a pre-release in the second
+        # interval and inside the region is force-admitted.
+        r = vr(">=1.0a1,<2.0") | vr(">=3.0,<4.0")
+        assert len(r._bounds) == 2
+        assert list(r.filter(["1.5a1", "3.5a1", "3.5"])) == ["1.5a1", "3.5a1", "3.5"]
+
+    def test_region_upper_bound_clips_force_admit(self) -> None:
+        # The region has a finite upper bound (~=1.0a1 gives [1.0a1, 2.dev0)), so a
+        # pre-release in bounds but ABOVE the region is not force-admitted. After
+        # widening with >=2.5, 2.6a1 is in bounds yet above the region, so it is
+        # buffered and then suppressed by the in-bounds final 2.7.
+        r = vr("~=1.0a1") | vr(">=2.5")
+        assert list(r.filter(["1.5a1", "2.6a1", "2.7"])) == ["1.5a1", "2.7"]
+
+    def test_disjoint_region_does_not_force_admit_gap(self) -> None:
+        # A disjoint two-interval region whose bounds span the gap: a pre-release
+        # in the region gap (but in bounds) is buffered, not force-admitted, and
+        # an in-bounds final then suppresses it. The filler ``>=2.0,<5.0`` widens
+        # the bounds over the gap without adding to the region.
+        r = (vr("<2.0a5") | vr(">=5.0a1")) | vr(">=2.0,<5.0")
+        assert len(r._pre_region) == 2
+        assert list(r.filter(["1.0a1", "3.0a1", "6.0a1", "3.0"])) == [
+            "1.0a1",
+            "6.0a1",
+            "3.0",
+        ]
+
+    def test_force_admit_does_not_suppress_buffer(self) -> None:
+        # A region-admitted pre-release is not a final, so it does not suppress a
+        # separate buffered (out-of-region) pre-release when no final appears.
+        u = vr(">=1.0") | vr(">=2.0b1")  # region [2.0b1, inf)
+        assert list(u.filter(["2.5b1", "1.5b1"])) == ["2.5b1", "1.5b1"]
+
+    def test_region_force_admit_through_key(self) -> None:
+        # The region force-admit fires when filtering with a key callable too.
+        u = vr(">=1.0") | vr(">=2.0b1")
+        items = [{"v": "2.0b1"}, {"v": "1.5b1"}, {"v": "2.5"}]
+        assert list(u.filter(items, key=lambda d: d["v"])) == [
+            {"v": "2.0b1"},
+            {"v": "2.5"},
+        ]
+
+    def test_difference_region_keyed_on_self_not_other(self) -> None:
+        # A region-bearing autodetect minuend keeps its opt-in when subtracting a
+        # configured-policy subtrahend (difference reads only self's policy).
+        a = vr(">=2.0b1")  # autodetect, region [2.0b1, +inf)
+        b = SpecifierSet(">=5.0", prereleases=False).to_range()  # configured False
+        d = a - b
+        assert d._pre_region
+        assert list(d.filter(["2.0b1", "2.5b1", "4.9", "5.0"])) == [
+            "2.0b1",
+            "2.5b1",
+            "4.9",
+        ]
+
+    def test_difference_empty_bounds_region_other_reaches_merge(self) -> None:
+        # Subtracting an empty-bounds range that still carries a region must NOT
+        # short-circuit: the region has to reach the merge so a - b == a & ~b.
+        a = vr(">=0,<10.0")
+        b = vr(">=2.0a1") & vr("<1.0")  # empty bounds, raw region [2.0a1, +inf)
+        assert b.is_empty
+        assert not b._bounds
+        assert b._pre_region
+        cand = ["2.0a1", "2.5a1", "5.0"]
+        assert (a - b) == (a & ~b)
+        assert list((a - b).filter(cand)) == list((a & ~b).filter(cand))
+
+    def test_configured_policy_with_prerelease_spec_mirrors_specifier_set(self) -> None:
+        # A configured policy on a pre-release-naming set drops the opt-in region
+        # (the policy governs); filter and contains still mirror the set.
+        pool = ["1.0a1", "1.5", "2.0b1", "2.5"]
+        cases = [
+            (">=1.0a1", False),
+            (">=1.0a1", True),
+            ("~=2.0b1", True),
+            ("<=2.0b1", False),
+            ("===1.0a1", False),
+            ("===1.0a1", True),
+        ]
+        for spec, pre in cases:
+            ss = SpecifierSet(spec, prereleases=pre)
+            r = ss.to_range()
+            assert r._pre_region == ()
+            assert list(r.filter(pool)) == list(ss.filter(pool)), (spec, pre)
+            for v in pool:
+                assert r.contains(v) == ss.contains(v), (spec, pre, v)
 
 
 class TestSetRelations:
@@ -931,8 +1236,8 @@ class TestCoverageEdges:
 
     def test_ge_floor_is_canonical_full(self) -> None:
         # >=0.dev0 admits every version, so its bounds canonicalize to the full
-        # range (its complement is empty). It keeps its autodetected pre-release
-        # policy, so it is not equal to the policy-free full().
+        # range (its complement is empty). It still carries an opt-in region from
+        # its .dev0 bound, so it is not equal to the region-free full().
         r = vr(">=0.dev0")
         assert r._bounds == VersionRange.full()._bounds
         assert (~r).is_empty
@@ -953,10 +1258,10 @@ class TestCoverageEdges:
         assert Version("1.0") in r
 
     def test_eq_ranges_filter_identically(self) -> None:
-        # Two ranges with identical bounds but different resolved pre-release
-        # policy must NOT compare equal, so equal ranges always filter the same.
-        autodetect_true = vr(">=1.0a1") & vr(">=2.0")  # resolved True, [2.0, inf)
-        autodetect_none = vr(">=2.0")  # resolved None, [2.0, inf)
+        # Two ranges with identical bounds but a different opt-in region must NOT
+        # compare equal, so equal ranges always filter the same.
+        autodetect_true = vr(">=1.0a1") & vr(">=2.0")  # opt-in region [1.0a1, inf)
+        autodetect_none = vr(">=2.0")  # empty opt-in region
         assert autodetect_true._bounds == autodetect_none._bounds
         assert autodetect_true != autodetect_none
         assert hash(autodetect_true) != hash(autodetect_none)
@@ -964,8 +1269,10 @@ class TestCoverageEdges:
             autodetect_none.filter(["2.0", "2.5a1"])
         )
 
-    def test_eq_full_resolved_mismatch(self) -> None:
-        # The floor shape that exposed the substitutability bug.
+    def test_eq_full_region_mismatch(self) -> None:
+        # The floor shape that exposed the substitutability bug: same bounds,
+        # but ``>=0.dev0`` carries a full opt-in region and ``full()`` carries
+        # none, so the two must stay unequal.
         b = ~~vr(">=0.dev0")
         c = VersionRange.full(admit_arbitrary=False)
         assert b._bounds == c._bounds


### PR DESCRIPTION
When I designed `VersionRange` I modeled pre-releases the same way they work in `SpecifierSet`s, but this leads to edge cases under different set operations that don't work correctly (e.g. the example in #1298).

This got me thinking that we could model the pre-release opt-in behavior as a range, instead of `True`/`False`/`None`, so that pre-releases stay consistent under set algebra.

In particular this now makes `a & ~b` = `a - b` even for the pre-release policy, not just for the version set they represent.

This does not impact `SpecifierSet` operations, which can only take the intersection of specifiers.

A simple example is `>=1.0` and `>=2.0b1` over the versions `1.0`, `1.5b1`, `2.0b1`, `2.5`. Individually, `>=1.0` filters to `1.0`, `2.5` and `>=2.0b1` filters to `2.0b1`, `2.5`. Prior to this change the union of the two would filter the whole list to `1.0`, `1.5b1`, `2.0b1`, `2.5`; now it filters to `1.0`, `2.0b1`, `2.5`, as `1.5b1` was never opted in by `>=1.0`.

This makes `VersionRange` comply with many more set algebra rules without needing a caveat about pre-release policy.
