### PR TITLE
fix(requirements): raise InvalidRequirement for malformed specifier lists

### DIFF
--- a/src/packaging/requirements.py
+++ b/src/packaging/requirements.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 from ._parser import parse_requirement as _parse_requirement
 from ._tokenizer import ParserSyntaxError
 from .markers import Marker, _normalize_extra_values
-from .specifiers import SpecifierSet
+from .specifiers import InvalidSpecifier, SpecifierSet
 from .utils import canonicalize_name
 
 if TYPE_CHECKING:
@@ -82,7 +82,10 @@ class Requirement:
         self.name: str = parsed.name
         self.url: str | None = parsed.url or None
         self.extras: set[str] = set(parsed.extras)
-        self.specifier: SpecifierSet = SpecifierSet(parsed.specifier)
+        try:
+            self.specifier: SpecifierSet = SpecifierSet(parsed.specifier)
+        except InvalidSpecifier as e:
+            raise InvalidRequirement(str(e)) from e
         self.marker: Marker | None = None
         if parsed.marker is not None:
             self.marker = Marker.__new__(Marker)

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -245,6 +245,14 @@ class TestRequirementParsing:
     # Start all method names with with `test_error_`
     # to make it easier to run these tests with `-k error`
 
+    def test_error_when_specifier_set_rejects_parsed_specifier(self) -> None:
+        # GIVEN
+        to_parse = "demo===x,y"
+
+        # WHEN
+        with pytest.raises(InvalidRequirement, match="Invalid specifier: 'y'"):
+            Requirement(to_parse)
+
     def test_error_when_empty_string(self) -> None:
         # GIVEN
         to_parse = ""
@@ -839,11 +847,17 @@ def test_pickle_requirement_setstate_rejects_invalid_state() -> None:
         r.__setstate__((1, 2, 3))
 
 
-def test_pickle_requirement_setstate_rejects_invalid_string() -> None:
+@pytest.mark.parametrize(
+    "invalid_requirement",
+    ["this is not a valid requirement", "demo===x,y"],
+)
+def test_pickle_requirement_setstate_rejects_invalid_string(
+    invalid_requirement: str,
+) -> None:
     # Cover the string branch where Requirement() raises InvalidRequirement.
     r = Requirement.__new__(Requirement)
     with pytest.raises(TypeError, match="Cannot restore Requirement"):
-        r.__setstate__("this is not a valid requirement")
+        r.__setstate__(invalid_requirement)
 
 
 # Pickle bytes generated with packaging==26.1, Python 3.13.1, pickle protocol 2.


### PR DESCRIPTION
## Summary

- translate `SpecifierSet` validation failures into `InvalidRequirement`, matching `Requirement`'s documented exception contract
- cover both direct construction and stable-pickle restoration with the malformed `demo===x,y` form

## Why

The requirement parser accepts the arbitrary-equality token and comma, but the later `SpecifierSet` construction rejects the bare `y`. That currently leaks `InvalidSpecifier` from `Requirement(...)`, so callers cannot consistently handle malformed requirement strings via `InvalidRequirement`; the same leak also bypasses `Requirement.__setstate__`'s invalid-string conversion.

## Validation

- `uv run pytest -q` — 62,115 passed, 1 platform skip
- `uv run pytest tests/test_requirements.py -q` — 5,322 passed
- `uv run ruff check src/packaging/requirements.py tests/test_requirements.py`
- `uv run ruff format --check src/packaging/requirements.py tests/test_requirements.py`
