### PR TITLE
feat(pylock): allow select() to prefer source distributions

### DIFF
--- a/src/packaging/pylock.py
+++ b/src/packaging/pylock.py
@@ -771,10 +771,10 @@ class Pylock:
         The *dependency_groups* parameter represents the groups to install. If
         unspecified, the default groups are used.
 
-        The *prefer_sdist_predicate* parameter can be used to select a source
-        distribution before attempting wheel compatibility for selected package
-        names. If no source distribution is available, wheel selection proceeds as
-        usual without calling the predicate.
+        The *prefer_sdist_predicate* parameter is called for packages with a source
+        distribution. If it returns ``True``, the source distribution is selected
+        before attempting wheel compatibility. If no source distribution is
+        available, wheel selection proceeds as usual without calling the predicate.
 
         This method must be used on valid Pylock instances (i.e. one obtained
         from :meth:`Pylock.from_dict` or if constructed manually, after calling
@@ -896,8 +896,7 @@ class Pylock:
             # - Else if source preference selects an available
             #   :ref:`pylock-packages-sdist`:
             elif (
-                package.wheels
-                and package.sdist is not None
+                package.sdist is not None
                 and prefer_sdist_predicate is not None
                 and prefer_sdist_predicate(package.name)
             ):

--- a/src/packaging/pylock.py
+++ b/src/packaging/pylock.py
@@ -749,6 +749,7 @@ class Pylock:
         tags: Sequence[Tag] | None = None,
         extras: Collection[str] | None = None,
         dependency_groups: Collection[str] | None = None,
+        prefer_sdist_predicate: Callable[[NormalizedName], bool] | None = None,
     ) -> Iterator[
         tuple[
             Package,
@@ -770,11 +771,19 @@ class Pylock:
         The *dependency_groups* parameter represents the groups to install. If
         unspecified, the default groups are used.
 
+        The *prefer_sdist_predicate* parameter can be used to prefer a source
+        distribution over a compatible wheel for selected package names. If the
+        predicate returns ``True`` but no source distribution is available, wheel
+        selection proceeds as usual.
+
         This method must be used on valid Pylock instances (i.e. one obtained
         from :meth:`Pylock.from_dict` or if constructed manually, after calling
         :meth:`Pylock.validate`).
 
         .. versionadded:: 26.1
+
+        .. versionchanged:: 26.3
+            Added the *prefer_sdist_predicate* parameter.
         """
         compatible_tags_selector = create_compatible_tags_selector(tags or sys_tags())
 
@@ -883,6 +892,16 @@ class Pylock:
             # - Else if :ref:`pylock-packages-archive` is set:
             elif package.archive is not None:
                 yield package, package.archive
+
+            # - Else if source preference selects an available
+            #   :ref:`pylock-packages-sdist`:
+            elif (
+                package.wheels
+                and prefer_sdist_predicate is not None
+                and prefer_sdist_predicate(package.name)
+                and package.sdist is not None
+            ):
+                yield package, package.sdist
 
             # - Else if there are entries for :ref:`pylock-packages-wheels`:
             elif package.wheels:

--- a/src/packaging/pylock.py
+++ b/src/packaging/pylock.py
@@ -771,10 +771,10 @@ class Pylock:
         The *dependency_groups* parameter represents the groups to install. If
         unspecified, the default groups are used.
 
-        The *prefer_sdist_predicate* parameter can be used to prefer a source
-        distribution over a compatible wheel for selected package names. If the
-        predicate returns ``True`` but no source distribution is available, wheel
-        selection proceeds as usual.
+        The *prefer_sdist_predicate* parameter can be used to select a source
+        distribution before attempting wheel compatibility for selected package
+        names. If no source distribution is available, wheel selection proceeds as
+        usual without calling the predicate.
 
         This method must be used on valid Pylock instances (i.e. one obtained
         from :meth:`Pylock.from_dict` or if constructed manually, after calling
@@ -897,9 +897,9 @@ class Pylock:
             #   :ref:`pylock-packages-sdist`:
             elif (
                 package.wheels
+                and package.sdist is not None
                 and prefer_sdist_predicate is not None
                 and prefer_sdist_predicate(package.name)
-                and package.sdist is not None
             ):
                 yield package, package.sdist
 

--- a/tests/test_pylock_select.py
+++ b/tests/test_pylock_select.py
@@ -308,7 +308,7 @@ def test_missing_sdist_fallback() -> None:
 
 
 def _pylock_with_wheel(
-    *, wheel_python_tag: str = "py3", include_sdist: bool = True
+    *, wheel_python_tag: str | None = "py3", include_sdist: bool = True
 ) -> Pylock:
     pylock = Pylock(
         lock_version=Version("1.0"),
@@ -324,12 +324,16 @@ def _pylock_with_wheel(
                     if include_sdist
                     else None
                 ),
-                wheels=[
-                    PackageWheel(
-                        path=f"./foo-1.0-{wheel_python_tag}-none-any.whl",
-                        hashes={"sha256": "abc123"},
-                    )
-                ],
+                wheels=(
+                    [
+                        PackageWheel(
+                            path=f"./foo-1.0-{wheel_python_tag}-none-any.whl",
+                            hashes={"sha256": "abc123"},
+                        )
+                    ]
+                    if wheel_python_tag is not None
+                    else []
+                ),
             ),
         ],
     )
@@ -344,16 +348,18 @@ def _pylock_with_wheel(
         ("py3", True, True, PackageSdist, True),
         ("py5", True, True, PackageSdist, True),
         ("py3", False, True, PackageWheel, False),
+        (None, True, False, PackageSdist, True),
     ],
     ids=[
         "compatible-wheel-predicate-false",
         "sdist-predicate-true",
         "sdist-predicate-true-incompatible-wheel",
         "compatible-wheel-no-sdist",
+        "sdist-only-predicate-false",
     ],
 )
 def test_prefer_sdist_predicate(
-    wheel_python_tag: str,
+    wheel_python_tag: str | None,
     include_sdist: bool,
     prefer_sdist: bool,
     expected_type: type[object],

--- a/tests/test_pylock_select.py
+++ b/tests/test_pylock_select.py
@@ -307,7 +307,7 @@ def test_missing_sdist_fallback() -> None:
         list(pylock.select())
 
 
-def _pylock_with_wheel(
+def _pylock_with_wheel_and_sdist(
     *, wheel_python_tag: str | None = "py3", include_sdist: bool = True
 ) -> Pylock:
     pylock = Pylock(
@@ -372,7 +372,7 @@ def test_prefer_sdist_predicate(
         return prefer_sdist
 
     selected = list(
-        _pylock_with_wheel(
+        _pylock_with_wheel_and_sdist(
             wheel_python_tag=wheel_python_tag,
             include_sdist=include_sdist,
         ).select(

--- a/tests/test_pylock_select.py
+++ b/tests/test_pylock_select.py
@@ -258,6 +258,55 @@ def test_yield_all_types() -> None:
     assert len(selected) == 5
 
 
+def test_sdist_fallback() -> None:
+    pylock = Pylock(
+        lock_version=Version("1.0"),
+        created_by="some_tool",
+        packages=[
+            Package(
+                name=cast("NormalizedName", "foo"),
+                sdist=PackageSdist(
+                    path="foo-1.0.tar.gz",
+                    hashes={"sha256": "abc123"},
+                ),
+                wheels=[
+                    PackageWheel(
+                        path="./foo-1.0-py5-none-any.whl",
+                        hashes={"sha256": "abc123"},
+                    )
+                ],
+            ),
+        ],
+    )
+    selected = list(pylock.select())
+    assert len(selected) == 1
+    assert isinstance(selected[0][1], PackageSdist)
+
+
+def test_missing_sdist_fallback() -> None:
+    pylock = Pylock(
+        lock_version=Version("1.0"),
+        created_by="some_tool",
+        packages=[
+            Package(
+                name=cast("NormalizedName", "foo"),
+                wheels=[
+                    PackageWheel(
+                        name="foo-1.0-py5-none-any.whl",
+                        path="./foo-1.0-py5-none-any.whl",
+                        hashes={"sha256": "abc123"},
+                    )
+                ],
+            ),
+        ],
+    )
+    pylock.validate()
+    with pytest.raises(
+        PylockSelectError, match=r"No wheel found matching .* and no sdist available"
+    ):
+        list(pylock.select())
+
+
 def _pylock_with_wheel(
     *, wheel_python_tag: str = "py3", include_sdist: bool = True
 ) -> Pylock:
@@ -289,65 +338,47 @@ def _pylock_with_wheel(
 
 
 @pytest.mark.parametrize(
-    (
-        "wheel_python_tag",
-        "include_sdist",
-        "prefer_sdist",
-        "expected_type",
-    ),
+    ("wheel_python_tag", "include_sdist", "prefer_sdist", "expected_type", "called"),
     [
-        ("py5", True, None, PackageSdist),
-        ("py3", True, None, PackageWheel),
-        ("py3", True, False, PackageWheel),
-        ("py3", True, True, PackageSdist),
-        ("py3", False, True, PackageWheel),
-        ("py5", False, None, PylockSelectError),
-        ("py5", False, True, PylockSelectError),
+        ("py3", True, False, PackageWheel, True),
+        ("py3", True, True, PackageSdist, True),
+        ("py5", True, True, PackageSdist, True),
+        ("py3", False, True, PackageWheel, False),
     ],
     ids=[
-        "incompatible-wheel-sdist-fallback",
-        "compatible-wheel-default",
         "compatible-wheel-predicate-false",
         "sdist-predicate-true",
+        "sdist-predicate-true-incompatible-wheel",
         "compatible-wheel-no-sdist",
-        "no-compatible-source-default",
-        "no-compatible-source-predicate-true",
     ],
 )
-def test_wheel_sdist_selection(
+def test_prefer_sdist_predicate(
     wheel_python_tag: str,
     include_sdist: bool,
-    prefer_sdist: bool | None,
+    prefer_sdist: bool,
     expected_type: type[object],
+    called: bool,
 ) -> None:
     names: list[NormalizedName] = []
 
     def predicate(name: NormalizedName) -> bool:
         names.append(name)
-        assert prefer_sdist is not None
         return prefer_sdist
 
-    selection = _pylock_with_wheel(
-        wheel_python_tag=wheel_python_tag,
-        include_sdist=include_sdist,
-    ).select(
-        tags=_py312_linux.tags,
-        environment=_py312_linux.environment,
-        prefer_sdist_predicate=predicate if prefer_sdist is not None else None,
+    selected = list(
+        _pylock_with_wheel(
+            wheel_python_tag=wheel_python_tag,
+            include_sdist=include_sdist,
+        ).select(
+            tags=_py312_linux.tags,
+            environment=_py312_linux.environment,
+            prefer_sdist_predicate=predicate,
+        )
     )
 
-    if expected_type is PylockSelectError:
-        with pytest.raises(
-            PylockSelectError,
-            match=r"No wheel found matching .* and no sdist available",
-        ):
-            list(selection)
-    else:
-        selected = list(selection)
-        assert len(selected) == 1
-        assert isinstance(selected[0][1], expected_type)
-
-    assert names == (["foo"] if prefer_sdist is not None else [])
+    assert len(selected) == 1
+    assert isinstance(selected[0][1], expected_type)
+    assert names == (["foo"] if called else [])
 
 
 @pytest.mark.parametrize(

--- a/tests/test_pylock_select.py
+++ b/tests/test_pylock_select.py
@@ -258,42 +258,26 @@ def test_yield_all_types() -> None:
     assert len(selected) == 5
 
 
-def test_sdist_fallback() -> None:
+def _pylock_with_wheel(
+    *, wheel_python_tag: str = "py3", include_sdist: bool = True
+) -> Pylock:
     pylock = Pylock(
         lock_version=Version("1.0"),
         created_by="some_tool",
         packages=[
             Package(
                 name=cast("NormalizedName", "foo"),
-                sdist=PackageSdist(
-                    path="foo-1.0.tar.gz",
-                    hashes={"sha256": "abc123"},
+                sdist=(
+                    PackageSdist(
+                        path="foo-1.0.tar.gz",
+                        hashes={"sha256": "abc123"},
+                    )
+                    if include_sdist
+                    else None
                 ),
                 wheels=[
                     PackageWheel(
-                        path="./foo-1.0-py5-none-any.whl",
-                        hashes={"sha256": "abc123"},
-                    )
-                ],
-            ),
-        ],
-    )
-    selected = list(pylock.select())
-    assert len(selected) == 1
-    assert isinstance(selected[0][1], PackageSdist)
-
-
-def test_missing_sdist_fallback() -> None:
-    pylock = Pylock(
-        lock_version=Version("1.0"),
-        created_by="some_tool",
-        packages=[
-            Package(
-                name=cast("NormalizedName", "foo"),
-                wheels=[
-                    PackageWheel(
-                        name="foo-1.0-py5-none-any.whl",
-                        path="./foo-1.0-py5-none-any.whl",
+                        path=f"./foo-1.0-{wheel_python_tag}-none-any.whl",
                         hashes={"sha256": "abc123"},
                     )
                 ],
@@ -301,10 +285,69 @@ def test_missing_sdist_fallback() -> None:
         ],
     )
     pylock.validate()
-    with pytest.raises(
-        PylockSelectError, match=r"No wheel found matching .* and no sdist available"
-    ):
-        list(pylock.select())
+    return pylock
+
+
+@pytest.mark.parametrize(
+    (
+        "wheel_python_tag",
+        "include_sdist",
+        "prefer_sdist",
+        "expected_type",
+    ),
+    [
+        ("py5", True, None, PackageSdist),
+        ("py3", True, None, PackageWheel),
+        ("py3", True, False, PackageWheel),
+        ("py3", True, True, PackageSdist),
+        ("py3", False, True, PackageWheel),
+        ("py5", False, None, PylockSelectError),
+        ("py5", False, True, PylockSelectError),
+    ],
+    ids=[
+        "incompatible-wheel-sdist-fallback",
+        "compatible-wheel-default",
+        "compatible-wheel-predicate-false",
+        "sdist-predicate-true",
+        "compatible-wheel-no-sdist",
+        "no-compatible-source-default",
+        "no-compatible-source-predicate-true",
+    ],
+)
+def test_wheel_sdist_selection(
+    wheel_python_tag: str,
+    include_sdist: bool,
+    prefer_sdist: bool | None,
+    expected_type: type[object],
+) -> None:
+    names: list[NormalizedName] = []
+
+    def predicate(name: NormalizedName) -> bool:
+        names.append(name)
+        assert prefer_sdist is not None
+        return prefer_sdist
+
+    selection = _pylock_with_wheel(
+        wheel_python_tag=wheel_python_tag,
+        include_sdist=include_sdist,
+    ).select(
+        tags=_py312_linux.tags,
+        environment=_py312_linux.environment,
+        prefer_sdist_predicate=predicate if prefer_sdist is not None else None,
+    )
+
+    if expected_type is PylockSelectError:
+        with pytest.raises(
+            PylockSelectError,
+            match=r"No wheel found matching .* and no sdist available",
+        ):
+            list(selection)
+    else:
+        selected = list(selection)
+        assert len(selected) == 1
+        assert isinstance(selected[0][1], expected_type)
+
+    assert names == (["foo"] if prefer_sdist is not None else [])
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Add the maintainer-proposed `prefer_sdist_predicate` argument to `Pylock.select()` so installers can apply per-package source-build policy.

- Select an available sdist before compatible wheels when the predicate returns `True`.
- Preserve compatible-wheel selection, sdist fallback, and the existing error when no usable source exists.
- Document the 26.3 API addition and cover the full wheel/sdist selection matrix.

Closes #1333.

## Verification

- `python -m pytest -q` (`62118 passed, 1 skipped, 417 deselected`)
- `python -m pytest tests/test_pylock_select.py -q` (`25 passed`)
- `ruff check src/packaging/pylock.py tests/test_pylock_select.py`
- `ruff format --check src/packaging/pylock.py tests/test_pylock_select.py`
- `uvx nox -s docs` (`392 doctests passed`; HTML and LaTeX builds clean)
- Targeted strict mypy check for both changed files
