### PR TITLE
fix(metadata): accept UTF-8 charset case-insensitively

### DIFF
--- a/src/packaging/metadata.py
+++ b/src/packaging/metadata.py
@@ -668,7 +668,7 @@ class _Validator(Generic[T]):
             raise self._invalid_metadata(invalid_msg)
 
         charset = parameters.get("charset", "UTF-8")
-        if charset.casefold() != "utf-8":
+        if charset.lower() != "utf-8":
             raise self._invalid_metadata(
                 f"{self.raw_name!r} can only specify the UTF-8 charset, not {charset!r}"
             )

--- a/src/packaging/metadata.py
+++ b/src/packaging/metadata.py
@@ -668,7 +668,7 @@ class _Validator(Generic[T]):
             raise self._invalid_metadata(invalid_msg)
 
         charset = parameters.get("charset", "UTF-8")
-        if charset != "UTF-8":
+        if charset.casefold() != "utf-8":
             raise self._invalid_metadata(
                 f"{self.raw_name!r} can only specify the UTF-8 charset, not {charset!r}"
             )

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -357,6 +357,16 @@ class TestMetadata:
             # Lacking all required fields.
             metadata.Metadata.from_email("Name: packaging", validate=True)
 
+    def test_from_email_description_content_type_lowercase_charset(self) -> None:
+        meta = metadata.Metadata.from_email(
+            "Metadata-Version: 2.6\n"
+            "Name: packaging\n"
+            "Version: 1.0\n"
+            "Description-Content-Type: text/plain; charset=utf-8\n"
+        )
+
+        assert meta.description_content_type == "text/plain; charset=utf-8"
+
     def test_from_email_unparsed_valid_field_name(self) -> None:
         with pytest.raises(ExceptionGroup):
             metadata.Metadata.from_email(
@@ -575,6 +585,8 @@ class TestMetadata:
             "text/x-rst",
             "text/markdown",
             "text/plain; charset=UTF-8",
+            "text/plain; charset=utf-8",
+            "text/plain; charset=Utf-8",
             "text/x-rst; charset=UTF-8",
             "text/markdown; charset=UTF-8; variant=GFM",
             "text/markdown; charset=UTF-8; variant=CommonMark",
@@ -594,7 +606,6 @@ class TestMetadata:
         [
             "application/json",
             "text/plain; charset=ascii",
-            "text/plain; charset=utf-8",
             "text/markdown; variant=gfm",
             "text/markdown; variant=commonmark",
             "text/plain; {b}",


### PR DESCRIPTION
## Summary
- accept `Description-Content-Type` charset values case-insensitively when they resolve to UTF-8
- move lowercase/mixed-case UTF-8 examples into the valid validator cases
- add a `Metadata.from_email()` regression for `charset=utf-8`

## Tests
- `PYTHONPATH=src python3 -m pytest tests/test_metadata.py -q`
- `python3 -m compileall -q src/packaging/metadata.py tests/test_metadata.py`
- `git diff --check`
- `uvx nox -s lint -- --show-diff-on-failure`
