### PR TITLE
ci: allow testing feature branches, and allow manual trigger via GH UI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,8 @@ on:
   push:
     branches-ignore:
       - dependabot/**
+      - pypa/**
+      - stack/**
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,6 @@
 name: Test
 
-on:
-  pull_request:
-  push:
-    branches:
-      - main
+on: [push, pull_request, workflow_dispatch]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,11 @@
 name: Test
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  pull_request:
+  workflow_dispatch:
+  push:
+    branches-ignore:
+      - dependabot/**
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}


### PR DESCRIPTION
I prefer to make sure my code passes on CI, before opening a PR and pinging all maintainers.

Right now, this CI only runs on pushes to `main`. This means I can only work on one PR at a time, and if I forget I have a PR open from `main`, I can accidentally close it by resetting to upstream: https://github.com/pypa/packaging/pull/1263#event-28598765036

> Won't this double-run CI when we make a PR from a in-repo branch? 

Yes, but I recommend creating PRs from your own fork and not from upstream:

* You get total control on whether the CI is even enabled
* By default it's disabled, you need explicit opt-in
* You don't "clutter" upstream with personal branches, which may live for years and affect everyone who forks

It's not common. Of the last 300 PRs to this repo, only 16 were in-repo:
* 11 dependabot
* 4 Henry
* 1 Brett

And the CI is fast, it doesn't use up too much time.

Plus, they're technically not really double-runs, a `push` and a `pull_request` test different things. A `push` is just what's on the branch. A `pull_request` simulates a merge against `main`, and tests that. Occasionally you get different results, and this can be useful info!

> You can also make a PR to your fork to get CI.

Indeed, but that's also adding extra friction to contribution.
