### PR TITLE
fix(ranges): require matching pre-release policy in difference

### DIFF
--- a/src/packaging/ranges.py
+++ b/src/packaging/ranges.py
@@ -785,10 +785,10 @@ class VersionRange:
     def is_subset(self, other: VersionRange) -> bool:
         """Return whether every member of self is also a member of other.
 
-        Equivalent to ``(self & ~other).is_empty``. For ``===`` ranges and the
-        arbitrary-admitting full range, complement is one-way, so the result
-        matches :meth:`contains` for versions but not for the non-version
-        strings those ranges admit.
+        Equivalent to ``self.difference(other).is_empty``: self is a subset of
+        other when subtracting other leaves nothing behind. This holds for
+        ``===`` literals and arbitrary-admitting ranges too, since
+        :meth:`difference` resolves each admitted string against both operands.
 
         Both operands must share the same configured pre-release policy;
         otherwise :exc:`ValueError` is raised.
@@ -807,7 +807,9 @@ class VersionRange:
         # Plain ranges: subset reduces to bounds containment, no algebra needed.
         if self._is_plain() and other._is_plain():
             return not intersect_ranges(self._bounds, _complement_ranges(other._bounds))
-        return self.intersection(other.complement()).is_empty
+        # difference (unlike intersection with the one-way complement) resolves
+        # ``===`` literals against both operands, so it stays correct for them.
+        return self.difference(other).is_empty
 
     def is_superset(self, other: VersionRange) -> bool:
         """Return whether every member of other is also a member of self.

--- a/src/packaging/ranges.py
+++ b/src/packaging/ranges.py
@@ -660,13 +660,13 @@ class VersionRange:
     def difference(self, other: VersionRange) -> VersionRange:
         """Range containing the versions in self but not in other.
 
-        On the version set this matches ``self & ~other``, but the result keeps
+        On the version set this matches ``self & ~other``, and the result keeps
         only ``self``'s admissions and pre-release policy: a non-version string
         or ``===`` literal is a member exactly when ``self`` admits it and
-        ``other`` does not. ``other`` is treated purely as an exclusion, so the
-        operands need not share a configured pre-release policy (unlike
-        :meth:`intersection` and :meth:`union`), and ``a - empty()`` returns a
-        range equal to ``a``.
+        ``other`` does not. Both operands must share the same configured
+        pre-release policy (as :meth:`intersection` and :meth:`union` require);
+        otherwise :exc:`ValueError` is raised. ``a - empty()`` returns a range
+        equal to ``a``.
 
         >>> a = SpecifierSet(">=1.0").to_range()
         >>> b = SpecifierSet(">=2.0").to_range()
@@ -677,8 +677,7 @@ class VersionRange:
         >>> a.difference(VersionRange.empty()) == a
         True
         """
-        if not isinstance(other, VersionRange):
-            raise TypeError(f"expected VersionRange, got {type(other).__name__}")
+        self._check_policy_compat(other)
 
         # Bound complement is two-way, so subtracting other's versions is an
         # intersection with its gaps.

--- a/tests/test_ranges.py
+++ b/tests/test_ranges.py
@@ -287,11 +287,11 @@ class TestSetAlgebra:
         keep = vr(">=2.0b1") - vr(">=3.0")
         assert list(keep.filter(["2.5", "2.0b1"])) == ["2.5", "2.0b1"]
 
-    def test_difference_allows_mismatched_policy(self) -> None:
-        # Unlike intersection, difference discards the subtrahend's policy, so
-        # the operands need not share a configured policy.
-        d = vr(">=1.0") - vr(">=2.0", prereleases=True)
-        assert list(d.filter(["2.0b1", "1.5a1", "1.0"])) == ["1.0"]
+    def test_difference_requires_matching_policy(self) -> None:
+        # difference matches ``self & ~other``, which requires a shared
+        # configured policy, so a mismatch raises like intersection and union.
+        with pytest.raises(ValueError, match="different"):
+            vr(">=1.0") - vr(">=2.0", prereleases=True)
 
     def test_difference_punches_hole(self) -> None:
         # Subtracting an interior range leaves two intervals.

--- a/tests/test_ranges.py
+++ b/tests/test_ranges.py
@@ -407,19 +407,29 @@ class TestSetRelations:
         assert vr("===a").is_disjoint(vr("===b"))
         assert not vr("===a").is_disjoint(vr("===a"))
 
-    def test_literal_range_subset_matches_algebra(self) -> None:
-        # ``===`` ranges take the fallback path; it equals the set algebra.
-        a, b = vr("===a"), vr("===a") | vr("===b")
-        assert a.is_subset(b) == (a & ~b).is_empty
-        assert a.is_subset(b)
+    def test_literal_range_subset(self) -> None:
+        # is_subset is ``self - other``, so a literal only ``self`` admits keeps
+        # it from being a subset. ``self & ~other`` would miss this, since
+        # complement is one-way for ``===`` literals.
+        a = vr("===a")
+        ab = vr("===a") | vr("===b")
+
+        assert a.is_subset(ab)
+        assert not ab.is_subset(a)
+
+        assert ab.is_superset(a)
+        assert not a.is_superset(ab)
 
     def test_full_arbitrary_matches_algebra(self) -> None:
         # ``full()`` carries the arbitrary-string flag, so it is not plain and
-        # both relations defer to the algebra.
+        # both relations take the non-plain path.
         f, b = VersionRange.full(), vr(">=1.0")
-        assert f.is_subset(b) == (f & ~b).is_empty
-        assert f.is_disjoint(b) == (f & b).is_empty
+
+        assert not f.is_subset(b)
         assert b.is_subset(f)
+
+        # Disjointness still mirrors the intersection algebra directly.
+        assert f.is_disjoint(b) == (f & b).is_empty
 
     def test_prerelease_excluding_policy_matches_algebra(self) -> None:
         # ``prereleases=False`` ranges are not plain, so both relations take


### PR DESCRIPTION
`intersection` and `union` raise on operands with different configured pre-release policies; `difference` did not, so `a - b` succeeded where the equivalent `a & ~b` raises, and dropped a pre-release the subtrahend's policy excludes (e.g. `>=1.0` minus `>=2.0b1` with `prereleases=False` drops `2.0b1`, which is in `a` and not in `b`).
