### PR TITLE
refactor(tags): make _generic_abi and _cpython_abis iterators

### DIFF
--- a/src/packaging/tags.py
+++ b/src/packaging/tags.py
@@ -353,9 +353,8 @@ def _abi3t_applies(python_version: PythonVersion, threading: bool) -> bool:
     return len(python_version) > 1 and tuple(python_version) >= (3, 2) and threading
 
 
-def _cpython_abis(py_version: PythonVersion, warn: bool = False) -> list[str]:
+def _cpython_abis(py_version: PythonVersion, warn: bool = False) -> Iterator[str]:
     py_version = tuple(py_version)  # To allow for version comparison.
-    abis = []
     version = _version_nodot(py_version[:2])
     threading = debug = pymalloc = ucs4 = ""
     with_debug = _get_config_var("Py_DEBUG", warn)
@@ -378,12 +377,11 @@ def _cpython_abis(py_version: PythonVersion, warn: bool = False) -> list[str]:
                 unicode_size is None and sys.maxunicode == 0x10FFFF
             ):
                 ucs4 = "u"
-    elif debug:
+    yield f"cp{version}{threading}{debug}{pymalloc}{ucs4}"
+    if py_version >= (3, 8) and debug:
         # Debug builds can also load "normal" extension modules.
         # We can also assume no UCS-4 or pymalloc requirement.
-        abis.append(f"cp{version}{threading}")
-    abis.insert(0, f"cp{version}{threading}{debug}{pymalloc}{ucs4}")
-    return abis
+        yield f"cp{version}{threading}"
 
 
 def cpython_tags(
@@ -465,9 +463,9 @@ def cpython_tags(
                     yield Tag(interpreter, "abi3t", platform_)
 
 
-def _generic_abi() -> list[str]:
+def _generic_abi() -> Iterator[str]:
     """
-    Return the ABI tag based on EXT_SUFFIX.
+    Yield the ABI tag based on EXT_SUFFIX.
     """
     # The following are examples of `EXT_SUFFIX`.
     # We want to keep the parts which are related to the ABI and remove the
@@ -486,7 +484,8 @@ def _generic_abi() -> list[str]:
     parts = ext_suffix.split(".")
     if len(parts) < 3:
         # CPython3.7 and earlier uses ".pyd" on Windows.
-        return _cpython_abis(sys.version_info[:2])
+        yield from _cpython_abis(sys.version_info[:2])
+        return
     soabi = parts[1]
     if soabi.startswith("cpython"):
         # non-windows
@@ -505,8 +504,8 @@ def _generic_abi() -> list[str]:
         # pyston, ironpython, others?
         abi = soabi
     else:
-        return []
-    return [_normalize_string(abi)]
+        return
+    yield _normalize_string(abi)
 
 
 def generic_tags(
@@ -541,7 +540,7 @@ def generic_tags(
         interp_name = interpreter_name()
         interp_version = interpreter_version(warn=warn)
         interpreter = f"{interp_name}{interp_version}"
-    abis = _generic_abi() if abis is None else list(abis)
+    abis = list(_generic_abi()) if abis is None else list(abis)
     platforms = list(platforms or platform_tags())
     if "none" not in abis:
         abis.append("none")

--- a/src/packaging/tags.py
+++ b/src/packaging/tags.py
@@ -362,9 +362,8 @@ def _abi3t_applies(python_version: PythonVersion, threading: bool) -> bool:
     return len(python_version) > 1 and tuple(python_version) >= (3, 2) and threading
 
 
-def _cpython_abis(py_version: PythonVersion, warn: bool = False) -> list[str]:
+def _cpython_abis(py_version: PythonVersion, warn: bool = False) -> Iterator[str]:
     py_version = tuple(py_version)  # To allow for version comparison.
-    abis = []
     version = _version_nodot(py_version[:2])
     threading = debug = pymalloc = ucs4 = ""
     with_debug = _get_config_var("Py_DEBUG", warn)
@@ -387,12 +386,11 @@ def _cpython_abis(py_version: PythonVersion, warn: bool = False) -> list[str]:
                 unicode_size is None and sys.maxunicode == 0x10FFFF
             ):
                 ucs4 = "u"
-    elif debug:
+    yield f"cp{version}{threading}{debug}{pymalloc}{ucs4}"
+    if py_version >= (3, 8) and debug:
         # Debug builds can also load "normal" extension modules.
         # We can also assume no UCS-4 or pymalloc requirement.
-        abis.append(f"cp{version}{threading}")
-    abis.insert(0, f"cp{version}{threading}{debug}{pymalloc}{ucs4}")
-    return abis
+        yield f"cp{version}{threading}"
 
 
 def cpython_tags(
@@ -476,9 +474,9 @@ def cpython_tags(
                     yield Tag(interpreter, "abi3t", platform_)
 
 
-def _generic_abi() -> list[str]:
+def _generic_abi() -> Iterator[str]:
     """
-    Return the ABI tag based on EXT_SUFFIX.
+    Yield the ABI tag based on EXT_SUFFIX.
     """
     # The following are examples of `EXT_SUFFIX`.
     # We want to keep the parts which are related to the ABI and remove the
@@ -497,7 +495,8 @@ def _generic_abi() -> list[str]:
     parts = ext_suffix.split(".")
     if len(parts) < 3:
         # CPython3.7 and earlier uses ".pyd" on Windows.
-        return _cpython_abis(sys.version_info[:2])
+        yield from _cpython_abis(sys.version_info[:2])
+        return
     soabi = parts[1]
     if soabi.startswith("cpython"):
         # non-windows
@@ -516,8 +515,8 @@ def _generic_abi() -> list[str]:
         # pyston, ironpython, others?
         abi = soabi
     else:
-        return []
-    return [_normalize_string(abi)]
+        return
+    yield _normalize_string(abi)
 
 
 def generic_tags(
@@ -554,7 +553,7 @@ def generic_tags(
         interp_name = interpreter_name()
         interp_version = interpreter_version(warn=warn)
         interpreter = f"{interp_name}{interp_version}"
-    abis = _generic_abi() if abis is None else list(abis)
+    abis = list(_generic_abi()) if abis is None else list(abis)
     platforms = list(platform_tags() if platforms is None else platforms)
     if "none" not in abis:
         abis.append("none")

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -991,14 +991,14 @@ class TestCPythonABI:
         if gettotalrefcount:
             monkeypatch.setattr(sys, "gettotalrefcount", 1, raising=False)
         expected = ["cp37d" if result else "cp37"]
-        assert tags._cpython_abis((3, 7)) == expected
+        assert list(tags._cpython_abis((3, 7))) == expected
 
     def test_debug_file_extension(self, monkeypatch: pytest.MonkeyPatch) -> None:
         config = {"Py_DEBUG": None}
         monkeypatch.setattr(sysconfig, "get_config_var", config.__getitem__)
         monkeypatch.delattr(sys, "gettotalrefcount", raising=False)
         monkeypatch.setattr(tags, "EXTENSION_SUFFIXES", {"_d.pyd"})
-        assert tags._cpython_abis((3, 8)) == ["cp38d", "cp38"]
+        assert list(tags._cpython_abis((3, 8))) == ["cp38d", "cp38"]
 
     @pytest.mark.parametrize(
         ("debug", "expected"), [(True, ["cp38d", "cp38"]), (False, ["cp38"])]
@@ -1008,7 +1008,7 @@ class TestCPythonABI:
     ) -> None:
         config = {"Py_DEBUG": debug}
         monkeypatch.setattr(sysconfig, "get_config_var", config.__getitem__)
-        assert tags._cpython_abis((3, 8)) == expected
+        assert list(tags._cpython_abis((3, 8))) == expected
 
     @pytest.mark.parametrize(
         ("pymalloc", "version", "result"),
@@ -1030,7 +1030,7 @@ class TestCPythonABI:
         monkeypatch.setattr(sysconfig, "get_config_var", config.__getitem__)
         base_abi = f"cp{version[0]}{version[1]}"
         expected = [base_abi + "m" if result else base_abi]
-        assert tags._cpython_abis(version) == expected
+        assert list(tags._cpython_abis(version)) == expected
 
     @pytest.mark.parametrize(
         ("unicode_size", "maxunicode", "version", "result"),
@@ -1055,7 +1055,7 @@ class TestCPythonABI:
         monkeypatch.setattr(sys, "maxunicode", maxunicode)
         base_abi = "cp" + tags._version_nodot(version)
         expected = [base_abi + "u" if result else base_abi]
-        assert tags._cpython_abis(version) == expected
+        assert list(tags._cpython_abis(version)) == expected
 
 
 class TestCPythonTags:
@@ -1341,7 +1341,7 @@ class TestGenericTags:
             sysconfig, "get_config_var", lambda _: ".cpython-37m-darwin.so"
         )
         monkeypatch.setattr(tags, "interpreter_name", lambda: "cp")
-        assert tags._generic_abi() == ["cp37m"]
+        assert list(tags._generic_abi()) == ["cp37m"]
 
     def test__generic_abi_linux_cpython(self, monkeypatch: pytest.MonkeyPatch) -> None:
         config = {
@@ -1352,18 +1352,18 @@ class TestGenericTags:
         monkeypatch.setattr(sysconfig, "get_config_var", config.__getitem__)
         monkeypatch.setattr(tags, "interpreter_name", lambda: "cp")
         # They are identical
-        assert tags._cpython_abis((3, 7)) == ["cp37m"]
-        assert tags._generic_abi() == ["cp37m"]
+        assert list(tags._cpython_abis((3, 7))) == ["cp37m"]
+        assert list(tags._generic_abi()) == ["cp37m"]
 
     def test__generic_abi_jp(self, monkeypatch: pytest.MonkeyPatch) -> None:
         config = {"EXT_SUFFIX": ".return_exactly_this.so"}
         monkeypatch.setattr(sysconfig, "get_config_var", config.__getitem__)
-        assert tags._generic_abi() == ["return_exactly_this"]
+        assert list(tags._generic_abi()) == ["return_exactly_this"]
 
     def test__generic_abi_graal(self, monkeypatch: pytest.MonkeyPatch) -> None:
         config = {"EXT_SUFFIX": ".graalpy-38-native-x86_64-darwin.so"}
         monkeypatch.setattr(sysconfig, "get_config_var", config.__getitem__)
-        assert tags._generic_abi() == ["graalpy_38_native"]
+        assert list(tags._generic_abi()) == ["graalpy_38_native"]
 
     def test__generic_abi_disable_gil(self, monkeypatch: pytest.MonkeyPatch) -> None:
         config = {
@@ -1373,13 +1373,13 @@ class TestGenericTags:
             "Py_GIL_DISABLED": 1,
         }
         monkeypatch.setattr(sysconfig, "get_config_var", config.__getitem__)
-        assert tags._generic_abi() == ["cp313t"]
-        assert tags._generic_abi() == tags._cpython_abis((3, 13))
+        assert list(tags._generic_abi()) == ["cp313t"]
+        assert list(tags._generic_abi()) == list(tags._cpython_abis((3, 13)))
 
     def test__generic_abi_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
         config = {"EXT_SUFFIX": "..so"}
         monkeypatch.setattr(sysconfig, "get_config_var", config.__getitem__)
-        assert tags._generic_abi() == []
+        assert list(tags._generic_abi()) == []
 
     @pytest.mark.parametrize("ext_suffix", ["invalid", "", None])
     def test__generic_abi_error(
@@ -1388,7 +1388,7 @@ class TestGenericTags:
         config = {"EXT_SUFFIX": ext_suffix}
         monkeypatch.setattr(sysconfig, "get_config_var", config.__getitem__)
         with pytest.raises(SystemError) as e:
-            tags._generic_abi()
+            list(tags._generic_abi())
         assert "EXT_SUFFIX" in str(e.value)
 
     # ".cpython.so" has no version component at all (would raise IndexError);
@@ -1402,7 +1402,7 @@ class TestGenericTags:
         config = {"EXT_SUFFIX": ext_suffix}
         monkeypatch.setattr(sysconfig, "get_config_var", config.__getitem__)
         with pytest.raises(SystemError) as e:
-            tags._generic_abi()
+            list(tags._generic_abi())
         assert "EXT_SUFFIX" in str(e.value)
 
     def test__generic_abi_linux_pypy(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1413,7 +1413,7 @@ class TestGenericTags:
         }
         monkeypatch.setattr(sysconfig, "get_config_var", config.__getitem__)
         monkeypatch.setattr(tags, "interpreter_name", lambda: "pp")
-        assert tags._generic_abi() == ["pypy39_pp73"]
+        assert list(tags._generic_abi()) == ["pypy39_pp73"]
 
     def test__generic_abi_old_windows(self, monkeypatch: pytest.MonkeyPatch) -> None:
         config = {
@@ -1423,19 +1423,23 @@ class TestGenericTags:
             "Py_GIL_DISABLED": 0,
         }
         monkeypatch.setattr(sysconfig, "get_config_var", config.__getitem__)
-        assert tags._generic_abi() == tags._cpython_abis(sys.version_info[:2])
+        assert list(tags._generic_abi()) == list(
+            tags._cpython_abis(sys.version_info[:2])
+        )
 
     def test__generic_abi_windows(self, monkeypatch: pytest.MonkeyPatch) -> None:
         config = {
             "EXT_SUFFIX": ".cp310-win_amd64.pyd",
         }
         monkeypatch.setattr(sysconfig, "get_config_var", config.__getitem__)
-        assert tags._generic_abi() == ["cp310"]
+        assert list(tags._generic_abi()) == ["cp310"]
 
     @pytest.mark.skipif(sys.implementation.name != "cpython", reason="CPython-only")
     def test__generic_abi_agree(self) -> None:
         """Test that the two methods of finding the abi tag agree"""
-        assert tags._generic_abi() == tags._cpython_abis(sys.version_info[:2])
+        assert list(tags._generic_abi()) == list(
+            tags._cpython_abis(sys.version_info[:2])
+        )
 
     def test_generic_platforms(self) -> None:
         platform = sysconfig.get_platform().replace("-", "_")
@@ -1671,7 +1675,7 @@ class TestSysTags:
         if platform.system() != "Darwin":
             monkeypatch.setattr(platform, "system", lambda: "Darwin")
             monkeypatch.setattr(tags, "mac_platforms", lambda: ["macosx_10_5_x86_64"])
-        abis = tags._cpython_abis(sys.version_info[:2])
+        abis = list(tags._cpython_abis(sys.version_info[:2]))
         platforms = list(tags.mac_platforms())
         result = list(tags.sys_tags())
         assert len(abis) == 1

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -1010,14 +1010,14 @@ class TestCPythonABI:
         if gettotalrefcount:
             monkeypatch.setattr(sys, "gettotalrefcount", 1, raising=False)
         expected = ["cp37d" if result else "cp37"]
-        assert tags._cpython_abis((3, 7)) == expected
+        assert list(tags._cpython_abis((3, 7))) == expected
 
     def test_debug_file_extension(self, monkeypatch: pytest.MonkeyPatch) -> None:
         config = {"Py_DEBUG": None}
         monkeypatch.setattr(sysconfig, "get_config_var", config.__getitem__)
         monkeypatch.delattr(sys, "gettotalrefcount", raising=False)
         monkeypatch.setattr(tags, "EXTENSION_SUFFIXES", {"_d.pyd"})
-        assert tags._cpython_abis((3, 8)) == ["cp38d", "cp38"]
+        assert list(tags._cpython_abis((3, 8))) == ["cp38d", "cp38"]
 
     @pytest.mark.parametrize(
         ("debug", "expected"), [(True, ["cp38d", "cp38"]), (False, ["cp38"])]
@@ -1027,7 +1027,7 @@ class TestCPythonABI:
     ) -> None:
         config = {"Py_DEBUG": debug}
         monkeypatch.setattr(sysconfig, "get_config_var", config.__getitem__)
-        assert tags._cpython_abis((3, 8)) == expected
+        assert list(tags._cpython_abis((3, 8))) == expected
 
     @pytest.mark.parametrize(
         ("pymalloc", "version", "result"),
@@ -1049,7 +1049,7 @@ class TestCPythonABI:
         monkeypatch.setattr(sysconfig, "get_config_var", config.__getitem__)
         base_abi = f"cp{version[0]}{version[1]}"
         expected = [base_abi + "m" if result else base_abi]
-        assert tags._cpython_abis(version) == expected
+        assert list(tags._cpython_abis(version)) == expected
 
     @pytest.mark.parametrize(
         ("unicode_size", "maxunicode", "version", "result"),
@@ -1074,7 +1074,7 @@ class TestCPythonABI:
         monkeypatch.setattr(sys, "maxunicode", maxunicode)
         base_abi = "cp" + tags._version_nodot(version)
         expected = [base_abi + "u" if result else base_abi]
-        assert tags._cpython_abis(version) == expected
+        assert list(tags._cpython_abis(version)) == expected
 
 
 class TestCPythonTags:
@@ -1363,7 +1363,7 @@ class TestGenericTags:
             sysconfig, "get_config_var", lambda _: ".cpython-37m-darwin.so"
         )
         monkeypatch.setattr(tags, "interpreter_name", lambda: "cp")
-        assert tags._generic_abi() == ["cp37m"]
+        assert list(tags._generic_abi()) == ["cp37m"]
 
     def test__generic_abi_linux_cpython(self, monkeypatch: pytest.MonkeyPatch) -> None:
         config = {
@@ -1374,18 +1374,18 @@ class TestGenericTags:
         monkeypatch.setattr(sysconfig, "get_config_var", config.__getitem__)
         monkeypatch.setattr(tags, "interpreter_name", lambda: "cp")
         # They are identical
-        assert tags._cpython_abis((3, 7)) == ["cp37m"]
-        assert tags._generic_abi() == ["cp37m"]
+        assert list(tags._cpython_abis((3, 7))) == ["cp37m"]
+        assert list(tags._generic_abi()) == ["cp37m"]
 
     def test__generic_abi_jp(self, monkeypatch: pytest.MonkeyPatch) -> None:
         config = {"EXT_SUFFIX": ".return_exactly_this.so"}
         monkeypatch.setattr(sysconfig, "get_config_var", config.__getitem__)
-        assert tags._generic_abi() == ["return_exactly_this"]
+        assert list(tags._generic_abi()) == ["return_exactly_this"]
 
     def test__generic_abi_graal(self, monkeypatch: pytest.MonkeyPatch) -> None:
         config = {"EXT_SUFFIX": ".graalpy-38-native-x86_64-darwin.so"}
         monkeypatch.setattr(sysconfig, "get_config_var", config.__getitem__)
-        assert tags._generic_abi() == ["graalpy_38_native"]
+        assert list(tags._generic_abi()) == ["graalpy_38_native"]
 
     def test__generic_abi_disable_gil(self, monkeypatch: pytest.MonkeyPatch) -> None:
         config = {
@@ -1395,13 +1395,13 @@ class TestGenericTags:
             "Py_GIL_DISABLED": 1,
         }
         monkeypatch.setattr(sysconfig, "get_config_var", config.__getitem__)
-        assert tags._generic_abi() == ["cp313t"]
-        assert tags._generic_abi() == tags._cpython_abis((3, 13))
+        assert list(tags._generic_abi()) == ["cp313t"]
+        assert list(tags._generic_abi()) == list(tags._cpython_abis((3, 13)))
 
     def test__generic_abi_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
         config = {"EXT_SUFFIX": "..so"}
         monkeypatch.setattr(sysconfig, "get_config_var", config.__getitem__)
-        assert tags._generic_abi() == []
+        assert list(tags._generic_abi()) == []
 
     @pytest.mark.parametrize("ext_suffix", ["invalid", "", None])
     def test__generic_abi_error(
@@ -1410,7 +1410,7 @@ class TestGenericTags:
         config = {"EXT_SUFFIX": ext_suffix}
         monkeypatch.setattr(sysconfig, "get_config_var", config.__getitem__)
         with pytest.raises(SystemError) as e:
-            tags._generic_abi()
+            list(tags._generic_abi())
         assert "EXT_SUFFIX" in str(e.value)
 
     # ".cpython.so" has no version component at all (would raise IndexError);
@@ -1424,7 +1424,7 @@ class TestGenericTags:
         config = {"EXT_SUFFIX": ext_suffix}
         monkeypatch.setattr(sysconfig, "get_config_var", config.__getitem__)
         with pytest.raises(SystemError) as e:
-            tags._generic_abi()
+            list(tags._generic_abi())
         assert "EXT_SUFFIX" in str(e.value)
 
     def test__generic_abi_linux_pypy(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1435,7 +1435,7 @@ class TestGenericTags:
         }
         monkeypatch.setattr(sysconfig, "get_config_var", config.__getitem__)
         monkeypatch.setattr(tags, "interpreter_name", lambda: "pp")
-        assert tags._generic_abi() == ["pypy39_pp73"]
+        assert list(tags._generic_abi()) == ["pypy39_pp73"]
 
     def test__generic_abi_old_windows(self, monkeypatch: pytest.MonkeyPatch) -> None:
         config = {
@@ -1445,19 +1445,23 @@ class TestGenericTags:
             "Py_GIL_DISABLED": 0,
         }
         monkeypatch.setattr(sysconfig, "get_config_var", config.__getitem__)
-        assert tags._generic_abi() == tags._cpython_abis(sys.version_info[:2])
+        assert list(tags._generic_abi()) == list(
+            tags._cpython_abis(sys.version_info[:2])
+        )
 
     def test__generic_abi_windows(self, monkeypatch: pytest.MonkeyPatch) -> None:
         config = {
             "EXT_SUFFIX": ".cp310-win_amd64.pyd",
         }
         monkeypatch.setattr(sysconfig, "get_config_var", config.__getitem__)
-        assert tags._generic_abi() == ["cp310"]
+        assert list(tags._generic_abi()) == ["cp310"]
 
     @pytest.mark.skipif(sys.implementation.name != "cpython", reason="CPython-only")
     def test__generic_abi_agree(self) -> None:
         """Test that the two methods of finding the abi tag agree"""
-        assert tags._generic_abi() == tags._cpython_abis(sys.version_info[:2])
+        assert list(tags._generic_abi()) == list(
+            tags._cpython_abis(sys.version_info[:2])
+        )
 
     def test_generic_platforms(self) -> None:
         platform = sysconfig.get_platform().replace("-", "_")
@@ -1739,7 +1743,7 @@ class TestSysTags:
         if platform.system() != "Darwin":
             monkeypatch.setattr(platform, "system", lambda: "Darwin")
             monkeypatch.setattr(tags, "mac_platforms", lambda: ["macosx_10_5_x86_64"])
-        abis = tags._cpython_abis(sys.version_info[:2])
+        abis = list(tags._cpython_abis(sys.version_info[:2]))
         platforms = list(tags.mac_platforms())
         result = list(tags.sys_tags())
         assert len(abis) == 1


### PR DESCRIPTION
Yield ABI tags lazily instead of building lists, so a consumer that only needs the first tag (e.g. next(iter(...))) can stop early. I think this is slightly nicer, and it ties to https://github.com/pypa/packaging/pull/611 nicely.

Review after 26.3.

Assisted-by: ClaudeCode:claude-opus-4.8
