### PR TITLE
fix(metadata): don't rewrite user values containing '{field}' in errors

### DIFF
--- a/src/packaging/metadata.py
+++ b/src/packaging/metadata.py
@@ -593,9 +593,7 @@ class _Validator(Generic[T]):
     def _invalid_metadata(
         self, msg: str, cause: Exception | None = None
     ) -> InvalidMetadata:
-        exc = InvalidMetadata(
-            self.raw_name, msg.format_map({"field": repr(self.raw_name)})
-        )
+        exc = InvalidMetadata(self.raw_name, msg)
         exc.__cause__ = cause
         return exc
 
@@ -607,31 +605,31 @@ class _Validator(Generic[T]):
 
     def _process_name(self, value: str) -> str:
         if not value:
-            raise self._invalid_metadata("{field} is a required field")
+            raise self._invalid_metadata(f"{self.raw_name!r} is a required field")
         # Validate the name as a side-effect.
         try:
             utils.canonicalize_name(value, validate=True)
         except utils.InvalidName as exc:
             raise self._invalid_metadata(
-                f"{value!r} is invalid for {{field}}", cause=exc
+                f"{value!r} is invalid for {self.raw_name!r}", cause=exc
             ) from exc
         else:
             return value
 
     def _process_version(self, value: str) -> Version:
         if not value:
-            raise self._invalid_metadata("{field} is a required field")
+            raise self._invalid_metadata(f"{self.raw_name!r} is a required field")
         try:
             return version_module.parse(value)
         except version_module.InvalidVersion as exc:
             raise self._invalid_metadata(
-                f"{value!r} is invalid for {{field}}", cause=exc
+                f"{value!r} is invalid for {self.raw_name!r}", cause=exc
             ) from exc
 
     def _process_summary(self, value: str) -> str:
         """Check the field contains no newlines."""
         if "\n" in value:
-            raise self._invalid_metadata("{field} must be a single line")
+            raise self._invalid_metadata(f"{self.raw_name!r} must be a single line")
         return value
 
     def _process_description_content_type(self, value: str) -> str:
@@ -648,21 +646,21 @@ class _Validator(Generic[T]):
         # not parseable.
         if content_type not in content_types or content_type not in value.lower():
             raise self._invalid_metadata(
-                f"{{field}} must be one of {list(content_types)}, not {value!r}"
+                f"{self.raw_name!r} must be one of {list(content_types)}, not {value!r}"
             )
 
         charset = parameters.get("charset", "UTF-8")
         if charset != "UTF-8":
             raise self._invalid_metadata(
-                f"{{field}} can only specify the UTF-8 charset, not {charset!r}"
+                f"{self.raw_name!r} can only specify the UTF-8 charset, not {charset!r}"
             )
 
         markdown_variants = {"GFM", "CommonMark"}
         variant = parameters.get("variant", "GFM")  # Use an acceptable default.
         if content_type == "text/markdown" and variant not in markdown_variants:
             raise self._invalid_metadata(
-                f"valid Markdown variants for {{field}} are {list(markdown_variants)}, "
-                f"not {variant!r}",
+                f"valid Markdown variants for {self.raw_name!r} are "
+                f"{list(markdown_variants)}, not {variant!r}",
             )
         return value
 
@@ -689,7 +687,7 @@ class _Validator(Generic[T]):
                 normalized_names.append(utils.canonicalize_name(name, validate=True))
         except utils.InvalidName as exc:
             raise self._invalid_metadata(
-                f"{name!r} is invalid for {{field}}", cause=exc
+                f"{name!r} is invalid for {self.raw_name!r}", cause=exc
             ) from exc
         else:
             return normalized_names
@@ -699,7 +697,7 @@ class _Validator(Generic[T]):
             return specifiers.SpecifierSet(value)
         except specifiers.InvalidSpecifier as exc:
             raise self._invalid_metadata(
-                f"{value!r} is invalid for {{field}}", cause=exc
+                f"{value!r} is invalid for {self.raw_name!r}", cause=exc
             ) from exc
 
     def _process_requires_dist(
@@ -712,7 +710,7 @@ class _Validator(Generic[T]):
                 reqs.append(requirements.Requirement(req))
         except requirements.InvalidRequirement as exc:
             raise self._invalid_metadata(
-                f"{req!r} is invalid for {{field}}", cause=exc
+                f"{req!r} is invalid for {self.raw_name!r}", cause=exc
             ) from exc
         else:
             return reqs
@@ -722,7 +720,7 @@ class _Validator(Generic[T]):
             return licenses.canonicalize_license_expression(value)
         except ValueError as exc:
             raise self._invalid_metadata(
-                f"{value!r} is invalid for {{field}}", cause=exc
+                f"{value!r} is invalid for {self.raw_name!r}", cause=exc
             ) from exc
 
     def _process_license_files(self, value: list[str]) -> list[str]:
@@ -730,23 +728,24 @@ class _Validator(Generic[T]):
         for path in value:
             if ".." in path:
                 raise self._invalid_metadata(
-                    f"{path!r} is invalid for {{field}}, "
+                    f"{path!r} is invalid for {self.raw_name!r}, "
                     "parent directory indicators are not allowed"
                 )
             if "*" in path:
                 raise self._invalid_metadata(
-                    f"{path!r} is invalid for {{field}}, paths must be resolved"
+                    f"{path!r} is invalid for {self.raw_name!r}, paths must be resolved"
                 )
             if (
                 pathlib.PurePosixPath(path).is_absolute()
                 or pathlib.PureWindowsPath(path).is_absolute()
             ):
                 raise self._invalid_metadata(
-                    f"{path!r} is invalid for {{field}}, paths must be relative"
+                    f"{path!r} is invalid for {self.raw_name!r}, paths must be relative"
                 )
             if pathlib.PureWindowsPath(path).as_posix() != path:
                 raise self._invalid_metadata(
-                    f"{path!r} is invalid for {{field}}, paths must use '/' delimiter"
+                    f"{path!r} is invalid for {self.raw_name!r}, "
+                    "paths must use '/' delimiter"
                 )
             paths.append(path)
         return paths
@@ -758,17 +757,17 @@ class _Validator(Generic[T]):
             for identifier in name.split("."):
                 if not identifier.isidentifier():
                     raise self._invalid_metadata(
-                        f"{name!r} is invalid for {{field}}; "
+                        f"{name!r} is invalid for {self.raw_name!r}; "
                         f"{identifier!r} is not a valid identifier"
                     )
                 elif keyword.iskeyword(identifier):
                     raise self._invalid_metadata(
-                        f"{name!r} is invalid for {{field}}; "
+                        f"{name!r} is invalid for {self.raw_name!r}; "
                         f"{identifier!r} is a keyword"
                     )
             if semicolon and private.lstrip() != "private":
                 raise self._invalid_metadata(
-                    f"{import_name!r} is invalid for {{field}}; "
+                    f"{import_name!r} is invalid for {self.raw_name!r}; "
                     "the only valid option is 'private'"
                 )
         return value

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -498,6 +498,14 @@ class TestMetadata:
         meta = metadata.Metadata.from_raw({"version": "a.b.c"}, validate=False)
         self._invalid_with_cause(meta, "version", version.InvalidVersion)
 
+    def test_invalid_version_with_placeholder_text(self) -> None:
+        # A user value containing the literal text "{field}" must survive
+        # unchanged in the error message.
+        meta = metadata.Metadata.from_raw({"version": "{field}"}, validate=False)
+        with pytest.raises(metadata.InvalidMetadata) as exc_info:
+            meta.version  # noqa: B018
+        assert str(exc_info.value) == "'{field}' is invalid for 'version'"
+
     def test_valid_summary(self) -> None:
         summary = "Hello"
         meta = metadata.Metadata.from_raw({"summary": summary}, validate=False)


### PR DESCRIPTION
I think this reads better, and fixes weird cases with braces in metadata error messages.

:robot: _AI text below_ :robot:

`_Validator._invalid_metadata()` deferred a placeholder substitution (`str.format_map`) that ran over the *already-interpolated* error message. Two consequences:

- A user value containing braces (e.g. a version of `{`) crashed `format_map` with `KeyError`/`ValueError` instead of producing an `InvalidMetadata`.
- A user value with the literal text `{field}` was silently rewritten to the field name.

This drops the placeholder mechanism entirely and interpolates the field name directly at each call site, so user values pass through verbatim.

Split out from #1268 as an independent fix.