### PR TITLE
fix(direct_url): reject out-of-root subdirectory paths

### DIFF
--- a/src/packaging/direct_url.py
+++ b/src/packaging/direct_url.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import dataclasses
+import ntpath
 import re
 import urllib.parse
 from collections.abc import Mapping
@@ -112,6 +113,24 @@ def _strip_url(url: str, safe_user_passwords: Collection[str]) -> str:
 
 def _file_url_has_absolute_path(parsed_url: SplitResult) -> bool:
     return parsed_url.path.startswith("/")
+
+
+def _subdirectory_is_within_source_root(subdirectory: str) -> bool:
+    drive, _ = ntpath.splitdrive(subdirectory)
+    if drive or subdirectory.startswith(("/", "\\")):
+        return False
+
+    depth = 0
+    for part in re.split(r"[/\\]+", subdirectory):
+        if not part or part == ".":
+            continue
+        if part == "..":
+            if depth == 0:
+                return False
+            depth -= 1
+        else:
+            depth += 1
+    return True
 
 
 class DirectUrlValidationError(Exception):
@@ -306,7 +325,14 @@ class DirectUrl:
                     "File URL must be absolute when dir_info is present",
                     context="url",
                 )
-        # XXX subdirectory must be relative, can we, should we validate that here?
+        if (
+            direct_url.subdirectory is not None
+            and not _subdirectory_is_within_source_root(direct_url.subdirectory)
+        ):
+            raise DirectUrlValidationError(
+                "Path must be relative to and remain within the source root",
+                context="subdirectory",
+            )
         return direct_url
 
     @classmethod

--- a/tests/test_direct_url.py
+++ b/tests/test_direct_url.py
@@ -289,6 +289,67 @@ def test_validate_error() -> None:
 
 
 @pytest.mark.parametrize(
+    "subdirectory",
+    ["", ".", "./src", "src/pkg", "src\\pkg", "src/../pkg", "src\\..\\pkg"],
+)
+def test_subdirectory_accepts_paths_within_source_root(subdirectory: str) -> None:
+    direct_url = DirectUrl.from_dict(
+        {
+            "url": "https://g.c/user/repo.git",
+            "vcs_info": {"vcs": "git", "commit_id": "a" * 40},
+            "subdirectory": subdirectory,
+        }
+    )
+
+    assert direct_url.subdirectory == subdirectory
+
+
+@pytest.mark.parametrize(
+    "subdirectory",
+    [
+        "/outside",
+        "\\outside",
+        "C:outside",
+        "C:/outside",
+        "C:\\outside",
+        "//server/share",
+        "\\\\server\\share",
+        "..",
+        "../outside",
+        "..\\outside",
+        "src/../../outside",
+        "src\\..\\..\\outside",
+    ],
+)
+def test_subdirectory_rejects_paths_outside_source_root(subdirectory: str) -> None:
+    with pytest.raises(
+        DirectUrlValidationError,
+        match=(
+            r"Path must be relative to and remain within the source root "
+            r"in 'subdirectory'"
+        ),
+    ):
+        DirectUrl.from_dict(
+            {
+                "url": "https://g.c/user/repo.git",
+                "vcs_info": {"vcs": "git", "commit_id": "a" * 40},
+                "subdirectory": subdirectory,
+            }
+        )
+
+
+def test_validate_rejects_out_of_root_subdirectory() -> None:
+    direct_url = DirectUrl(
+        url="https://g.c/user/repo.git",
+        vcs_info=VcsInfo(vcs="git", commit_id="a" * 40),
+        subdirectory="../outside",
+    )
+
+    with pytest.raises(DirectUrlValidationError, match="in 'subdirectory'"):
+        direct_url.validate()
+
+
+@pytest.mark.parametrize(
     ("url", "safe_user_passwords", "expected_url"),
     [
         ("https://g.c/user/repo.git", ["git"], "https://g.c/user/repo.git"),


### PR DESCRIPTION
## Summary

- enforce the Direct URL specification's requirement that `subdirectory` remain relative to the referenced source root
- reject POSIX absolute, Windows rooted/drive/UNC, and parent-traversal paths with one platform-independent lexical check
- preserve valid relative strings unchanged and keep validation at `from_dict()` / `validate()` rather than dataclass construction

## Tests

- `uv run --group test pytest -q` (`62414 passed, 1 skipped, 427 deselected`)
- `uv run --group test pytest tests/test_direct_url.py -q` (`66 passed`)
- `uv run ruff check src/packaging/direct_url.py tests/test_direct_url.py`
- `uv run ruff format --check src/packaging/direct_url.py tests/test_direct_url.py`
- `git diff --check`
