### PR TITLE
feat(specifiers): add accepted-version relation helpers

### DIFF
--- a/docs/specifiers.rst
+++ b/docs/specifiers.rst
@@ -62,11 +62,24 @@ Usage
     >>> # We can convert a specifier set into a set-algebra VersionRange
     >>> SpecifierSet(">=1.0,<2.0").to_range()
     <VersionRange '[1.0, 2.0.dev0)'>
+    >>> # Or ask set-relation questions directly
+    >>> SpecifierSet(">=3.12,<3.13").is_subset(SpecifierSet(">=3.12"))
+    True
+    >>> SpecifierSet(">=3.12").is_superset(SpecifierSet(">=3.12,<3.13"))
+    True
+    >>> SpecifierSet("<3.12").is_disjoint(SpecifierSet(">=3.12"))
+    True
 
 The :meth:`~packaging.specifiers.SpecifierSet.to_range` method returns a
 :class:`~packaging.ranges.VersionRange`, a set-algebra view of the accepted
 versions that supports intersection, union, complement, and difference. See
 :doc:`ranges` for details.
+
+The relation helpers accept another ``SpecifierSet`` and delegate to
+``VersionRange``. Comparing sets with incompatible pre-release policies raises
+:exc:`ValueError`. Sets containing ``===`` specifiers are not supported by these
+helpers; convert to ``VersionRange`` directly if you need lower-level arbitrary
+equality handling.
 
 
 Reference

--- a/docs/specifiers.rst
+++ b/docs/specifiers.rst
@@ -62,12 +62,12 @@ Usage
     >>> # We can convert a specifier set into a set-algebra VersionRange
     >>> SpecifierSet(">=1.0,<2.0").to_range()
     <VersionRange '[1.0, 2.0.dev0)'>
-    >>> # Or ask accepted-version relation questions directly
-    >>> SpecifierSet(">=3.12,<3.13").is_version_subset(SpecifierSet(">=3.12"))
+    >>> # Or ask set-relation questions directly
+    >>> SpecifierSet(">=3.12,<3.13").is_subset(SpecifierSet(">=3.12"))
     True
-    >>> SpecifierSet(">=3.12").is_version_superset(SpecifierSet(">=3.12,<3.13"))
+    >>> SpecifierSet(">=3.12").is_superset(SpecifierSet(">=3.12,<3.13"))
     True
-    >>> SpecifierSet("<3.12").is_version_disjoint(SpecifierSet(">=3.12"))
+    >>> SpecifierSet("<3.12").is_disjoint(SpecifierSet(">=3.12"))
     True
 
 The :meth:`~packaging.specifiers.SpecifierSet.to_range` method returns a
@@ -75,11 +75,11 @@ The :meth:`~packaging.specifiers.SpecifierSet.to_range` method returns a
 versions that supports intersection, union, complement, and difference. See
 :doc:`ranges` for details.
 
-The accepted-version relation helpers accept another ``SpecifierSet`` and
-delegate to ``VersionRange``. Comparing sets with incompatible pre-release
-policies raises :exc:`ValueError`. Sets containing ``===`` specifiers are not
-supported by these helpers; convert to ``VersionRange`` directly if you need
-lower-level arbitrary equality handling.
+The relation helpers accept another ``SpecifierSet`` and delegate to
+``VersionRange``. Comparing sets with incompatible pre-release policies raises
+:exc:`ValueError`. Sets containing ``===`` specifiers are not supported by these
+helpers; convert to ``VersionRange`` directly if you need lower-level arbitrary
+equality handling.
 
 
 Reference

--- a/docs/specifiers.rst
+++ b/docs/specifiers.rst
@@ -62,12 +62,12 @@ Usage
     >>> # We can convert a specifier set into a set-algebra VersionRange
     >>> SpecifierSet(">=1.0,<2.0").to_range()
     <VersionRange '[1.0, 2.0.dev0)'>
-    >>> # Or ask set-relation questions directly
-    >>> SpecifierSet(">=3.12,<3.13").is_subset(SpecifierSet(">=3.12"))
+    >>> # Or ask accepted-version relation questions directly
+    >>> SpecifierSet(">=3.12,<3.13").is_version_subset(SpecifierSet(">=3.12"))
     True
-    >>> SpecifierSet(">=3.12").is_superset(SpecifierSet(">=3.12,<3.13"))
+    >>> SpecifierSet(">=3.12").is_version_superset(SpecifierSet(">=3.12,<3.13"))
     True
-    >>> SpecifierSet("<3.12").is_disjoint(SpecifierSet(">=3.12"))
+    >>> SpecifierSet("<3.12").is_version_disjoint(SpecifierSet(">=3.12"))
     True
 
 The :meth:`~packaging.specifiers.SpecifierSet.to_range` method returns a
@@ -75,11 +75,11 @@ The :meth:`~packaging.specifiers.SpecifierSet.to_range` method returns a
 versions that supports intersection, union, complement, and difference. See
 :doc:`ranges` for details.
 
-The relation helpers accept another ``SpecifierSet`` and delegate to
-``VersionRange``. Comparing sets with incompatible pre-release policies raises
-:exc:`ValueError`. Sets containing ``===`` specifiers are not supported by these
-helpers; convert to ``VersionRange`` directly if you need lower-level arbitrary
-equality handling.
+The accepted-version relation helpers accept another ``SpecifierSet`` and
+delegate to ``VersionRange``. Comparing sets with incompatible pre-release
+policies raises :exc:`ValueError`. Sets containing ``===`` specifiers are not
+supported by these helpers; convert to ``VersionRange`` directly if you need
+lower-level arbitrary equality handling.
 
 
 Reference

--- a/docs/specifiers.rst
+++ b/docs/specifiers.rst
@@ -75,11 +75,14 @@ The :meth:`~packaging.specifiers.SpecifierSet.to_range` method returns a
 versions that supports intersection, union, complement, and difference. See
 :doc:`ranges` for details.
 
-The relation helpers accept another ``SpecifierSet`` and delegate to
-``VersionRange``. Comparing sets with incompatible pre-release policies raises
-:exc:`ValueError`. Sets containing ``===`` specifiers are not supported by these
-helpers; convert to ``VersionRange`` directly if you need lower-level arbitrary
-equality handling.
+The relation helpers take another :class:`~packaging.specifiers.SpecifierSet`
+and compare the versions the two sets accept, not the specifier objects
+themselves. Both sets must have been given the same ``prereleases`` argument,
+not just the same derived
+:attr:`~packaging.specifiers.SpecifierSet.prereleases` value, or the
+comparison raises :exc:`ValueError`. Sets containing ``===`` specifiers are
+rejected; call :meth:`~packaging.specifiers.SpecifierSet.to_range` on both
+sides for those.
 
 
 Reference

--- a/src/packaging/specifiers.py
+++ b/src/packaging/specifiers.py
@@ -1136,9 +1136,9 @@ class SpecifierSet(BaseSpecifier):
         if not isinstance(other, SpecifierSet):
             raise TypeError("expected a SpecifierSet")
         if self._has_arbitrary or other._has_arbitrary:
-            raise ValueError("set relations do not support === specifiers")
+            raise ValueError("version set relations do not support === specifiers")
 
-    def is_subset(self, other: SpecifierSet) -> bool:
+    def is_version_subset(self, other: SpecifierSet) -> bool:
         """Return whether every version matching this set also matches other.
 
         :raises ValueError:
@@ -1147,9 +1147,9 @@ class SpecifierSet(BaseSpecifier):
         :raises TypeError:
             If other is not a :class:`SpecifierSet`.
 
-        >>> SpecifierSet(">=3.12,<3.13").is_subset(SpecifierSet(">=3.12"))
+        >>> SpecifierSet(">=3.12,<3.13").is_version_subset(SpecifierSet(">=3.12"))
         True
-        >>> SpecifierSet(">=3.12").is_subset(SpecifierSet(">=3.12,<3.13"))
+        >>> SpecifierSet(">=3.12").is_version_subset(SpecifierSet(">=3.12,<3.13"))
         False
 
         .. versionadded:: 26.3
@@ -1157,7 +1157,7 @@ class SpecifierSet(BaseSpecifier):
         self._check_relation_operand(other)
         return self.to_range().is_subset(other.to_range())
 
-    def is_superset(self, other: SpecifierSet) -> bool:
+    def is_version_superset(self, other: SpecifierSet) -> bool:
         """Return whether every version matching other also matches this set.
 
         :raises ValueError:
@@ -1166,7 +1166,7 @@ class SpecifierSet(BaseSpecifier):
         :raises TypeError:
             If other is not a :class:`SpecifierSet`.
 
-        >>> SpecifierSet(">=3.12").is_superset(SpecifierSet(">=3.12,<3.13"))
+        >>> SpecifierSet(">=3.12").is_version_superset(SpecifierSet(">=3.12,<3.13"))
         True
 
         .. versionadded:: 26.3
@@ -1174,7 +1174,7 @@ class SpecifierSet(BaseSpecifier):
         self._check_relation_operand(other)
         return self.to_range().is_superset(other.to_range())
 
-    def is_disjoint(self, other: SpecifierSet) -> bool:
+    def is_version_disjoint(self, other: SpecifierSet) -> bool:
         """Return whether this set and other share no matching versions.
 
         :raises ValueError:
@@ -1183,9 +1183,9 @@ class SpecifierSet(BaseSpecifier):
         :raises TypeError:
             If other is not a :class:`SpecifierSet`.
 
-        >>> SpecifierSet("<3.12").is_disjoint(SpecifierSet(">=3.12"))
+        >>> SpecifierSet("<3.12").is_version_disjoint(SpecifierSet(">=3.12"))
         True
-        >>> SpecifierSet("<3.12").is_disjoint(SpecifierSet(">=3.11"))
+        >>> SpecifierSet("<3.12").is_version_disjoint(SpecifierSet(">=3.11"))
         False
 
         .. versionadded:: 26.3

--- a/src/packaging/specifiers.py
+++ b/src/packaging/specifiers.py
@@ -1136,9 +1136,9 @@ class SpecifierSet(BaseSpecifier):
         if not isinstance(other, SpecifierSet):
             raise TypeError("expected a SpecifierSet")
         if self._has_arbitrary or other._has_arbitrary:
-            raise ValueError("version set relations do not support === specifiers")
+            raise ValueError("set relations do not support === specifiers")
 
-    def is_version_subset(self, other: SpecifierSet) -> bool:
+    def is_subset(self, other: SpecifierSet) -> bool:
         """Return whether every version matching this set also matches other.
 
         :raises ValueError:
@@ -1147,9 +1147,9 @@ class SpecifierSet(BaseSpecifier):
         :raises TypeError:
             If other is not a :class:`SpecifierSet`.
 
-        >>> SpecifierSet(">=3.12,<3.13").is_version_subset(SpecifierSet(">=3.12"))
+        >>> SpecifierSet(">=3.12,<3.13").is_subset(SpecifierSet(">=3.12"))
         True
-        >>> SpecifierSet(">=3.12").is_version_subset(SpecifierSet(">=3.12,<3.13"))
+        >>> SpecifierSet(">=3.12").is_subset(SpecifierSet(">=3.12,<3.13"))
         False
 
         .. versionadded:: 26.3
@@ -1157,7 +1157,7 @@ class SpecifierSet(BaseSpecifier):
         self._check_relation_operand(other)
         return self.to_range().is_subset(other.to_range())
 
-    def is_version_superset(self, other: SpecifierSet) -> bool:
+    def is_superset(self, other: SpecifierSet) -> bool:
         """Return whether every version matching other also matches this set.
 
         :raises ValueError:
@@ -1166,7 +1166,7 @@ class SpecifierSet(BaseSpecifier):
         :raises TypeError:
             If other is not a :class:`SpecifierSet`.
 
-        >>> SpecifierSet(">=3.12").is_version_superset(SpecifierSet(">=3.12,<3.13"))
+        >>> SpecifierSet(">=3.12").is_superset(SpecifierSet(">=3.12,<3.13"))
         True
 
         .. versionadded:: 26.3
@@ -1174,7 +1174,7 @@ class SpecifierSet(BaseSpecifier):
         self._check_relation_operand(other)
         return self.to_range().is_superset(other.to_range())
 
-    def is_version_disjoint(self, other: SpecifierSet) -> bool:
+    def is_disjoint(self, other: SpecifierSet) -> bool:
         """Return whether this set and other share no matching versions.
 
         :raises ValueError:
@@ -1183,9 +1183,9 @@ class SpecifierSet(BaseSpecifier):
         :raises TypeError:
             If other is not a :class:`SpecifierSet`.
 
-        >>> SpecifierSet("<3.12").is_version_disjoint(SpecifierSet(">=3.12"))
+        >>> SpecifierSet("<3.12").is_disjoint(SpecifierSet(">=3.12"))
         True
-        >>> SpecifierSet("<3.12").is_version_disjoint(SpecifierSet(">=3.11"))
+        >>> SpecifierSet("<3.12").is_disjoint(SpecifierSet(">=3.11"))
         False
 
         .. versionadded:: 26.3

--- a/src/packaging/specifiers.py
+++ b/src/packaging/specifiers.py
@@ -1132,6 +1132,67 @@ class SpecifierSet(BaseSpecifier):
 
         return VersionRange._from_specifier_set(self)
 
+    def _check_relation_operand(self, other: object) -> None:
+        if not isinstance(other, SpecifierSet):
+            raise TypeError("expected a SpecifierSet")
+        if self._has_arbitrary or other._has_arbitrary:
+            raise ValueError("set relations do not support === specifiers")
+
+    def is_subset(self, other: SpecifierSet) -> bool:
+        """Return whether every version matching this set also matches other.
+
+        :raises ValueError:
+            If the two sets use ``===`` specifiers or incompatible pre-release
+            policies.
+        :raises TypeError:
+            If other is not a :class:`SpecifierSet`.
+
+        >>> SpecifierSet(">=3.12,<3.13").is_subset(SpecifierSet(">=3.12"))
+        True
+        >>> SpecifierSet(">=3.12").is_subset(SpecifierSet(">=3.12,<3.13"))
+        False
+
+        .. versionadded:: 26.3
+        """
+        self._check_relation_operand(other)
+        return self.to_range().is_subset(other.to_range())
+
+    def is_superset(self, other: SpecifierSet) -> bool:
+        """Return whether every version matching other also matches this set.
+
+        :raises ValueError:
+            If the two sets use ``===`` specifiers or incompatible pre-release
+            policies.
+        :raises TypeError:
+            If other is not a :class:`SpecifierSet`.
+
+        >>> SpecifierSet(">=3.12").is_superset(SpecifierSet(">=3.12,<3.13"))
+        True
+
+        .. versionadded:: 26.3
+        """
+        self._check_relation_operand(other)
+        return self.to_range().is_superset(other.to_range())
+
+    def is_disjoint(self, other: SpecifierSet) -> bool:
+        """Return whether this set and other share no matching versions.
+
+        :raises ValueError:
+            If the two sets use ``===`` specifiers or incompatible pre-release
+            policies.
+        :raises TypeError:
+            If other is not a :class:`SpecifierSet`.
+
+        >>> SpecifierSet("<3.12").is_disjoint(SpecifierSet(">=3.12"))
+        True
+        >>> SpecifierSet("<3.12").is_disjoint(SpecifierSet(">=3.11"))
+        False
+
+        .. versionadded:: 26.3
+        """
+        self._check_relation_operand(other)
+        return self.to_range().is_disjoint(other.to_range())
+
     def __contains__(self, item: UnparsedVersion) -> bool:
         """Return whether or not the item is contained in this specifier.
 

--- a/src/packaging/specifiers.py
+++ b/src/packaging/specifiers.py
@@ -1142,8 +1142,9 @@ class SpecifierSet(BaseSpecifier):
         """Return whether every version matching this set also matches other.
 
         :raises ValueError:
-            If the two sets use ``===`` specifiers or incompatible pre-release
-            policies.
+            If either set uses ``===`` specifiers, or the two sets were
+            given different ``prereleases`` arguments (unset on one side
+            counts as different).
         :raises TypeError:
             If other is not a :class:`SpecifierSet`.
 
@@ -1161,8 +1162,9 @@ class SpecifierSet(BaseSpecifier):
         """Return whether every version matching other also matches this set.
 
         :raises ValueError:
-            If the two sets use ``===`` specifiers or incompatible pre-release
-            policies.
+            If either set uses ``===`` specifiers, or the two sets were
+            given different ``prereleases`` arguments (unset on one side
+            counts as different).
         :raises TypeError:
             If other is not a :class:`SpecifierSet`.
 
@@ -1178,8 +1180,9 @@ class SpecifierSet(BaseSpecifier):
         """Return whether this set and other share no matching versions.
 
         :raises ValueError:
-            If the two sets use ``===`` specifiers or incompatible pre-release
-            policies.
+            If either set uses ``===`` specifiers, or the two sets were
+            given different ``prereleases`` arguments (unset on one side
+            counts as different).
         :raises TypeError:
             If other is not a :class:`SpecifierSet`.
 

--- a/tests/test_specifiers.py
+++ b/tests/test_specifiers.py
@@ -2394,14 +2394,12 @@ class TestSpecifierSet:
             ("", ">=3.12", False),
         ],
     )
-    def test_is_version_subset(self, left: str, right: str, expected: bool) -> None:
+    def test_is_subset(self, left: str, right: str, expected: bool) -> None:
         spec = SpecifierSet(left)
         other = SpecifierSet(right)
 
-        assert spec.is_version_subset(other) is expected
-        assert spec.is_version_subset(other) == spec.to_range().is_subset(
-            other.to_range()
-        )
+        assert spec.is_subset(other) is expected
+        assert spec.is_subset(other) == spec.to_range().is_subset(other.to_range())
 
     @pytest.mark.parametrize(
         ("left", "right", "expected"),
@@ -2416,14 +2414,12 @@ class TestSpecifierSet:
             (">=3.12", "", False),
         ],
     )
-    def test_is_version_superset(self, left: str, right: str, expected: bool) -> None:
+    def test_is_superset(self, left: str, right: str, expected: bool) -> None:
         spec = SpecifierSet(left)
         other = SpecifierSet(right)
 
-        assert spec.is_version_superset(other) is expected
-        assert spec.is_version_superset(other) == spec.to_range().is_superset(
-            other.to_range()
-        )
+        assert spec.is_superset(other) is expected
+        assert spec.is_superset(other) == spec.to_range().is_superset(other.to_range())
 
     @pytest.mark.parametrize(
         ("left", "right", "expected"),
@@ -2436,18 +2432,16 @@ class TestSpecifierSet:
             ("", ">=3.12", False),
         ],
     )
-    def test_is_version_disjoint(self, left: str, right: str, expected: bool) -> None:
+    def test_is_disjoint(self, left: str, right: str, expected: bool) -> None:
         spec = SpecifierSet(left)
         other = SpecifierSet(right)
 
-        assert spec.is_version_disjoint(other) is expected
-        assert spec.is_version_disjoint(other) == spec.to_range().is_disjoint(
-            other.to_range()
-        )
+        assert spec.is_disjoint(other) is expected
+        assert spec.is_disjoint(other) == spec.to_range().is_disjoint(other.to_range())
 
     @pytest.mark.parametrize(
         "method",
-        ["is_version_subset", "is_version_superset", "is_version_disjoint"],
+        ["is_subset", "is_superset", "is_disjoint"],
     )
     def test_set_relations_raise_on_prerelease_policy_mismatch(
         self, method: str
@@ -2460,17 +2454,17 @@ class TestSpecifierSet:
 
     @pytest.mark.parametrize(
         "method",
-        ["is_version_subset", "is_version_superset", "is_version_disjoint"],
+        ["is_subset", "is_superset", "is_disjoint"],
     )
     def test_set_relations_require_specifierset(self, method: str) -> None:
         spec = SpecifierSet(">=1.0")
 
         with pytest.raises(TypeError, match="SpecifierSet"):
-            getattr(spec, method)(">=1.0")
+            getattr(spec, method)(">=1.0")  # type: ignore[arg-type]
 
     @pytest.mark.parametrize(
         "method",
-        ["is_version_subset", "is_version_superset", "is_version_disjoint"],
+        ["is_subset", "is_superset", "is_disjoint"],
     )
     @pytest.mark.parametrize(
         ("left", "right"),

--- a/tests/test_specifiers.py
+++ b/tests/test_specifiers.py
@@ -2394,12 +2394,14 @@ class TestSpecifierSet:
             ("", ">=3.12", False),
         ],
     )
-    def test_is_subset(self, left: str, right: str, expected: bool) -> None:
+    def test_is_version_subset(self, left: str, right: str, expected: bool) -> None:
         spec = SpecifierSet(left)
         other = SpecifierSet(right)
 
-        assert spec.is_subset(other) is expected
-        assert spec.is_subset(other) == spec.to_range().is_subset(other.to_range())
+        assert spec.is_version_subset(other) is expected
+        assert spec.is_version_subset(other) == spec.to_range().is_subset(
+            other.to_range()
+        )
 
     @pytest.mark.parametrize(
         ("left", "right", "expected"),
@@ -2414,12 +2416,14 @@ class TestSpecifierSet:
             (">=3.12", "", False),
         ],
     )
-    def test_is_superset(self, left: str, right: str, expected: bool) -> None:
+    def test_is_version_superset(self, left: str, right: str, expected: bool) -> None:
         spec = SpecifierSet(left)
         other = SpecifierSet(right)
 
-        assert spec.is_superset(other) is expected
-        assert spec.is_superset(other) == spec.to_range().is_superset(other.to_range())
+        assert spec.is_version_superset(other) is expected
+        assert spec.is_version_superset(other) == spec.to_range().is_superset(
+            other.to_range()
+        )
 
     @pytest.mark.parametrize(
         ("left", "right", "expected"),
@@ -2432,16 +2436,18 @@ class TestSpecifierSet:
             ("", ">=3.12", False),
         ],
     )
-    def test_is_disjoint(self, left: str, right: str, expected: bool) -> None:
+    def test_is_version_disjoint(self, left: str, right: str, expected: bool) -> None:
         spec = SpecifierSet(left)
         other = SpecifierSet(right)
 
-        assert spec.is_disjoint(other) is expected
-        assert spec.is_disjoint(other) == spec.to_range().is_disjoint(other.to_range())
+        assert spec.is_version_disjoint(other) is expected
+        assert spec.is_version_disjoint(other) == spec.to_range().is_disjoint(
+            other.to_range()
+        )
 
     @pytest.mark.parametrize(
         "method",
-        ["is_subset", "is_superset", "is_disjoint"],
+        ["is_version_subset", "is_version_superset", "is_version_disjoint"],
     )
     def test_set_relations_raise_on_prerelease_policy_mismatch(
         self, method: str
@@ -2454,17 +2460,17 @@ class TestSpecifierSet:
 
     @pytest.mark.parametrize(
         "method",
-        ["is_subset", "is_superset", "is_disjoint"],
+        ["is_version_subset", "is_version_superset", "is_version_disjoint"],
     )
     def test_set_relations_require_specifierset(self, method: str) -> None:
         spec = SpecifierSet(">=1.0")
 
         with pytest.raises(TypeError, match="SpecifierSet"):
-            getattr(spec, method)(">=1.0")  # type: ignore[arg-type]
+            getattr(spec, method)(">=1.0")
 
     @pytest.mark.parametrize(
         "method",
-        ["is_subset", "is_superset", "is_disjoint"],
+        ["is_version_subset", "is_version_superset", "is_version_disjoint"],
     )
     @pytest.mark.parametrize(
         ("left", "right"),

--- a/tests/test_specifiers.py
+++ b/tests/test_specifiers.py
@@ -2460,7 +2460,7 @@ class TestSpecifierSet:
         spec = SpecifierSet(">=1.0")
 
         with pytest.raises(TypeError, match="SpecifierSet"):
-            getattr(spec, method)(">=1.0")  # type: ignore[arg-type]
+            getattr(spec, method)(">=1.0")
 
     @pytest.mark.parametrize(
         "method",

--- a/tests/test_specifiers.py
+++ b/tests/test_specifiers.py
@@ -2382,6 +2382,108 @@ class TestSpecifierSet:
         assert not SpecifierSet("==1.0") == 12
 
     @pytest.mark.parametrize(
+        ("left", "right", "expected"),
+        [
+            (">2", ">1", True),
+            (">1", ">2", False),
+            (">=3.12,<3.13", ">=3.12", True),
+            (">=3.12,<3.13", ">=3.11,<3.13", True),
+            (">=3.12,<3.13", ">=3.12,<3.13", True),
+            (">=3.12,<3.13", ">=3.12,<3.12.5", False),
+            (">=2.0,<1.0", ">=3.12", True),
+            ("", ">=3.12", False),
+        ],
+    )
+    def test_is_subset(self, left: str, right: str, expected: bool) -> None:
+        spec = SpecifierSet(left)
+        other = SpecifierSet(right)
+
+        assert spec.is_subset(other) is expected
+        assert spec.is_subset(other) == spec.to_range().is_subset(other.to_range())
+
+    @pytest.mark.parametrize(
+        ("left", "right", "expected"),
+        [
+            (">1", ">2", True),
+            (">2", ">1", False),
+            (">=3.12", ">=3.12,<3.13", True),
+            (">=3.11,<3.13", ">=3.12,<3.13", True),
+            (">=3.12,<3.13", ">=3.12,<3.13", True),
+            (">=3.12,<3.12.5", ">=3.12,<3.13", False),
+            (">=3.12", ">=2.0,<1.0", True),
+            (">=3.12", "", False),
+        ],
+    )
+    def test_is_superset(self, left: str, right: str, expected: bool) -> None:
+        spec = SpecifierSet(left)
+        other = SpecifierSet(right)
+
+        assert spec.is_superset(other) is expected
+        assert spec.is_superset(other) == spec.to_range().is_superset(other.to_range())
+
+    @pytest.mark.parametrize(
+        ("left", "right", "expected"),
+        [
+            ("<3.12", ">=3.12", True),
+            ("<3.12", ">=3.11", False),
+            (">=3.12,<3.13", ">=3.13", True),
+            (">=3.12,<3.13", "==3.12.1", False),
+            (">=2.0,<1.0", ">=3.12", True),
+            ("", ">=3.12", False),
+        ],
+    )
+    def test_is_disjoint(self, left: str, right: str, expected: bool) -> None:
+        spec = SpecifierSet(left)
+        other = SpecifierSet(right)
+
+        assert spec.is_disjoint(other) is expected
+        assert spec.is_disjoint(other) == spec.to_range().is_disjoint(other.to_range())
+
+    @pytest.mark.parametrize(
+        "method",
+        ["is_subset", "is_superset", "is_disjoint"],
+    )
+    def test_set_relations_raise_on_prerelease_policy_mismatch(
+        self, method: str
+    ) -> None:
+        spec = SpecifierSet(">=1.0", prereleases=True)
+        other = SpecifierSet(">=1.0", prereleases=False)
+
+        with pytest.raises(ValueError, match="pre-release"):
+            getattr(spec, method)(other)
+
+    @pytest.mark.parametrize(
+        "method",
+        ["is_subset", "is_superset", "is_disjoint"],
+    )
+    def test_set_relations_require_specifierset(self, method: str) -> None:
+        spec = SpecifierSet(">=1.0")
+
+        with pytest.raises(TypeError, match="SpecifierSet"):
+            getattr(spec, method)(">=1.0")  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize(
+        "method",
+        ["is_subset", "is_superset", "is_disjoint"],
+    )
+    @pytest.mark.parametrize(
+        ("left", "right"),
+        [
+            ("===1.0", "==1.0"),
+            ("==1.0", "===1.0"),
+            ("===foobar", ">=1.0"),
+        ],
+    )
+    def test_set_relations_reject_arbitrary_equality(
+        self, method: str, left: str, right: str
+    ) -> None:
+        spec = SpecifierSet(left)
+        other = SpecifierSet(right)
+
+        with pytest.raises(ValueError, match="==="):
+            getattr(spec, method)(other)
+
+    @pytest.mark.parametrize(
         ("version", "specifier", "expected"),
         [
             ("1.0.0+local", "==1.0.0", True),


### PR DESCRIPTION
## Summary

- add `SpecifierSet.is_version_subset`, `is_version_superset`, and `is_version_disjoint` as direct wrappers over `VersionRange` set-relation helpers
- document that the helpers compare the sets of accepted versions, not the specifier objects themselves
- reject `===` specifier sets at this wrapper layer for now, and keep existing `VersionRange` pre-release policy errors visible

This keeps the first public wrapper scope to `SpecifierSet` operands. `Specifier`-level helpers and arbitrary-equality relation semantics can be added separately if desired.

Refs #947.

## Tests

- `uv run --group test --with ruff pytest tests/test_specifiers.py -q`
- `uv run --group test --with ruff ruff check src/packaging/specifiers.py tests/test_specifiers.py`
- `uv run --with nox nox -s lint -- --show-diff-on-failure`
