### PR TITLE
Validate pylock package index URLs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ dynamc = "dynamc"
 notin = "notin"
 nd = "nd"
 tou = "tou"
+"itms" = "itms"
 
 [tool.coverage.run]
 branch = true

--- a/src/packaging/pylock.py
+++ b/src/packaging/pylock.py
@@ -64,6 +64,8 @@ def __dir__() -> list[str]:
 _T = TypeVar("_T")
 _T2 = TypeVar("_T2")
 
+# Not documented, so frozen here:
+# urllib.parse.uses_netloc - {"", "file"}
 _URL_SCHEMES_REQUIRING_NETLOC = frozenset(
     {
         "ftp",

--- a/src/packaging/pylock.py
+++ b/src/packaging/pylock.py
@@ -14,7 +14,7 @@ from typing import (
     TypeVar,
     cast,
 )
-from urllib.parse import urlparse
+from urllib.parse import urlparse, uses_netloc
 
 from .markers import (
     Environment,
@@ -245,6 +245,17 @@ def _validate_normalized_name(name: str) -> NormalizedName:
 def _validate_path_url(path: str | None, url: str | None) -> None:
     if not path and not url:
         raise PylockValidationError("path or url must be provided")
+
+
+def _validate_url(url: str) -> str:
+    parsed_url = urlparse(url)
+    if not parsed_url.scheme or (
+        parsed_url.scheme in uses_netloc
+        and parsed_url.scheme != "file"
+        and not parsed_url.netloc
+    ):
+        raise PylockValidationError(f"Invalid URL {url!r}")
+    return url
 
 
 def _path_name(path: str | None) -> str | None:
@@ -587,7 +598,7 @@ class Package:
             vcs=_get_object(d, PackageVcs, "vcs"),
             directory=_get_object(d, PackageDirectory, "directory"),
             archive=_get_object(d, PackageArchive, "archive"),
-            index=_get(d, str, "index"),
+            index=_get_as(d, str, _validate_url, "index"),
             sdist=_get_object(d, PackageSdist, "sdist"),
             wheels=_get_sequence_of_objects(d, PackageWheel, "wheels"),
             attestation_identities=_get_sequence(d, Mapping, "attestation-identities"),  # type: ignore[type-abstract]

--- a/src/packaging/pylock.py
+++ b/src/packaging/pylock.py
@@ -14,7 +14,7 @@ from typing import (
     TypeVar,
     cast,
 )
-from urllib.parse import urlparse, uses_netloc
+from urllib.parse import urlparse
 
 from .markers import (
     Environment,
@@ -63,6 +63,36 @@ def __dir__() -> list[str]:
 
 _T = TypeVar("_T")
 _T2 = TypeVar("_T2")
+
+_URL_SCHEMES_REQUIRING_NETLOC = frozenset(
+    {
+        "ftp",
+        "git",
+        "git+ssh",
+        "gopher",
+        "http",
+        "https",
+        "imap",
+        "itms-services",
+        "mms",
+        "nfs",
+        "nntp",
+        "prospero",
+        "rsync",
+        "rtsp",
+        "rtsps",
+        "rtspu",
+        "sftp",
+        "shttp",
+        "snews",
+        "svn",
+        "svn+ssh",
+        "telnet",
+        "wais",
+        "ws",
+        "wss",
+    }
+)
 
 
 class _FromMappingProtocol(Protocol):  # pragma: no cover
@@ -250,9 +280,7 @@ def _validate_path_url(path: str | None, url: str | None) -> None:
 def _validate_url(url: str) -> str:
     parsed_url = urlparse(url)
     if not parsed_url.scheme or (
-        parsed_url.scheme in uses_netloc
-        and parsed_url.scheme != "file"
-        and not parsed_url.netloc
+        parsed_url.scheme in _URL_SCHEMES_REQUIRING_NETLOC and not parsed_url.netloc
     ):
         raise PylockValidationError(f"Invalid URL {url!r}")
     return url

--- a/tests/test_pylock.py
+++ b/tests/test_pylock.py
@@ -260,6 +260,29 @@ def test_pylock_basic_package() -> None:
     assert pylock.to_dict() == data
 
 
+def test_pylock_invalid_package_index_url() -> None:
+    data = {
+        "lock-version": "1.0",
+        "created-by": "pip",
+        "packages": [
+            {
+                "name": "example",
+                "index": "not-a-url",
+                "wheels": [
+                    {
+                        "name": "example-1.0-py3-none-any.whl",
+                        "url": "https://example.com/example-1.0-py3-none-any.whl",
+                        "hashes": {"sha256": "f" * 40},
+                    }
+                ],
+            }
+        ],
+    }
+    with pytest.raises(PylockValidationError) as exc_info:
+        Pylock.from_dict(data)
+    assert str(exc_info.value) == "Invalid URL 'not-a-url' in 'packages[0].index'"
+
+
 def test_pylock_vcs_package() -> None:
     data = {
         "lock-version": "1.0",

--- a/tests/test_pylock.py
+++ b/tests/test_pylock.py
@@ -283,6 +283,51 @@ def test_pylock_invalid_package_index_url() -> None:
     assert str(exc_info.value) == "Invalid URL 'not-a-url' in 'packages[0].index'"
 
 
+def test_pylock_valid_package_index_url() -> None:
+    data = {
+        "lock-version": "1.0",
+        "created-by": "pip",
+        "packages": [
+            {
+                "name": "example",
+                "index": "https://example.com/simple/",
+                "wheels": [
+                    {
+                        "name": "example-1.0-py3-none-any.whl",
+                        "url": "https://example.com/example-1.0-py3-none-any.whl",
+                        "hashes": {"sha256": "f" * 40},
+                    }
+                ],
+            }
+        ],
+    }
+    pylock = Pylock.from_dict(data)
+    assert pylock.packages[0].index == "https://example.com/simple/"
+    assert pylock.to_dict() == data
+
+
+def test_pylock_missing_package_index_url() -> None:
+    data = {
+        "lock-version": "1.0",
+        "created-by": "pip",
+        "packages": [
+            {
+                "name": "example",
+                "wheels": [
+                    {
+                        "name": "example-1.0-py3-none-any.whl",
+                        "url": "https://example.com/example-1.0-py3-none-any.whl",
+                        "hashes": {"sha256": "f" * 40},
+                    }
+                ],
+            }
+        ],
+    }
+    pylock = Pylock.from_dict(data)
+    assert pylock.packages[0].index is None
+    assert pylock.to_dict() == data
+
+
 def test_pylock_vcs_package() -> None:
     data = {
         "lock-version": "1.0",


### PR DESCRIPTION
## Summary

- Validate `packages.index` as an absolute URL when parsing `pylock.toml`.
- Add a regression for invalid `packages.index` values.

## Why

`packages.index` is specified as the package index base URL. Today `Pylock.from_dict()` accepts values such as `not-a-url`, which lets invalid lock files pass validation. Fixes #1185.

## Validation

- `. .venv/bin/activate && pytest tests/test_pylock.py tests/test_pylock_select.py -q` — passed
- `. .venv/bin/activate && ruff format --check src/packaging/pylock.py tests/test_pylock.py` — passed
- `. .venv/bin/activate && ruff check src/packaging/pylock.py tests/test_pylock.py` — passed
- `. .venv/bin/activate && mypy src/packaging/pylock.py tests/test_pylock.py` — passed
- `git diff --check` — passed