### PR TITLE
fix: reject invalid interpreter tags

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,6 +33,8 @@ Fixes:
 * Normalize requested extra names before comparing or hashing requirements (:issue:`644`)
 * Preserve a ``Requirement``'s specifier ``prereleases`` override across a
   pickle round trip. (:issue:`1204`)
+* Reject wheel tags whose interpreter component is not an identifier.
+  (:issue:`577`)
 
 26.2 - 2026-04-24
 ~~~~~~~~~~~~~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,7 +33,7 @@ Fixes:
 * Normalize requested extra names before comparing or hashing requirements (:issue:`644`)
 * Preserve a ``Requirement``'s specifier ``prereleases`` override across a
   pickle round trip. (:issue:`1204`)
-* Reject wheel tags whose interpreter component is not an identifier.
+* Reject wheel tags containing interpreter components that are not identifiers.
   (:issue:`577`)
 
 26.2 - 2026-04-24

--- a/src/packaging/tags.py
+++ b/src/packaging/tags.py
@@ -95,8 +95,8 @@ class UnsortedTagsError(ValueError):
 
 class InvalidTag(ValueError):
     """
-    Raised when a tag has an invalid or empty interpreter, ABI, or platform
-    component, or does not have exactly three components.
+    Raised when an interpreter component is not an identifier, a tag component
+    is empty, or a tag does not have exactly three components.
 
     .. versionadded:: 26.3
     """
@@ -259,8 +259,9 @@ def parse_tag(
        The *validate_order* parameter.
 
     .. versionadded:: 26.3
-       Raises :class:`InvalidTag` on invalid interpreter components, empty tag
-       components, or a tag that does not have exactly three components.
+       Raises :class:`InvalidTag` when an interpreter component is not an
+       identifier, a tag component is empty, or a tag does not have exactly
+       three components.
        Added the *limit* parameter. Raises :class:`TooManyTagsError` if the compressed
        tag set would generate more than *limit* tags.
     """

--- a/src/packaging/tags.py
+++ b/src/packaging/tags.py
@@ -95,8 +95,8 @@ class UnsortedTagsError(ValueError):
 
 class InvalidTag(ValueError):
     """
-    Raised when a tag has an empty interpreter, ABI, or platform component, or
-    does not have exactly three components.
+    Raised when a tag has an invalid or empty interpreter, ABI, or platform
+    component, or does not have exactly three components.
 
     .. versionadded:: 26.3
     """
@@ -248,9 +248,9 @@ def parse_tag(
     :param int | None limit: The maximum number of tags to parse.
     :raises UnsortedTagsError: If **validate_order** is true and any compressed tag
         set component is not in sorted order.
-    :raises InvalidTag: If the interpreter, ABI, or platform field (or any member
-        of a compressed tag set) is empty, or the tag does not have exactly three
-        components.
+    :raises InvalidTag: If the interpreter field is not an identifier; if the
+        interpreter, ABI, or platform field (or any member of a compressed tag
+        set) is empty; or if the tag does not have exactly three components.
     :raises TooManyTagsError: If **limit** is not ``None`` and the compressed tag
         set would generate more than **limit** tags.
     :raises ValueError: If **limit** is negative.
@@ -259,8 +259,8 @@ def parse_tag(
        The *validate_order* parameter.
 
     .. versionadded:: 26.3
-       Raises :class:`InvalidTag` on empty tag components, or a tag that does
-       not have exactly three components.
+       Raises :class:`InvalidTag` on invalid interpreter components, empty tag
+       components, or a tag that does not have exactly three components.
        Added the *limit* parameter. Raises :class:`TooManyTagsError` if the compressed
        tag set would generate more than *limit* tags.
     """
@@ -293,6 +293,9 @@ def parse_tag(
         interpreters, abis, platforms = component_parts
     except ValueError as exc:
         raise InvalidTag(f"Tag {tag!r} must have exactly three components") from exc
+    for interpreter in interpreters:
+        if not interpreter.isidentifier():
+            raise InvalidTag(f"Tag {tag!r} has an invalid interpreter: {interpreter!r}")
     return frozenset(
         Tag(interpreter, abi, platform_)
         for interpreter in interpreters

--- a/src/packaging/utils.py
+++ b/src/packaging/utils.py
@@ -220,8 +220,9 @@ def parse_wheel_filename(
        The *validate_order* parameter.
 
     .. versionchanged:: 26.3
-       Raises :class:`InvalidWheelFilename` on invalid or empty tag set
-       components, or an empty project name.
+       Raises :class:`InvalidWheelFilename` when an interpreter component is
+       not an identifier, a tag set component is empty, or the project name is
+       empty.
     """
     if not filename.endswith(".whl"):
         raise InvalidWheelFilename(

--- a/src/packaging/utils.py
+++ b/src/packaging/utils.py
@@ -220,8 +220,8 @@ def parse_wheel_filename(
        The *validate_order* parameter.
 
     .. versionchanged:: 26.3
-       Raises :class:`InvalidWheelFilename` on empty tag set components or an
-       empty project name.
+       Raises :class:`InvalidWheelFilename` on invalid or empty tag set
+       components, or an empty project name.
     """
     if not filename.endswith(".whl"):
         raise InvalidWheelFilename(
@@ -269,7 +269,7 @@ def parse_wheel_filename(
         ) from None
     except InvalidTag:
         raise InvalidWheelFilename(
-            f"Invalid wheel filename (empty tag component): {filename!r}"
+            f"Invalid wheel filename (invalid tag component): {filename!r}"
         ) from None
     return (name, version, build, tags)
 

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -237,6 +237,25 @@ class TestParseTag:
     @pytest.mark.parametrize(
         "tag",
         [
+            "2-none-any",
+            "2.7.6-none-any",
+            "py3.2-none-any",
+            "py+3-none-any",
+        ],
+    )
+    def test_invalid_interpreter_raises(self, tag: str) -> None:
+        with pytest.raises(tags.InvalidTag, match="invalid interpreter"):
+            tags.parse_tag(tag)
+
+    @pytest.mark.parametrize("interpreter", ["sillywalk", "graalpy311", "_custom"])
+    def test_identifier_interpreter_is_valid(self, interpreter: str) -> None:
+        assert tags.parse_tag(f"{interpreter}-none-any") == {
+            tags.Tag(interpreter, "none", "any")
+        }
+
+    @pytest.mark.parametrize(
+        "tag",
+        [
             "py3-none",
             "py3-none-any-extra",
         ],

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -200,6 +200,7 @@ def test_parse_wheel_filename(
         ("foo-1.0--none-any.whl"),  # Empty interpreter component
         ("foo-1.0-py3-none-.whl"),  # Empty platform component
         ("foo-1.0-py3.-none-any.whl"),  # Empty member in a compressed tag set
+        ("playlyfe-0.1.1-2.7.6-none-any.whl"),  # Invalid interpreter components
     ],
 )
 def test_parse_wheel_invalid_filename(filename: str) -> None:


### PR DESCRIPTION
Fixes #577.

## Summary

- validate every compressed interpreter-tag member as an identifier before constructing `Tag` objects
- reject malformed wheel names such as `playlyfe-0.1.1-2.7.6-none-any.whl`, which previously expanded into the numeric interpreter tags `2`, `7`, and `6`
- preserve support for custom implementation identifiers and wrap parser failures as `InvalidWheelFilename`
- update the API documentation and changelog

## Compatibility

The validation uses `str.isidentifier()` rather than a fixed implementation allowlist. Existing well-known tags, custom implementation identifiers, uppercase input normalized by `Tag`, and every tag produced by `sys_tags()` continue to parse. Non-empty ABI and platform components retain their existing behavior.

## Tests

- `python -m pytest tests/test_tags.py::TestParseTag tests/test_utils.py -q` — 105 passed
- `python -m pytest -q` — 62,399 passed, 1 skipped, 427 deselected
- targeted `ruff-check`, `ruff-format`, and reStructuredText pre-commit hooks — passed
- `python -m nox -s docs` — HTML, LaTeX, and doctest builds passed; 418 doctests passed
- compatibility probe over all 45 local `sys_tags()` entries plus custom interpreter identifiers — passed
- validation-boundary probe confirming non-empty ABI/platform components remain accepted — passed

`nox -s lint` also passed all hooks except the repository's pinned mypy hook on Windows: mypy 2.1 rejects the configured Python 3.9 target and reports the existing `os.confstr` platform error in `_manylinux.py`.