### PR TITLE
fix(parser): use a strict end-of-input anchor

### DIFF
--- a/src/packaging/_tokenizer.py
+++ b/src/packaging/_tokenizer.py
@@ -89,7 +89,7 @@ DEFAULT_RULES: dict[str, re.Pattern[str]] = {
     "VERSION_PREFIX_TRAIL": re.compile(r"\.\*"),
     "VERSION_LOCAL_LABEL_TRAIL": re.compile(r"\+[a-z0-9]+(?:[-_\.][a-z0-9]+)*"),
     "WS": re.compile(r"[ \t]+"),
-    "END": re.compile(r"$"),
+    "END": re.compile(r"\Z"),
 }
 
 

--- a/tests/test_markers.py
+++ b/tests/test_markers.py
@@ -230,6 +230,17 @@ class TestMarker:
         with pytest.raises(InvalidMarker):
             Marker(marker_string)
 
+    @pytest.mark.parametrize("line_break", ["\n", "\r", "\r\n"])
+    def test_parses_invalid_trailing_line_break(self, line_break: str) -> None:
+        with pytest.raises(InvalidMarker):
+            Marker('python_version >= "3"' + line_break)
+
+    @pytest.mark.parametrize("whitespace", [" ", "\t", " \t"])
+    def test_parses_trailing_horizontal_whitespace(self, whitespace: str) -> None:
+        assert Marker('python_version >= "3"' + whitespace) == Marker(
+            'python_version >= "3"'
+        )
+
     @pytest.mark.parametrize(
         ("marker_string", "expected"),
         [

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -229,6 +229,24 @@ class TestRequirementParsing:
         # THEN
         assert req.url == url
 
+    @pytest.mark.parametrize("line_break", ["\n", "\r", "\r\n"])
+    @pytest.mark.parametrize(
+        "requirement",
+        [
+            "name>=1",
+            'name; python_version >= "3"',
+        ],
+    )
+    def test_error_when_suffixed_with_line_break(
+        self, requirement: str, line_break: str
+    ) -> None:
+        with pytest.raises(InvalidRequirement):
+            Requirement(requirement + line_break)
+
+    @pytest.mark.parametrize("whitespace", [" ", "\t", " \t"])
+    def test_trailing_horizontal_whitespace(self, whitespace: str) -> None:
+        assert Requirement("name>=1" + whitespace) == Requirement("name>=1")
+
     def test_empty_extras(self) -> None:
         # GIVEN
         to_parse = "name[]"


### PR DESCRIPTION
## Summary

- require the shared `Requirement` and `Marker` tokenizer to match the true end of input
- cover trailing line breaks while preserving trailing horizontal whitespace

## Rationale

Python's `$` anchor also matches immediately before one final newline, so otherwise complete requirements and markers could silently accept an LF suffix. Using `\Z` makes the tokenizer's existing `END` rule unambiguous and follows the strict-anchor correction made for wheel names in #1341.

## Verification

- `uv run --group test pytest tests/test_markers.py tests/test_requirements.py -q` - 7,638 passed
- Ruff check and format check on changed files
- `git diff --check`
