### PR TITLE
ci: install hypothesis as wheel-only to fix PyPy and free-threaded jobs

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -37,6 +37,11 @@ nox.options.default_venv_backend = "uv|virtualenv"
 PYPROJECT = nox.project.load_toml("pyproject.toml")
 PYTHON_VERSIONS = nox.project.python_versions(PYPROJECT)
 
+# hypothesis 6.156+ ships as a maturin/pyo3 project without wheels for PyPy or
+# free-threaded CPython, so building from the sdist fails there. Restrict it to
+# binaries so uv/pip picks the newest version with a compatible wheel instead.
+HYPOTHESIS_BINARY_ONLY = ("--only-binary", "hypothesis")
+
 
 @nox.session(
     python=[
@@ -56,7 +61,9 @@ def tests(session: nox.Session) -> None:
     """
     coverage = ["python", "-m", "coverage"]
 
-    session.install(*nox.project.dependency_groups(PYPROJECT, "test"))
+    session.install(
+        *HYPOTHESIS_BINARY_ONLY, *nox.project.dependency_groups(PYPROJECT, "test")
+    )
     session.install("-e.")
     env = {} if session.python != "3.14" else {"COVERAGE_CORE": "sysmon"}
 
@@ -92,7 +99,9 @@ def property_tests(session: nox.Session) -> None:
     """
     Run property-based tests (no coverage).
     """
-    session.install(*nox.project.dependency_groups(PYPROJECT, "test"))
+    session.install(
+        *HYPOTHESIS_BINARY_ONLY, *nox.project.dependency_groups(PYPROJECT, "test")
+    )
     session.install("-e.")
     session.run(
         "python",


### PR DESCRIPTION
CI broke 9 hours ago, when hypothesis started shipping an SDist. Now low-support Pythons (3.13t, PyPy 3.10) no longer work, since PyO3 won't build on them.

The note below is for old free-threaded CPython (3.13t) only, 3.14t does have wheels - but only binary doesn't hurt there. Also, 3.15 doesn't have wheels yet. This might become a problem in the future when we update to 3.16+ alphas and hypothesis cannot ship wheels yet - we might need to make sure we can run without hypothesis on alpha/beta Pythons.

:robot: _AI text below_ :robot:

The PyPy and free-threaded CPython (`3.13t`) test jobs started failing at dependency install, unrelated to any code change.

`hypothesis` 6.156+ ships as a maturin/pyo3 project and publishes no wheels for PyPy or free-threaded CPython. `uv` therefore falls back to building the sdist, where `pyo3` 0.29 refuses to build against those interpreters (e.g. `error: the configured PyPy interpreter version (3.10) is lower than` its supported minimum), so the whole job dies before any test runs.

This passes `--only-binary hypothesis` in the nox test installs, so `uv`/`pip` picks the newest `hypothesis` with a compatible wheel (6.155.7 today) on those interpreters and keeps using the latest everywhere else. It is self-healing: once upstream publishes wheels again, the newest version is selected automatically.