### PR TITLE
fix(markers): keep parentheses of a nested group when serializing

### DIFF
--- a/src/packaging/markers.py
+++ b/src/packaging/markers.py
@@ -188,16 +188,14 @@ def _format_marker(
 ) -> str:
     assert isinstance(marker, (list, tuple, str))
 
-    # Sometimes we have a structure like [[...]] which is a single item list
-    # where the single item is itself it's own list. In that case we want skip
-    # the rest of this function so that we don't get extraneous () on the
-    # outside.
+    # Unwrap a redundant [[...]] wrapper, but keep the nesting context so a
+    # nested group keeps the parentheses its and/or precedence needs.
     if (
         isinstance(marker, list)
         and len(marker) == 1
         and isinstance(marker[0], (list, tuple))
     ):
-        return _format_marker(marker[0])
+        return _format_marker(marker[0], first=first)
 
     if isinstance(marker, list):
         inner = (_format_marker(m, first=False) for m in marker)

--- a/tests/test_markers.py
+++ b/tests/test_markers.py
@@ -605,6 +605,21 @@ def test_chaining_associativity_and_str() -> None:
     assert str(a) == str(b)
 
 
+def test_str_preserves_nested_group_precedence() -> None:
+    # A nested group must keep its parentheses so str(Marker(...)) round-trips.
+    m = Marker(
+        'python_version < "3.10" and '
+        '((sys_platform == "linux" or sys_platform == "darwin"))'
+    )
+    reparsed = Marker(str(m))
+    for env in (
+        {"python_version": "3.12", "sys_platform": "darwin"},
+        {"python_version": "3.12", "sys_platform": "linux"},
+        {"python_version": "3.9", "sys_platform": "darwin"},
+    ):
+        assert reparsed.evaluate(env) == m.evaluate(env)
+
+
 def test_hash_eq_for_combined_markers() -> None:
     assert hash(Marker('python_version >= "3.6" and os_name == "posix"')) == hash(
         Marker('python_version >= "3.6"') & Marker('os_name == "posix"')


### PR DESCRIPTION
Keeps the parentheses of a nested `and`/`or` group so `str(Marker(...))` round-trips.

Fixes #1315