### PR TITLE
fix(metadata): reject malformed Description-Content-Type values

### DIFF
--- a/src/packaging/metadata.py
+++ b/src/packaging/metadata.py
@@ -643,11 +643,18 @@ class _Validator(Generic[T]):
         # The email parser can raise IndexError on malformed RFC 2231
         # parameters such as "text/plain; x*".
         except (ValueError, IndexError) as exc:
-            raise self._invalid_metadata(invalid_msg, cause=exc) from exc
+            raise self._invalid_metadata(
+                f"{value!r} is not a valid content type for {self.raw_name!r}",
+                cause=exc,
+            ) from exc
         content_type_header = message["content-type"]
         if content_type_header.defects:
             defect = content_type_header.defects[0]
-            raise self._invalid_metadata(invalid_msg, cause=defect) from defect
+            raise self._invalid_metadata(
+                f"{value!r} is not a valid content type for "
+                f"{self.raw_name!r}: {defect}",
+                cause=defect,
+            ) from defect
 
         content_type, parameters = (
             # Defaults to `text/plain` if parsing failed.

--- a/src/packaging/metadata.py
+++ b/src/packaging/metadata.py
@@ -643,18 +643,15 @@ class _Validator(Generic[T]):
         # The email parser can raise IndexError on malformed RFC 2231
         # parameters such as "text/plain; x*".
         except (ValueError, IndexError) as exc:
-            raise self._invalid_metadata(
-                f"{value!r} is not a valid content type for {self.raw_name!r}",
-                cause=exc,
-            ) from exc
+            msg = f"{value!r} is not a valid content type for {self.raw_name!r}"
+            raise self._invalid_metadata(msg, cause=exc) from exc
         content_type_header = message["content-type"]
         if content_type_header.defects:
             defect = content_type_header.defects[0]
-            raise self._invalid_metadata(
-                f"{value!r} is not a valid content type for "
-                f"{self.raw_name!r}: {defect}",
-                cause=defect,
-            ) from defect
+            msg = (
+                f"{value!r} is not a valid content type for {self.raw_name!r}: {defect}"
+            )
+            raise self._invalid_metadata(msg, cause=defect) from defect
 
         content_type, parameters = (
             # Defaults to `text/plain` if parsing failed.

--- a/src/packaging/metadata.py
+++ b/src/packaging/metadata.py
@@ -634,20 +634,30 @@ class _Validator(Generic[T]):
 
     def _process_description_content_type(self, value: str) -> str:
         content_types = {"text/plain", "text/x-rst", "text/markdown"}
+        invalid_msg = (
+            f"{self.raw_name!r} must be one of {list(content_types)}, not {value!r}"
+        )
         message = email.message.EmailMessage()
-        message["content-type"] = value
+        try:
+            message["content-type"] = value
+        # The email parser can raise IndexError on malformed RFC 2231
+        # parameters such as "text/plain; x*".
+        except (ValueError, IndexError) as exc:
+            raise self._invalid_metadata(invalid_msg, cause=exc) from exc
+        content_type_header = message["content-type"]
+        if content_type_header.defects:
+            defect = content_type_header.defects[0]
+            raise self._invalid_metadata(invalid_msg, cause=defect) from defect
 
         content_type, parameters = (
             # Defaults to `text/plain` if parsing failed.
             message.get_content_type().lower(),
-            message["content-type"].params,
+            content_type_header.params,
         )
         # Check if content-type is valid or defaulted to `text/plain` and thus was
         # not parseable.
         if content_type not in content_types or content_type not in value.lower():
-            raise self._invalid_metadata(
-                f"{self.raw_name!r} must be one of {list(content_types)}, not {value!r}"
-            )
+            raise self._invalid_metadata(invalid_msg)
 
         charset = parameters.get("charset", "UTF-8")
         if charset != "UTF-8":

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -380,6 +380,7 @@ class TestMetadata:
         assert isinstance(exc, metadata.InvalidMetadata)
         assert exc.field == "description-content-type"
         assert repr(description_content_type) in str(exc)
+        assert "is not a valid content type" in str(exc)
 
     def test_required_fields(self) -> None:
         meta = metadata.Metadata.from_raw(_RAW_EXAMPLE)

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -354,6 +354,33 @@ class TestMetadata:
                 "Project-URL: A, B\nProject-URL: A, C", validate=True
             )
 
+    @pytest.mark.parametrize(
+        "description_content_type",
+        [
+            "text/plain\n folded",
+            'text/plain; charset="unterminated',
+            "text/plain; {b}",
+            "text/plain; a}b",
+            "text/plain; x*",
+        ],
+    )
+    def test_from_email_wraps_description_content_type_parse_errors(
+        self,
+        description_content_type: str,
+    ) -> None:
+        with pytest.raises(ExceptionGroup) as exc_info:
+            metadata.Metadata.from_email(
+                "Metadata-Version: 2.6\n"
+                "Name: packaging\n"
+                "Version: 1.0\n"
+                f"Description-Content-Type: {description_content_type}\n"
+            )
+
+        (exc,) = exc_info.value.exceptions
+        assert isinstance(exc, metadata.InvalidMetadata)
+        assert exc.field == "description-content-type"
+        assert repr(description_content_type) in str(exc)
+
     def test_required_fields(self) -> None:
         meta = metadata.Metadata.from_raw(_RAW_EXAMPLE)
 
@@ -560,11 +587,22 @@ class TestMetadata:
             "text/plain; charset=utf-8",
             "text/markdown; variant=gfm",
             "text/markdown; variant=commonmark",
+            "text/plain; {b}",
+            "text/plain; a}b",
+            "text/plain; x*",
         ],
     )
     def test_invalid_description_content_type(self, content_type: str) -> None:
         meta = metadata.Metadata.from_raw(
             {"description_content_type": content_type}, validate=False
+        )
+
+        with pytest.raises(metadata.InvalidMetadata):
+            meta.description_content_type  # noqa: B018
+
+    def test_invalid_description_content_type_without_defects(self) -> None:
+        meta = metadata.Metadata.from_raw(
+            {"description_content_type": "application/octet-stream"}, validate=False
         )
 
         with pytest.raises(metadata.InvalidMetadata):


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Malformed `Description-Content-Type` values could leak a bare `IndexError` from the email header parser (e.g. `text/plain; x*`) or be silently accepted despite header defects (e.g. duplicated parameters). Raise `InvalidMetadata` for both, with a message that names the actual problem rather than claiming the content type is not one of the allowed values.

Split out of #1268 (part of #1239); validation tightening by @r266-tech, error-message wording per review.