### PR TITLE
fix(pylock): respect an explicitly empty tag sequence in select()

### DIFF
--- a/src/packaging/pylock.py
+++ b/src/packaging/pylock.py
@@ -786,7 +786,9 @@ class Pylock:
         .. versionchanged:: 26.3
             Added the *prefer_sdist_predicate* parameter.
         """
-        compatible_tags_selector = create_compatible_tags_selector(tags or sys_tags())
+        compatible_tags_selector = create_compatible_tags_selector(
+            tags if tags is not None else sys_tags()
+        )
 
         # #. Gather the extras and dependency groups to install and set ``extras`` and
         #    ``dependency_groups`` for marker evaluation, respectively.

--- a/tests/test_pylock_select.py
+++ b/tests/test_pylock_select.py
@@ -307,6 +307,34 @@ def test_missing_sdist_fallback() -> None:
         list(pylock.select())
 
 
+def test_empty_tags_selects_sdist_instead_of_host_compatible_wheel() -> None:
+    pylock = _pylock_with_wheel_and_sdist()
+
+    selected = list(
+        pylock.select(
+            tags=[],
+            environment=_py312_linux.environment,
+        )
+    )
+
+    assert len(selected) == 1
+    assert isinstance(selected[0][1], PackageSdist)
+
+
+def test_empty_tags_rejects_wheel_only_lock() -> None:
+    pylock = _pylock_with_wheel_and_sdist(include_sdist=False)
+
+    with pytest.raises(
+        PylockSelectError, match=r"No wheel found matching .* and no sdist available"
+    ):
+        list(
+            pylock.select(
+                tags=[],
+                environment=_py312_linux.environment,
+            )
+        )
+
+
 def _pylock_with_wheel_and_sdist(
     *, wheel_python_tag: str | None = "py3", include_sdist: bool = True
 ) -> Pylock:


### PR DESCRIPTION
`Pylock.select(tags=[])` currently treats the explicit empty sequence like an omitted argument and falls back to the running interpreter's `sys_tags()`. That can select a host-compatible wheel even when the caller supplied no compatible tags.

This changes the defaulting check to distinguish `None` from an explicit empty sequence:

- an empty tag sequence falls back to an available sdist;
- a wheel-only lock raises `PylockSelectError`;
- omitted `tags` and non-empty tag sequences retain their existing behavior.

Tests: `PYTHONPATH=src python3 -m pytest -q tests/test_pylock_select.py` (27 passed).
