### PR TITLE
feat(tags): add a pure-Python compatibility tag generator

### DIFF
--- a/docs/tags.rst
+++ b/docs/tags.rst
@@ -94,6 +94,8 @@ to the implementation to provide.
 
 .. autofunction:: compatible_tags
 
+.. autofunction:: pure_python_tags
+
 .. autofunction:: cpython_tags
 
 .. autofunction:: generic_tags

--- a/src/packaging/tags.py
+++ b/src/packaging/tags.py
@@ -46,6 +46,7 @@ __all__ = [
     "mac_platforms",
     "parse_tag",
     "platform_tags",
+    "pure_python_tags",
     "sys_tags",
 ]
 
@@ -565,6 +566,30 @@ def _py_interpreter_range(py_version: PythonVersion) -> Iterator[str]:
             yield f"py{_version_nodot((py_version[0], minor))}"
 
 
+def pure_python_tags(
+    python_version: PythonVersion | None = None,
+) -> Iterator[Tag]:
+    """
+    Yields the pure-Python tags compatible with ``python_version``.
+
+    The tags use the ``"none"`` ABI and ``"any"`` platform, so their
+    generation does not depend on the running platform.
+
+    .. versionadded:: 26.3
+
+    :param Sequence python_version: A one- or two-item sequence representing the
+                                 compatible version of Python. Defaults to
+                                 ``sys.version_info[:2]``.
+    :raises ValueError: If ``python_version`` is an empty sequence.
+    """
+    if python_version is None:
+        python_version = sys.version_info[:2]
+    elif not python_version:
+        raise ValueError("python_version must contain at least one item")
+    for version in _py_interpreter_range(python_version):
+        yield Tag(version, "none", "any")
+
+
 def compatible_tags(
     python_version: PythonVersion | None = None,
     interpreter: str | None = None,
@@ -596,8 +621,7 @@ def compatible_tags(
             yield Tag(version, "none", platform_)
     if interpreter:
         yield Tag(interpreter, "none", "any")
-    for version in _py_interpreter_range(python_version):
-        yield Tag(version, "none", "any")
+    yield from pure_python_tags(python_version)
 
 
 def _mac_arch(arch: str, is_32bit: bool = _32_BIT_INTERPRETER) -> str:

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -1490,6 +1490,41 @@ class TestGenericTags:
         assert result == [tags.Tag("sillywalk", "none", "plat")]
 
 
+class TestPurePythonTags:
+    def test_python_version(self) -> None:
+        result = list(tags.pure_python_tags((3, 3)))
+        assert result == [
+            tags.Tag("py33", "none", "any"),
+            tags.Tag("py3", "none", "any"),
+            tags.Tag("py32", "none", "any"),
+            tags.Tag("py31", "none", "any"),
+            tags.Tag("py30", "none", "any"),
+        ]
+
+    def test_major_only_python_version(self) -> None:
+        assert list(tags.pure_python_tags((3,))) == [tags.Tag("py3", "none", "any")]
+
+    def test_empty_python_version(self) -> None:
+        with pytest.raises(ValueError, match="must contain at least one item"):
+            list(tags.pure_python_tags(()))
+
+    def test_default_python_version(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(sys, "version_info", (3, 1))
+        assert list(tags.pure_python_tags()) == [
+            tags.Tag("py31", "none", "any"),
+            tags.Tag("py3", "none", "any"),
+            tags.Tag("py30", "none", "any"),
+        ]
+
+    def test_does_not_query_platforms(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            tags,
+            "platform_tags",
+            lambda: pytest.fail("pure_python_tags() queried the running platform"),
+        )
+        assert list(tags.pure_python_tags((3,))) == [tags.Tag("py3", "none", "any")]
+
+
 class TestCompatibleTags:
     def test_all_args(self) -> None:
         result = list(tags.compatible_tags((3, 3), "cp33", ["plat1", "plat2"]))


### PR DESCRIPTION
Closes #781.

Extracts the existing `py*-none-any` tail into public `pure_python_tags()`, letting callers generate pure-Python compatibility tags without querying the running platform. `compatible_tags()` delegates to it without changing its ordering.

Validation: 62,346 tests passed; `nox -s lint` and `nox -s docs` passed.
