### PR TITLE
docs: add direct URL helper version markers

### DIFF
--- a/src/packaging/direct_url.py
+++ b/src/packaging/direct_url.py
@@ -154,7 +154,10 @@ class _DirectUrlRequiredKeyError(DirectUrlValidationError):
 
 @dataclasses.dataclass(frozen=True, init=False)
 class VcsInfo:
-    """The version control information of a :class:`DirectUrl`."""
+    """The version control information of a :class:`DirectUrl`.
+
+    .. versionadded:: 26.1
+    """
 
     vcs: str
     commit_id: str
@@ -183,7 +186,10 @@ class VcsInfo:
 
 @dataclasses.dataclass(frozen=True, init=False)
 class ArchiveInfo:
-    """The archive information of a :class:`DirectUrl`."""
+    """The archive information of a :class:`DirectUrl`.
+
+    .. versionadded:: 26.1
+    """
 
     hashes: Mapping[str, str] | None = None
 
@@ -231,7 +237,10 @@ class ArchiveInfo:
 
 @dataclasses.dataclass(frozen=True, init=False)
 class DirInfo:
-    """The local directory information of a :class:`DirectUrl`."""
+    """The local directory information of a :class:`DirectUrl`.
+
+    .. versionadded:: 26.1
+    """
 
     editable: bool | None = None
 


### PR DESCRIPTION
## Summary

- add `.. versionadded:: 26.1` to the public `VcsInfo`, `ArchiveInfo`, and `DirInfo` docstrings
- make the generated API reference show when those direct URL helpers were introduced

`packaging.direct_url` was added in 26.1, but these helper docstrings were added after the module's first version-marker pass. This fills that narrow documentation gap and keeps the helpers consistent with `DirectUrl` and `DirectUrlValidationError`.

Refs #597.

## Testing

- `python -m nox -s docs` (HTML, LaTeX, and 392 doctests; warnings treated as errors)
- `python -m nox -s tests-3.13 --download-python never` (62,113 passed, 1 platform skip, 417 deselected; 100% coverage)
- `ruff check .`
- `ruff format --check .`
- `mypy --platform linux --python-version 3.10 src tests tasks noxfile.py` (65 source files)
- `python -m build`
- `twine check dist/*`
- `git diff --check`

## Limitations

The aggregate `nox -s lint` session could not get past `prek` environment bootstrap on this Windows host because its installer hit a TLS EOF while fetching `setuptools`. The corresponding whitespace, Ruff, mypy, build, and Twine checks were run directly and passed. The only test skip requires glibc-based Linux; this change does not alter runtime behavior.

## AI disclosure

This draft was prepared by an OpenAI Codex autonomous agent. The agent selected the issue, reviewed repository history and contribution policy, made the documentation-only change, ran the checks above, and drafted this PR text. No human manually reviewed the patch before opening this draft; a separate Codex agent performed an independent review and reported no findings.
