### PR TITLE
fix(utils): reject empty project name in parse_wheel_filename/parse_sdist_filename

### DIFF
--- a/src/packaging/utils.py
+++ b/src/packaging/utils.py
@@ -65,7 +65,8 @@ _normalized_regex = re.compile(r"[a-z0-9]+(?:-[a-z0-9]+)*", re.ASCII)
 # PEP 427: The build number must start with a digit.
 _build_tag_regex = re.compile(r"(\d+)(.*)", re.ASCII)
 # PEP 427: Valid characters for an escaped project name in a wheel filename.
-_wheel_name_regex = re.compile(r"^[\w._]*$", re.UNICODE)
+# Requires at least one character so an empty project name is rejected.
+_wheel_name_regex = re.compile(r"^[\w._]+$", re.UNICODE)
 
 
 def canonicalize_name(name: str, *, validate: bool = False) -> NormalizedName:
@@ -210,7 +211,8 @@ def parse_wheel_filename(
        The *validate_order* parameter.
 
     .. versionchanged:: 26.3
-       Raises :class:`InvalidWheelFilename` on empty tag set components.
+       Raises :class:`InvalidWheelFilename` on empty tag set components or an
+       empty project name.
     """
     if not filename.endswith(".whl"):
         raise InvalidWheelFilename(
@@ -274,7 +276,8 @@ def parse_sdist_filename(filename: str) -> tuple[NormalizedName, Version]:
     :raises InvalidSdistFilename: If the filename does not end
         with an sdist extension (``.zip`` or ``.tar.gz``), if it does not
         contain a dash separating the name and the version of the distribution,
-        or if the version portion is not a valid version.
+        if the project name is empty, or if the version portion is not a valid
+        version.
 
     >>> from packaging.utils import parse_sdist_filename
     >>> from packaging.version import Version
@@ -283,6 +286,9 @@ def parse_sdist_filename(filename: str) -> tuple[NormalizedName, Version]:
     'foo'
     >>> ver == Version('1.0')
     True
+
+    .. versionchanged:: 26.3
+       Raises :class:`InvalidSdistFilename` on an empty project name.
 
     .. _Source distribution format: https://packaging.python.org/specifications/source-distribution-format/#source-distribution-file-name
     """
@@ -301,6 +307,10 @@ def parse_sdist_filename(filename: str) -> tuple[NormalizedName, Version]:
     name_part, sep, version_part = file_stem.rpartition("-")
     if not sep:
         raise InvalidSdistFilename(f"Invalid sdist filename: {filename!r}")
+    if not name_part:
+        raise InvalidSdistFilename(
+            f"Invalid sdist filename (empty project name): {filename!r}"
+        )
 
     name = canonicalize_name(name_part)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -178,6 +178,8 @@ def test_parse_wheel_filename(
         ("foo-1.0-py3-none-any.wheel"),  # Incorrect file extension (`.wheel`)
         ("foo__bar-1.0-py3-none-any.whl"),  # Invalid name (`__`)
         ("foo#bar-1.0-py3-none-any.whl"),  # Invalid name (`#`)
+        ("-1.0-py3-none-any.whl"),  # Empty project name
+        ("-1.0-200-py3-none-any.whl"),  # Empty project name (with build number)
         ("foobar-1.x-py3-none-any.whl"),  # Invalid version (`1.x`)
         # Build number doesn't start with a digit (`abc`)
         ("foo-1.0-abc-py3-none-any.whl"),
@@ -230,6 +232,8 @@ def test_parse_sdist_filename(filename: str, name: str, version: Version) -> Non
         ("foo-1.0.xz"),  # Incorrect extension
         ("foo1.0.tar.gz"),  # Missing separator
         ("foo-1.x.tar.gz"),  # Invalid version
+        ("-1.0.tar.gz"),  # Empty project name
+        ("-1.0.zip"),  # Empty project name (zip)
     ],
 )
 def test_parse_sdist_invalid_filename(filename: str) -> None:


### PR DESCRIPTION
`parse_wheel_filename` and `parse_sdist_filename` silently accept a filename whose distribution name is **empty** and return `("", Version(...))` instead of raising the documented `InvalidWheelFilename` / `InvalidSdistFilename`:

```pycon
>>> from packaging.utils import parse_wheel_filename, parse_sdist_filename
>>> parse_wheel_filename("-1.0-py3-none-any.whl")
('', <Version('1.0')>, (), frozenset({<py3-none-any @ ...>}))
>>> parse_sdist_filename("-1.0.tar.gz")
('', <Version('1.0')>)
```

An empty name is invalid per the binary/source distribution-format specs, and `canonicalize_name(..., validate=True)` already rejects it — so the parsers are inconsistent with their own `:raises:` contract, and callers using them to validate artifact filenames get a silently-empty name instead of a clear parse error.

**Fix**
- wheel: `_wheel_name_regex` used `*` (zero-or-more), so it matched the empty string and the existing "Invalid project name" branch never fired; change it to `+`.
- sdist: add an explicit empty-name guard after the `rpartition`, before `canonicalize_name`.

Both raise the parser-specific exception (`InvalidWheelFilename` / `InvalidSdistFilename`, both `ValueError` subclasses) so back-compat holds; valid filenames are unaffected. Regression cases added to the existing empty-component parametrize lists.

Sibling of the empty-tag-component rejection in #1234.
