### PR TITLE
docs(metadata): explain selective field validation

### DIFF
--- a/docs/metadata.rst
+++ b/docs/metadata.rst
@@ -38,9 +38,9 @@ Selective validation
 
 :meth:`Metadata.from_raw` and :meth:`Metadata.from_email` validate every field
 by default. If an application only relies on selected fields, it can disable
-that eager pass and access the required attributes explicitly. This is useful
-for otherwise usable legacy metadata containing a field that is invalid under
-newer metadata rules.
+that eager pass and access the attributes it needs explicitly. This is useful
+for otherwise usable legacy metadata containing a field introduced in a later
+metadata version than the one declared.
 
 .. doctest::
 

--- a/docs/metadata.rst
+++ b/docs/metadata.rst
@@ -33,42 +33,6 @@ Usage
     <Version('24.0')>
 
 
-Selective validation
-''''''''''''''''''''
-
-:meth:`Metadata.from_raw` and :meth:`Metadata.from_email` validate every field
-by default. If an application only relies on selected fields, it can disable
-that eager pass and access the attributes it needs explicitly. This is useful
-for otherwise usable legacy metadata containing a field introduced in a later
-metadata version than the one declared.
-
-.. doctest::
-
-    >>> legacy = (
-    ...     "Metadata-Version: 2.1\nName: example\n"
-    ...     "Version: 1.0\nLicense-File: LICENSE"
-    ... )
-    >>> raw, unparsed = parse_email(legacy)
-    >>> unparsed
-    {}
-    >>> metadata = Metadata.from_raw(raw, validate=False)
-    >>> metadata.metadata_version
-    '2.1'
-    >>> metadata.name
-    'example'
-    >>> metadata.version
-    <Version('1.0')>
-
-Accessing an attribute still validates and converts that individual value. It
-does not validate fields that are not accessed, collect all validation errors,
-or perform the eager metadata-version eligibility checks. Callers should only
-use this mode when they deliberately own validation of the fields they consume.
-
-When malformed or unrecognized email headers matter, call :func:`parse_email`
-directly and inspect its ``unparsed`` result, as above. That information is not
-available from ``Metadata.from_email(..., validate=False)``.
-
-
 Reference
 ---------
 

--- a/docs/metadata.rst
+++ b/docs/metadata.rst
@@ -33,6 +33,42 @@ Usage
     <Version('24.0')>
 
 
+Selective validation
+''''''''''''''''''''
+
+:meth:`Metadata.from_raw` and :meth:`Metadata.from_email` validate every field
+by default. If an application only relies on selected fields, it can disable
+that eager pass and access the required attributes explicitly. This is useful
+for otherwise usable legacy metadata containing a field that is invalid under
+newer metadata rules.
+
+.. doctest::
+
+    >>> legacy = (
+    ...     "Metadata-Version: 2.1\nName: example\n"
+    ...     "Version: 1.0\nLicense-File: LICENSE"
+    ... )
+    >>> raw, unparsed = parse_email(legacy)
+    >>> unparsed
+    {}
+    >>> metadata = Metadata.from_raw(raw, validate=False)
+    >>> metadata.metadata_version
+    '2.1'
+    >>> metadata.name
+    'example'
+    >>> metadata.version
+    <Version('1.0')>
+
+Accessing an attribute still validates and converts that individual value. It
+does not validate fields that are not accessed, collect all validation errors,
+or perform the eager metadata-version eligibility checks. Callers should only
+use this mode when they deliberately own validation of the fields they consume.
+
+When malformed or unrecognized email headers matter, call :func:`parse_email`
+directly and inspect its ``unparsed`` result, as above. That information is not
+available from ``Metadata.from_email(..., validate=False)``.
+
+
 Reference
 ---------
 

--- a/src/packaging/metadata.py
+++ b/src/packaging/metadata.py
@@ -808,8 +808,9 @@ class Metadata:
     def from_raw(cls, data: RawMetadata, *, validate: bool = True) -> Metadata:
         """Create an instance from :class:`RawMetadata`.
 
-        If *validate* is true, all metadata will be validated. All exceptions
-        related to validation will be gathered and raised as an :class:`ExceptionGroup`.
+        If *validate* is true, all metadata will be validated and all related
+        exceptions will be gathered and raised as an :class:`ExceptionGroup`;
+        otherwise, validation happens per attribute when it is accessed.
         """
         ins = cls()
         ins._raw = data.copy()  # Mutations occur due to caching enriched values.


### PR DESCRIPTION
## Summary

- document the `validate=False` behavior directly on `Metadata.from_raw`
- clarify that validation happens per attribute when accessed

This follows the documentation path proposed by the maintainer in #862 and the review feedback on this PR.

## Testing

- `uvx nox -s docs` (Sphinx HTML/LaTeX build and 410 doctests)
