### PR TITLE
fix: validate pylock package index URLs

### DIFF
--- a/src/packaging/pylock.py
+++ b/src/packaging/pylock.py
@@ -247,6 +247,13 @@ def _validate_path_url(path: str | None, url: str | None) -> None:
         raise PylockValidationError("path or url must be provided")
 
 
+def _validate_absolute_url(url: str) -> str:
+    parsed_url = urlparse(url)
+    if not parsed_url.scheme or not parsed_url.netloc:
+        raise PylockValidationError("index must be an absolute URL")
+    return url
+
+
 def _path_name(path: str | None) -> str | None:
     if not path:
         return None
@@ -587,7 +594,7 @@ class Package:
             vcs=_get_object(d, PackageVcs, "vcs"),
             directory=_get_object(d, PackageDirectory, "directory"),
             archive=_get_object(d, PackageArchive, "archive"),
-            index=_get(d, str, "index"),
+            index=_get_as(d, str, _validate_absolute_url, "index"),
             sdist=_get_object(d, PackageSdist, "sdist"),
             wheels=_get_sequence_of_objects(d, PackageWheel, "wheels"),
             attestation_identities=_get_sequence(d, Mapping, "attestation-identities"),  # type: ignore[type-abstract]

--- a/tests/test_pylock.py
+++ b/tests/test_pylock.py
@@ -260,6 +260,30 @@ def test_pylock_basic_package() -> None:
     assert pylock.to_dict() == data
 
 
+def test_pylock_invalid_package_index() -> None:
+    data = {
+        "lock-version": "1.0",
+        "created-by": "pip",
+        "packages": [
+            {
+                "name": "example",
+                "version": "1.0",
+                "index": "not-a-url",
+                "wheels": [
+                    {
+                        "name": "example-1.0-py3-none-any.whl",
+                        "url": "https://example.com/example-1.0-py3-none-any.whl",
+                        "hashes": {"sha256": "f" * 64},
+                    }
+                ],
+            }
+        ],
+    }
+    with pytest.raises(PylockValidationError) as exc_info:
+        Pylock.from_dict(data)
+    assert str(exc_info.value) == "index must be an absolute URL in 'packages[0].index'"
+
+
 def test_pylock_vcs_package() -> None:
     data = {
         "lock-version": "1.0",


### PR DESCRIPTION
Summary:
- Validate `packages.index` when parsing pylock data so relative strings such as `not-a-url` are rejected.
- Keep the existing pylock validation context (`packages[0].index`) in the error message.
- Add regression coverage for an invalid package index with an otherwise valid wheel entry.

Tests:
- `uv run --group test python -m pytest tests/test_pylock.py -q`
- `uv run --group test python -m pytest tests/test_pylock_select.py -q`
- `uvx ruff check src/packaging/pylock.py tests/test_pylock.py`
- `uvx ruff format --check src/packaging/pylock.py tests/test_pylock.py`
- `git diff --check`

Fixes #1185
