### PR TITLE
feat: add strict wheel filename validation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,8 +33,9 @@ Fixes:
 * Normalize requested extra names before comparing or hashing requirements (:issue:`644`)
 * Preserve a ``Requirement``'s specifier ``prereleases`` override across a
   pickle round trip. (:issue:`1204`)
-* Reject wheel filenames whose version field is not already normalized
-  according to PEP 440. (:issue:`873`)
+* Add a ``strict`` option to ``parse_wheel_filename()`` so callers can opt
+  into rejecting non-normalized version fields while keeping the default
+  parser lenient for legacy wheel filenames. (:issue:`873`)
 
 26.2 - 2026-04-24
 ~~~~~~~~~~~~~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -34,8 +34,9 @@ Fixes:
 * Preserve a ``Requirement``'s specifier ``prereleases`` override across a
   pickle round trip. (:issue:`1204`)
 * Add a ``strict`` option to ``parse_wheel_filename()`` so callers can opt
-  into rejecting non-normalized version fields while keeping the default
-  parser lenient for legacy wheel filenames. (:issue:`873`)
+  into rejecting non-normalized project names, versions, and compressed tag
+  sets while keeping the default parser lenient for legacy wheel filenames.
+  (:issue:`873`)
 
 26.2 - 2026-04-24
 ~~~~~~~~~~~~~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,6 +33,8 @@ Fixes:
 * Normalize requested extra names before comparing or hashing requirements (:issue:`644`)
 * Preserve a ``Requirement``'s specifier ``prereleases`` override across a
   pickle round trip. (:issue:`1204`)
+* Reject wheel filenames whose version field is not already normalized
+  according to PEP 440. (:issue:`873`)
 
 26.2 - 2026-04-24
 ~~~~~~~~~~~~~~~~~

--- a/src/packaging/utils.py
+++ b/src/packaging/utils.py
@@ -196,13 +196,13 @@ def parse_wheel_filename(
 
     If **validate_order** is true, compressed tag set components are
     checked to be in sorted order as required by PEP 425.
-    If **strict** is true, the version component must already be
-    normalized according to PEP 440.
+    If **strict** is true, the project name, version, and compressed tag sets
+    must already be normalized according to their respective specifications.
 
     :param str filename: The name of the wheel file.
     :param bool validate_order: Check whether compressed tag set components
         are in sorted order.
-    :param bool strict: Check whether the version component is normalized.
+    :param bool strict: Check whether normalized filename components are used.
     :raises InvalidWheelFilename: If the filename in question
         does not follow the :ref:`wheel specification
         <pypug:binary-distribution-format>`.
@@ -226,7 +226,7 @@ def parse_wheel_filename(
     .. versionchanged:: 26.3
        Raises :class:`InvalidWheelFilename` on empty tag set components or an
        empty project name, and adds the *strict* parameter to opt into
-       rejecting non-normalized version fields.
+       rejecting non-normalized filename components.
     """
     if not filename.endswith(".whl"):
         raise InvalidWheelFilename(
@@ -246,6 +246,10 @@ def parse_wheel_filename(
     if "__" in name_part or _wheel_name_regex.match(name_part) is None:
         raise InvalidWheelFilename(f"Invalid project name: {filename!r}")
     name = canonicalize_name(name_part)
+    if strict and name_part != name.replace("-", "_"):
+        raise InvalidWheelFilename(
+            f"Invalid wheel filename (project name is not normalized): {filename!r}"
+        )
 
     try:
         version = Version(parts[1])
@@ -270,7 +274,7 @@ def parse_wheel_filename(
         build = ()
     tag_str = parts[-1]
     try:
-        tags = parse_tag(tag_str, validate_order=validate_order)
+        tags = parse_tag(tag_str, validate_order=validate_order or strict)
     except UnsortedTagsError:
         raise InvalidWheelFilename(
             f"Invalid wheel filename (compressed tag set components must be in "

--- a/src/packaging/utils.py
+++ b/src/packaging/utils.py
@@ -248,6 +248,10 @@ def parse_wheel_filename(
         raise InvalidWheelFilename(
             f"Invalid wheel filename (invalid version): {filename!r}"
         ) from e
+    if parts[1] != str(version):
+        raise InvalidWheelFilename(
+            f"Invalid wheel filename (version is not normalized): {filename!r}"
+        )
 
     if dashes == 5:
         build_part = parts[2]

--- a/src/packaging/utils.py
+++ b/src/packaging/utils.py
@@ -178,6 +178,7 @@ def parse_wheel_filename(
     filename: str,
     *,
     validate_order: bool = False,
+    strict: bool = False,
 ) -> tuple[NormalizedName, Version, BuildTag, frozenset[Tag]]:
     """
     This function takes the filename of a wheel file, and parses it,
@@ -195,10 +196,13 @@ def parse_wheel_filename(
 
     If **validate_order** is true, compressed tag set components are
     checked to be in sorted order as required by PEP 425.
+    If **strict** is true, the version component must already be
+    normalized according to PEP 440.
 
     :param str filename: The name of the wheel file.
     :param bool validate_order: Check whether compressed tag set components
         are in sorted order.
+    :param bool strict: Check whether the version component is normalized.
     :raises InvalidWheelFilename: If the filename in question
         does not follow the :ref:`wheel specification
         <pypug:binary-distribution-format>`.
@@ -221,7 +225,8 @@ def parse_wheel_filename(
 
     .. versionchanged:: 26.3
        Raises :class:`InvalidWheelFilename` on empty tag set components or an
-       empty project name.
+       empty project name, and adds the *strict* parameter to opt into
+       rejecting non-normalized version fields.
     """
     if not filename.endswith(".whl"):
         raise InvalidWheelFilename(
@@ -248,7 +253,7 @@ def parse_wheel_filename(
         raise InvalidWheelFilename(
             f"Invalid wheel filename (invalid version): {filename!r}"
         ) from e
-    if parts[1] != str(version):
+    if strict and parts[1] != str(version):
         raise InvalidWheelFilename(
             f"Invalid wheel filename (version is not normalized): {filename!r}"
         )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -214,6 +214,15 @@ def test_parse_wheel_non_normalized_version_valid_by_default(
     assert tags == frozenset({Tag("py3", "none", "any")})
 
 
+def test_parse_wheel_non_normalized_name_valid_by_default() -> None:
+    name, version, build, tags = parse_wheel_filename("Foo.Bar-1.0-py3-none-any.whl")
+
+    assert name == "foo-bar"
+    assert version == Version("1.0")
+    assert build == ()
+    assert tags == frozenset({Tag("py3", "none", "any")})
+
+
 @pytest.mark.parametrize(
     "filename",
     [
@@ -228,6 +237,11 @@ def test_parse_wheel_non_normalized_version_invalid_with_strict(
 ) -> None:
     with pytest.raises(InvalidWheelFilename):
         parse_wheel_filename(filename, strict=True)
+
+
+def test_parse_wheel_non_normalized_name_invalid_with_strict() -> None:
+    with pytest.raises(InvalidWheelFilename):
+        parse_wheel_filename("Foo.Bar-1.0-py3-none-any.whl", strict=True)
 
 
 @pytest.mark.parametrize(
@@ -249,9 +263,13 @@ def test_parse_wheel_unsorted_tags_valid_by_default(filename: str) -> None:
         "foo-1.0-py3.py2-none-any.whl",
     ],
 )
-def test_parse_wheel_unsorted_tags_invalid_with_validate(filename: str) -> None:
+def test_parse_wheel_unsorted_tags_invalid_with_validate_or_strict(
+    filename: str,
+) -> None:
     with pytest.raises(InvalidWheelFilename):
         parse_wheel_filename(filename, validate_order=True)
+    with pytest.raises(InvalidWheelFilename):
+        parse_wheel_filename(filename, strict=True)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -181,6 +181,10 @@ def test_parse_wheel_filename(
         ("-1.0-py3-none-any.whl"),  # Empty project name
         ("-1.0-200-py3-none-any.whl"),  # Empty project name (with build number)
         ("foobar-1.x-py3-none-any.whl"),  # Invalid version (`1.x`)
+        ("foo-01.0.0-py3-none-any.whl"),  # Version is not normalized
+        ("foo-v1.0-py3-none-any.whl"),  # Version is not normalized
+        ("foo-1.0c1-py3-none-any.whl"),  # Version is not normalized
+        ("foo-1.0+AbC-py3-none-any.whl"),  # Version is not normalized
         # Build number doesn't start with a digit (`abc`)
         ("foo-1.0-abc-py3-none-any.whl"),
         ("foo-1.0-200-py3-none-any-junk.whl"),  # Too many dashes (`-junk`)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -181,10 +181,6 @@ def test_parse_wheel_filename(
         ("-1.0-py3-none-any.whl"),  # Empty project name
         ("-1.0-200-py3-none-any.whl"),  # Empty project name (with build number)
         ("foobar-1.x-py3-none-any.whl"),  # Invalid version (`1.x`)
-        ("foo-01.0.0-py3-none-any.whl"),  # Version is not normalized
-        ("foo-v1.0-py3-none-any.whl"),  # Version is not normalized
-        ("foo-1.0c1-py3-none-any.whl"),  # Version is not normalized
-        ("foo-1.0+AbC-py3-none-any.whl"),  # Version is not normalized
         # Build number doesn't start with a digit (`abc`)
         ("foo-1.0-abc-py3-none-any.whl"),
         ("foo-1.0-200-py3-none-any-junk.whl"),  # Too many dashes (`-junk`)
@@ -196,6 +192,42 @@ def test_parse_wheel_filename(
 def test_parse_wheel_invalid_filename(filename: str) -> None:
     with pytest.raises(InvalidWheelFilename):
         parse_wheel_filename(filename)
+
+
+@pytest.mark.parametrize(
+    ("filename", "version"),
+    [
+        ("foo-01.0.0-py3-none-any.whl", Version("1.0.0")),
+        ("foo-v1.0-py3-none-any.whl", Version("1.0")),
+        ("foo-1.0c1-py3-none-any.whl", Version("1.0rc1")),
+        ("foo-1.0+AbC-py3-none-any.whl", Version("1.0+abc")),
+    ],
+)
+def test_parse_wheel_non_normalized_version_valid_by_default(
+    filename: str, version: Version
+) -> None:
+    name, parsed_version, build, tags = parse_wheel_filename(filename)
+
+    assert name == "foo"
+    assert parsed_version == version
+    assert build == ()
+    assert tags == frozenset({Tag("py3", "none", "any")})
+
+
+@pytest.mark.parametrize(
+    "filename",
+    [
+        "foo-01.0.0-py3-none-any.whl",
+        "foo-v1.0-py3-none-any.whl",
+        "foo-1.0c1-py3-none-any.whl",
+        "foo-1.0+AbC-py3-none-any.whl",
+    ],
+)
+def test_parse_wheel_non_normalized_version_invalid_with_strict(
+    filename: str,
+) -> None:
+    with pytest.raises(InvalidWheelFilename):
+        parse_wheel_filename(filename, strict=True)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
Fixes #873.

`parse_wheel_filename()` remains lenient for legacy wheel consumers. With `strict=True`, it now validates all three normalized wheel-filename components: the project name in wheel form, the PEP 440 version token, and sorted compressed tag sets.

## User outcome
Strict consumers can reject malformed wheel filenames without changing the existing lenient parser behavior for installed legacy artifacts.

## Verification
- `uv run --group test pytest tests/test_utils.py -q`
- `uvx ruff check src/packaging/utils.py tests/test_utils.py`
- `uvx ruff format --check src/packaging/utils.py tests/test_utils.py`

## Limitations
This opt-in change is scoped to wheel filenames; sdist parsing and the default lenient API remain unchanged.