### PR TITLE
fix(markers): normalize extras/dependency_groups membership values at parse time

### DIFF
--- a/src/packaging/markers.py
+++ b/src/packaging/markers.py
@@ -172,6 +172,18 @@ def _normalize_extras(
     elif isinstance(rhs, Variable) and rhs.value == "extra" and isinstance(lhs, Value):
         normalized_extra = canonicalize_name(lhs.value)
         lhs = Value(normalized_extra)
+    elif (
+        isinstance(rhs, Variable)
+        and rhs.value in MARKERS_ALLOWING_SET
+        and isinstance(lhs, Value)
+    ):
+        # PEP 685 (extras) / PEP 735 (dependency_groups): the set-valued membership
+        # literal must also be normalized. evaluate() already canonicalizes both
+        # operands for these keys (see _normalize), so normalizing the literal at
+        # parse time keeps __str__/__eq__/__hash__ consistent with evaluate() -- e.g.
+        # Marker('"Foo" in extras') and Marker('"foo" in extras') must compare and
+        # hash equal (the membership variable is always the right-hand operand).
+        lhs = Value(canonicalize_name(lhs.value))
     return lhs, op, rhs
 
 

--- a/tests/test_markers.py
+++ b/tests/test_markers.py
@@ -465,6 +465,26 @@ class TestMarker:
         )
         assert marker.evaluate({"extra": "foo-bar", "python_version": "3.12"})
 
+    @pytest.mark.parametrize("variable", ["extras", "dependency_groups"])
+    def test_membership_value_str_normalization(self, variable: str) -> None:
+        # PEP 685 (extras) / PEP 735 (dependency_groups): the set-membership literal
+        # is normalized at parse time, so __str__/__eq__/__hash__ stay consistent with
+        # evaluate() (which already canonicalizes both operands for these keys).
+        raw = Marker(f'"S_P__A_M" in {variable}')
+        normalized = Marker(f'"s-p-a-m" in {variable}')
+
+        assert str(raw) == f'"s-p-a-m" in {variable}'
+        assert raw == normalized
+        assert hash(raw) == hash(normalized)
+
+    @pytest.mark.parametrize("variable", ["extras", "dependency_groups"])
+    def test_membership_value_str_normalization_negated(self, variable: str) -> None:
+        raw = Marker(f'"Foo_Bar" not in {variable}')
+
+        assert str(raw) == f'"foo-bar" not in {variable}'
+        assert raw == Marker(f'"foo-bar" not in {variable}')
+        assert hash(raw) == hash(Marker(f'"foo-bar" not in {variable}'))
+
     def test_python_full_version_untagged_user_provided(self) -> None:
         """A user-provided python_full_version ending with a + is also repaired."""
         assert Marker("python_full_version < '3.12'").evaluate(


### PR DESCRIPTION
## Problem

`_normalize_extras` (the parse-time normalizer run in `Marker.__init__` / `Requirement.__init__`) canonicalizes only the **singular** `extra == "X"` form. The **plural, set-valued membership** forms `"X" in extras` and `"X" in dependency_groups` are left un-normalized at parse time, so a marker's `__str__` / `__eq__` / `__hash__` disagree with its `evaluate()` result — and with PEP 685 (extras) / PEP 735 (dependency-groups), which mandate PEP 503 normalization of these names.

```pycon
>>> from packaging.markers import Marker
>>> Marker('"Foo" in extras') == Marker('"foo" in extras')
False                              # str/hash differ ...
>>> Marker('"Foo" in extras').evaluate({"extras": {"foo"}})
True
>>> Marker('"foo" in extras').evaluate({"extras": {"foo"}})
True                               # ... yet they evaluate identically
>>> Marker('extra == "Foo"') == Marker('extra == "foo"')
True                               # the singular form is already normalized
```

`evaluate()` is consistent because `_normalize` canonicalizes both operands whenever `key in MARKERS_ALLOWING_SET`; only the parse-time path was missing the plural case. The practical consequence is that equal extras/dependency-groups markers fail to dedup in sets/dicts and compare unequal in requirement/lock-file processing.

## Fix

Extend `_normalize_extras` to canonicalize the string-literal operand when the other operand is a `Variable` named `extras`/`dependency_groups`, mirroring the existing `extra` guards. The membership variable is always the right-hand operand (`Value in Variable`), so a single branch covers both `in` and `not in`. No operator check is needed because `_normalize` already normalizes these keys regardless of operator, so parse-time and eval-time now agree.

This is a follow-up completing the plural-membership gap left by the recent PEP 685 normalization work (#1246 nested singular `extra`, #1278 `Requirement` extras).

## Tests

Added `test_membership_value_str_normalization` and `..._negated` (parametrized over `extras` / `dependency_groups`) asserting `str`, `==`, and `hash` consistency for both `in` and `not in`. Full `tests/test_markers.py` (2284 tests) passes; `ruff check` and `ruff format` are clean.
