### PR TITLE
Reject commas in arbitrary-equality (===) version strings

### DIFF
--- a/src/packaging/specifiers.py
+++ b/src/packaging/specifiers.py
@@ -254,10 +254,11 @@ class Specifier(BaseSpecifier):
                 # but included entirely as an escape hatch.
                 ===  # Only match for the identity operator
                 \s*
-                [^\s;)]*  # The arbitrary version can be just about anything,
-                          # we match everything except for whitespace, a
-                          # semi-colon for marker support, and a closing paren
-                          # since versions can be enclosed in them.
+                [^\s;,)]*  # The arbitrary version can be just about anything,
+                           # we match everything except for whitespace, a
+                           # semi-colon for marker support, a closing paren,
+                           # and a comma (used by SpecifierSet as a separator)
+                           # since versions can be enclosed in them.
             )
             |
             (?:

--- a/tests/test_issue_1000.py
+++ b/tests/test_issue_1000.py
@@ -1,0 +1,29 @@
+"""Regression test for issue 1000: arbitrary equality parsing."""
+
+import pytest
+
+from packaging.specifiers import InvalidSpecifier, Specifier, SpecifierSet
+
+
+def test_issue_1000():
+    # Commas should not be part of an === version string.
+    with pytest.raises(InvalidSpecifier):
+        Specifier("===hello,")
+    with pytest.raises(InvalidSpecifier):
+        Specifier("===moo,<=0.1")
+    # A comma between specifiers is a separator for SpecifierSet.
+    s = SpecifierSet("===hello,<=0.1")
+    assert len(s) == 2
+    # We don't depend on order; just check that both are present.
+    spec_strs = {str(spec) for spec in s}
+    assert spec_strs == {"===hello", "<=0.1"}
+    # Constructing from a list of Specifier objects should match.
+    s2 = SpecifierSet([Specifier("===hello"), Specifier("<=0.1")])
+    assert s == s2
+    # A lone === without a comma must still work.
+    lone = Specifier("===hello")
+    assert lone.operator == "==="
+    assert lone.version == "hello"
+    # === with a version string that has no comma is fine.
+    fine = Specifier("===<=0.1")
+    assert fine.version == "<=0.1"


### PR DESCRIPTION
An arbitrary-equality (`===`) version accepts commas, but `SpecifierSet` treats a comma as the separator between specifiers, so the two disagree:

- `SpecifierSet("===hello,")` and `SpecifierSet([Specifier("===hello,")])` produce different results.
- `Specifier("===moo,<=0.1")` silently swallows the second specifier.

This excludes commas from the arbitrary-equality character class in the specifier regex, so `Specifier` and `SpecifierSet` agree and a comma consistently separates specifiers.

Added `tests/test_issue_1000.py`, which fails on the current tree and passes with the change; `tests/test_specifiers.py` still passes in full.

Closes #1000
