### PR TITLE
fix(version): reject non-string versions consistently

### DIFF
--- a/src/packaging/version.py
+++ b/src/packaging/version.py
@@ -410,6 +410,9 @@ class Version(_BaseVersion):
             If the ``version`` does not conform to PEP 440 in any way then this
             exception will be raised.
         """
+        if not isinstance(version, str):
+            raise InvalidVersion(f"Invalid version: {version!r}")
+
         if _SIMPLE_VERSION_INDICATORS.issuperset(version):
             try:
                 self._release = tuple(map(int, version.split(".")))

--- a/src/packaging/version.py
+++ b/src/packaging/version.py
@@ -410,12 +410,16 @@ class Version(_BaseVersion):
             If the ``version`` does not conform to PEP 440 in any way then this
             exception will be raised.
         """
-        if not isinstance(version, str):
-            raise InvalidVersion(f"Invalid version: {version!r}")
+        try:
+            is_simple = _SIMPLE_VERSION_INDICATORS.issuperset(version)
+        except TypeError:
+            raise InvalidVersion(f"Invalid version: {version!r}") from None
 
-        if _SIMPLE_VERSION_INDICATORS.issuperset(version):
+        if is_simple:
             try:
                 self._release = tuple(map(int, version.split(".")))
+            except AttributeError:
+                raise InvalidVersion(f"Invalid version: {version!r}") from None
             except ValueError:
                 # Empty parts (from "1..2", ".1", etc.) are invalid versions.
                 # Any other ValueError (e.g. int str-digits limit) should
@@ -435,7 +439,10 @@ class Version(_BaseVersion):
             return
 
         # Validate the version and parse it into pieces
-        match = self._regex.fullmatch(version)
+        try:
+            match = self._regex.fullmatch(version)
+        except TypeError:
+            raise InvalidVersion(f"Invalid version: {version!r}") from None
         if not match:
             raise InvalidVersion(f"Invalid version: {version!r}")
         self._epoch = int(match.group("epoch")) if match.group("epoch") else 0

--- a/tests/test_specifiers.py
+++ b/tests/test_specifiers.py
@@ -3458,7 +3458,7 @@ def test_filter_keyed_none_version_is_skipped() -> None:
     """Non-string keyed versions are skipped like other invalid versions."""
     items = [{"v": "1.0"}, {"v": None}, {"v": "2.0"}]
     spec = SpecifierSet(">=1")
-    assert list(spec.filter(items, key=lambda x: x["v"])) == [
+    assert list(spec.filter(items, key=lambda x: x["v"])) == [  # type: ignore[index]
         {"v": "1.0"},
         {"v": "2.0"},
     ]

--- a/tests/test_specifiers.py
+++ b/tests/test_specifiers.py
@@ -3454,6 +3454,16 @@ def test_filter_arbitrary_unparsable_uses_key() -> None:
     ]
 
 
+def test_filter_keyed_none_version_is_skipped() -> None:
+    """Non-string keyed versions are skipped like other invalid versions."""
+    items = [{"v": "1.0"}, {"v": None}, {"v": "2.0"}]
+    spec = SpecifierSet(">=1")
+    assert list(spec.filter(items, key=lambda x: x["v"])) == [
+        {"v": "1.0"},
+        {"v": "2.0"},
+    ]
+
+
 def test_filter_arbitrary_pep440_unparsable_buffer_flush() -> None:
     """``===wat`` flushes the unparsable buffer when no final ever lands."""
     # "wat" never parses, so no final can be reached for the literal

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -215,6 +215,11 @@ class TestVersion:
         with pytest.raises(InvalidVersion):
             Version(version)
 
+    @pytest.mark.parametrize("version", [None, 1])
+    def test_non_string_versions_raise_invalid_version(self, version: object) -> None:
+        with pytest.raises(InvalidVersion):
+            Version(version)
+
     @pytest.mark.skipif(
         not hasattr(sys, "get_int_max_str_digits"),
         reason="requires int max str digits limit",

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -215,10 +215,10 @@ class TestVersion:
         with pytest.raises(InvalidVersion):
             Version(version)
 
-    @pytest.mark.parametrize("version", [None, 1])
+    @pytest.mark.parametrize("version", [None, 1, ["1", ".", "0"], ("1",), b"1.0"])
     def test_non_string_versions_raise_invalid_version(self, version: object) -> None:
         with pytest.raises(InvalidVersion):
-            Version(version)
+            Version(version)  # type: ignore[arg-type]
 
     @pytest.mark.skipif(
         not hasattr(sys, "get_int_max_str_digits"),


### PR DESCRIPTION
Fixes #1318.

`Version.__init__` now rejects non-string input before the simple-version fast path calls `_SIMPLE_VERSION_INDICATORS.issuperset(version)`. That preserves the normal `InvalidVersion` path instead of leaking a raw `TypeError` for values like `None`.

I also added coverage for the downstream range-filtering case: keyed arbitrary items with `None` versions are skipped like other invalid versions rather than aborting `SpecifierSet.filter()`.

Checks run:

- `uv run --group test --with ruff pytest tests/test_version.py tests/test_specifiers.py -q`
- `uv run --group test --with ruff pytest tests/test_version.py::TestVersion::test_non_string_versions_raise_invalid_version tests/test_specifiers.py::test_filter_keyed_none_version_is_skipped -q`
- `uv run ruff check src/packaging/version.py tests/test_version.py tests/test_specifiers.py`
- `uv run ruff format --check src/packaging/version.py tests/test_version.py tests/test_specifiers.py`
