### PR TITLE
fix(specifiers): normalize iterable string inputs

### DIFF
--- a/src/packaging/specifiers.py
+++ b/src/packaging/specifiers.py
@@ -785,7 +785,7 @@ class SpecifierSet(BaseSpecifier):
 
     def __init__(
         self,
-        specifiers: str | Iterable[Specifier] = "",
+        specifiers: str | Iterable[str | Specifier] = "",
         prereleases: bool | None = None,
     ) -> None:
         """Initialize a SpecifierSet instance.
@@ -793,8 +793,9 @@ class SpecifierSet(BaseSpecifier):
         :param specifiers:
             The string representation of a specifier or a comma-separated list of
             specifiers which will be parsed and normalized before use.
-            May also be an iterable of ``Specifier`` instances, which will be used
-            as is.
+            May also be an iterable of individual specifier strings or ``Specifier``
+            instances. Strings will be parsed and normalized, while ``Specifier``
+            instances will be used as is.
         :param prereleases:
             This tells the SpecifierSet if it should accept prerelease versions if
             applicable or not. The default of ``None`` will autodetect it from the
@@ -814,9 +815,12 @@ class SpecifierSet(BaseSpecifier):
             # Fast substring check; avoids iterating parsed specs.
             self._has_arbitrary = "===" in specifiers
         else:
-            self._specs = tuple(specifiers)
+            self._specs = tuple(
+                Specifier(specifier) if isinstance(specifier, str) else specifier
+                for specifier in specifiers
+            )
             # Substring check works for both Specifier objects and plain
-            # strings (setuptools passes lists of strings).
+            # strings (including legacy pickle state).
             self._has_arbitrary = any("===" in str(s) for s in self._specs)
 
         self._canonicalized = len(self._specs) <= 1
@@ -870,34 +874,40 @@ class SpecifierSet(BaseSpecifier):
         self._ranges = None
         self._is_unsatisfiable = None
 
+        def normalize_specs(value: object) -> tuple[Specifier, ...] | None:
+            if isinstance(value, frozenset):
+                value = tuple(sorted(value, key=str))
+            if not isinstance(value, tuple) or not all(
+                isinstance(specifier, (str, Specifier)) for specifier in value
+            ):
+                return None
+            try:
+                return tuple(
+                    Specifier(specifier) if isinstance(specifier, str) else specifier
+                    for specifier in value
+                )
+            except InvalidSpecifier:
+                return None
+
         if isinstance(state, tuple):
             if len(state) == 2:
                 # New format (26.2+): (specs, prereleases)
                 specs, prereleases = state
-                if (
-                    isinstance(specs, tuple)
-                    and all(isinstance(s, Specifier) for s in specs)
-                    and _validate_pre(prereleases)
-                ):
-                    self._specs = specs
+                normalized_specs = normalize_specs(specs)
+                if normalized_specs is not None and _validate_pre(prereleases):
+                    self._specs = normalized_specs
                     self._prereleases = prereleases
-                    self._canonicalized = len(specs) <= 1
-                    self._has_arbitrary = any("===" in str(s) for s in specs)
+                    self._canonicalized = len(normalized_specs) <= 1
+                    self._has_arbitrary = any("===" in str(s) for s in normalized_specs)
                     return
             if len(state) == 2 and isinstance(state[1], dict):
                 # Format (packaging 26.0-26.1): (None, {slot: value}).
                 _, slot_dict = state
                 specs = slot_dict.get("_specs", ())
                 prereleases = slot_dict.get("_prereleases")
-                # Convert frozenset to tuple (26.0 stored as frozenset)
-                if isinstance(specs, frozenset):
-                    specs = tuple(sorted(specs, key=str))
-                if (
-                    isinstance(specs, tuple)
-                    and all(isinstance(s, Specifier) for s in specs)
-                    and _validate_pre(prereleases)
-                ):
-                    self._specs = specs
+                normalized_specs = normalize_specs(specs)
+                if normalized_specs is not None and _validate_pre(prereleases):
+                    self._specs = normalized_specs
                     self._prereleases = prereleases
                     self._canonicalized = len(self._specs) <= 1
                     self._has_arbitrary = any("===" in str(s) for s in self._specs)
@@ -906,15 +916,9 @@ class SpecifierSet(BaseSpecifier):
             # Old format (packaging <= 25.x, no __slots__): state is a plain dict.
             specs = state.get("_specs", ())
             prereleases = state.get("_prereleases")
-            # Convert frozenset to tuple (26.0 stored as frozenset)
-            if isinstance(specs, frozenset):
-                specs = tuple(sorted(specs, key=str))
-            if (
-                isinstance(specs, tuple)
-                and all(isinstance(s, Specifier) for s in specs)
-                and _validate_pre(prereleases)
-            ):
-                self._specs = specs
+            normalized_specs = normalize_specs(specs)
+            if normalized_specs is not None and _validate_pre(prereleases):
+                self._specs = normalized_specs
                 self._prereleases = prereleases
                 self._canonicalized = len(self._specs) <= 1
                 self._has_arbitrary = any("===" in str(s) for s in self._specs)

--- a/tests/test_specifiers.py
+++ b/tests/test_specifiers.py
@@ -1320,6 +1320,19 @@ class TestSpecifierSet:
         spec = SpecifierSet(iter(specs))
         assert set(spec) == set(specs)
 
+    def test_create_from_specifier_strings(self) -> None:
+        spec_strs = [">=1.0", "!=1.1", "<2.0"]
+        spec = SpecifierSet(iter(spec_strs))
+        expected = SpecifierSet(",".join(spec_strs))
+
+        assert all(isinstance(item, Specifier) for item in spec)
+        assert spec == expected
+        assert spec.prereleases == expected.prereleases
+        assert spec.contains("1.5") == expected.contains("1.5")
+        assert spec.is_unsatisfiable() == expected.is_unsatisfiable()
+        assert spec.to_range() == expected.to_range()
+        assert pickle.loads(pickle.dumps(spec)) == expected
+
     def test_match_args(self) -> None:
         assert SpecifierSet.__match_args__ == ("_str",)
         assert SpecifierSet(">=1.0,<2")._str == str(SpecifierSet(">=1.0,<2"))
@@ -3120,6 +3133,25 @@ def test_pickle_specifierset_setstate_rejects_malformed_legacy_state() -> None:
     # _specs contains non-Specifier items (legacy dict format).
     with pytest.raises(TypeError, match="Cannot restore SpecifierSet"):
         ss.__setstate__({"_specs": {1, 2}, "_prereleases": None})
+
+
+@pytest.mark.parametrize(
+    "state",
+    [
+        ((">=1.0", "<2.0"), None),
+        (None, {"_specs": frozenset({">=1.0", "<2.0"}), "_prereleases": None}),
+        {"_specs": frozenset({">=1.0", "<2.0"}), "_prereleases": None},
+    ],
+)
+def test_pickle_specifierset_normalizes_iterable_string_state(state: object) -> None:
+    ss = SpecifierSet.__new__(SpecifierSet)
+    ss.__setstate__(state)
+
+    assert all(isinstance(item, Specifier) for item in ss)
+    assert ss == SpecifierSet(">=1.0,<2.0")
+    assert ss.contains("1.5")
+    assert not ss.is_unsatisfiable()
+    assert ss.to_range() == SpecifierSet(">=1.0,<2.0").to_range()
 
 
 def test_pickle_specifierset_setstate_on_initialized_instance() -> None:

--- a/tests/test_specifiers.py
+++ b/tests/test_specifiers.py
@@ -3127,6 +3127,9 @@ def test_pickle_specifier_setstate_rejects_malformed_legacy_state() -> None:
 def test_pickle_specifierset_setstate_rejects_malformed_legacy_state() -> None:
     # Verify validation catches malformed legacy slot-dict and dict formats.
     ss = SpecifierSet.__new__(SpecifierSet)
+    # _specs contains an invalid specifier string (new tuple format).
+    with pytest.raises(TypeError, match="Cannot restore SpecifierSet"):
+        ss.__setstate__((("not a specifier",), None))
     # _specs contains non-Specifier items (legacy slot-dict format).
     with pytest.raises(TypeError, match="Cannot restore SpecifierSet"):
         ss.__setstate__((None, {"_specs": {1, 2}, "_prereleases": None}))


### PR DESCRIPTION
## Summary

Normalize string elements passed through `SpecifierSet`'s iterable constructor path so its internal `_specs` invariant matches the semantic methods that consume it.

- Parse iterable strings into `Specifier` objects while preserving existing `Specifier` instances.
- Apply the same normalization when restoring supported pickle state, including objects created from iterable strings on older releases.
- Cover equality, prerelease detection, containment, satisfiability, range conversion, and pickle compatibility.

This addresses the compatibility case already called out in the constructor (`setuptools` passes lists of strings) and the adjacent crash reproduced during review of #1270, without changing PEP 440 comparison semantics.

## Verification

- `uv run pytest tests/test_specifiers.py -q` (`1998 passed`)
- `uv run ruff check src/packaging/specifiers.py tests/test_specifiers.py`
- `uv run ruff format --check src/packaging/specifiers.py tests/test_specifiers.py`
- `git diff --check`
