### PR TITLE
perf: add __slots__ to Requirement

### DIFF
--- a/src/packaging/requirements.py
+++ b/src/packaging/requirements.py
@@ -71,6 +71,8 @@ class Requirement:
     #       the thing as well as the version? What about the markers?
     # TODO: Can we normalize the name and extra name?
 
+    __slots__ = ("extras", "marker", "name", "specifier", "url")
+
     def __init__(self, requirement_string: str) -> None:
         try:
             parsed = _parse_requirement(requirement_string)
@@ -124,9 +126,10 @@ class Requirement:
         ):
             # New format (26.3+): (requirement string, specifier prereleases).
             requirement_string, prereleases = state
-        elif isinstance(state, dict):
+        elif isinstance(state, dict) and state.keys() >= set(self.__slots__):
             # Old format (packaging <= 26.1, no __slots__): plain __dict__.
-            self.__dict__.update(state)
+            for key in self.__slots__:
+                setattr(self, key, state[key])
             return
         else:
             raise TypeError(f"Cannot restore Requirement from {state!r}")

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -789,6 +789,15 @@ class TestRequirementBehaviour:
         assert Requirement("packaging>=21.3") != "packaging>=21.3"
 
 
+def test_requirement_slots() -> None:
+    # Requirement defines __slots__, so instances have no __dict__ and reject
+    # unknown attributes.
+    r = Requirement("requests>=2.0")
+    assert not hasattr(r, "__dict__")
+    with pytest.raises(AttributeError):
+        r.nonexistent = 1  # type: ignore[attr-defined]
+
+
 @pytest.mark.parametrize(
     "req_str",
     [


### PR DESCRIPTION
Looking at #1252, the first step toward making these immutable is adding slots. This is the only remaining one missing one of the major classes that would benefit (not counting dataclasses).

:robot: _AI text below_ :robot:

Adds `__slots__` to `Requirement`, matching `Version`, `Specifier`, `SpecifierSet`, `Marker`, and `Tag`.

The legacy-pickle branch in `__setstate__` (for pickles from packaging <= 26.1, which stored a plain `__dict__`) now restores attributes via `setattr`, since slotted instances have no `__dict__`. The existing tests that load real pickle bytes from packaging 25.0/26.0/26.1 cover that path; a new test asserts instances have no `__dict__`.