### PR TITLE
ci: drop 3.13t on Windows (3.13.14t may fail to build, run takes 9 minutes)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,10 @@ jobs:
             python_version: "3.13.0"
           - os: Ubuntu
             python_version: "3.14.0"
+        exclude:
+          # Fails to build in CI (not packaging's fault)
+          - os: Windows
+            python_version: "3.13t"
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
           - os: Ubuntu
             python_version: "3.14.0"
         exclude:
-          # Fails to build in CI (not packaging's fault)
+          # Slow, sometimes fails to build in CI (not packaging's fault)
           - os: Windows
             python_version: "3.13t"
 


### PR DESCRIPTION
Since this is only Windows, and 3.13t was experimental and has been dropped from manylinux, cibuildwheel, etc, let's just drop it. We still have 3.14t on Windows and 3.13t on other platforms.
