### PR TITLE
fix: make InvalidMetadata and CyclicDependencyGroup picklable

### DIFF
--- a/src/packaging/dependency_groups.py
+++ b/src/packaging/dependency_groups.py
@@ -54,6 +54,10 @@ class CyclicDependencyGroup(ValueError):
             f"{requested_group}: {reason}"
         )
 
+    # Support pickling; ``args`` does not match ``__init__``'s signature.
+    def __reduce__(self) -> tuple[type[CyclicDependencyGroup], tuple[str, str, str]]:
+        return (self.__class__, (self.requested_group, self.group, self.include_group))
+
 
 # in the PEP 735 spec, the tables in dependency group lists were described as
 # "Dependency Object Specifiers", but the only defined type of object was a

--- a/src/packaging/metadata.py
+++ b/src/packaging/metadata.py
@@ -52,6 +52,10 @@ class InvalidMetadata(ValueError):
         self.field = field
         super().__init__(message)
 
+    # Support pickling; ``args`` does not match ``__init__``'s signature.
+    def __reduce__(self) -> tuple[type[InvalidMetadata], tuple[str, str]]:
+        return (self.__class__, (self.field, self.args[0]))
+
 
 # The RawMetadata class attempts to make as few assumptions about the underlying
 # serialization formats as possible. The idea is that as long as a serialization

--- a/tests/test_dependency_groups.py
+++ b/tests/test_dependency_groups.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import pickle
 import re
 import unittest.mock
 from typing import TYPE_CHECKING, Any
@@ -320,6 +321,15 @@ def test_cyclic_include_self() -> None:
             "group1 includes itself"
         ),
     )
+
+
+def test_cyclic_include_pickle_roundtrip() -> None:
+    exc = CyclicDependencyGroup("group1", "group2", "group1")
+    copy = pickle.loads(pickle.dumps(exc))
+    assert copy.requested_group == exc.requested_group
+    assert copy.group == exc.group
+    assert copy.include_group == exc.include_group
+    assert str(copy) == str(exc)
 
 
 def test_cyclic_include_ring_under_root() -> None:

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import email
 import inspect
 import pathlib
+import pickle
 import textwrap
 import typing
 
@@ -279,6 +280,14 @@ class TestRawMetadata:
         assert raw["description"] == "This description intentionally left blank.\n"
         assert raw["import_names"] == ["beaglevote", "_beaglevote ; private"]
         assert raw["import_namespaces"] == ["spam", "_bacon ; private"]
+
+
+class TestInvalidMetadata:
+    def test_pickle_roundtrip(self) -> None:
+        exc = metadata.InvalidMetadata("version", "'1.0.a' is invalid")
+        copy = pickle.loads(pickle.dumps(exc))
+        assert copy.field == exc.field
+        assert str(copy) == str(exc)
 
 
 class TestExceptionGroup:


### PR DESCRIPTION
The only other exception that isn't picklable is `ParserSyntaxError`, but there's no way it could cross a multiprocessing boundary (it's internal and we reraise a different exception), so I didn't change that one.

:robot: _AI text below_ :robot:

A review of #1268 noted that `InvalidMetadata` cannot be unpickled. Its `__init__(field, message)` signature doesn't match `self.args` (which only holds the message), so the default exception reduction fails with a `TypeError`. A sweep of all exception classes in the package found one other case: `CyclicDependencyGroup` (new in 26.1), whose three-argument `__init__` has the same mismatch.

This matters when exceptions cross process boundaries, e.g. `concurrent.futures`/`multiprocessing` workers validating metadata or resolving dependency groups.

Both classes get a `__reduce__` that reconstructs from the original constructor arguments, preserving `str(e)` and all attributes. Regression tests were confirmed to fail before the fix.