### PR TITLE
fix(metadata): fold every line boundary when writing headers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -87,12 +87,7 @@ Fixes for metadata and licenses:
 * Make ``InvalidMetadata`` and ``CyclicDependencyGroup`` picklable.
   (:pull:`1328`)
 * Fold every line boundary ``str.splitlines`` recognizes when writing a header
-  with :class:`~packaging.metadata.RFC822Message`. A value holding a bare
-  carriage return no longer makes the email generator raise
-  ``HeaderWriteError``, and on CPython releases without the CVE-2024-6923 fix
-  the other boundaries (form feed, line separator, ...) no longer end the
-  header and start a new one. ``Summary`` is validated against the same set of
-  line boundaries. (:pull:`1356`)
+  with :class:`~packaging.metadata.RFC822Message`. (:pull:`1356`)
 * Raise ``InvalidLicenseExpression`` for misplaced ``WITH`` clauses and empty
   ``LicenseRef-`` names. (:pull:`1266`)
 * Raise ``InvalidLicenseExpression`` instead of ``KeyError`` for a

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -86,6 +86,11 @@ Fixes for metadata and licenses:
   (:pull:`1247`)
 * Make ``InvalidMetadata`` and ``CyclicDependencyGroup`` picklable.
   (:pull:`1328`)
+* Fold every line boundary ``str.splitlines`` recognizes when writing a header
+  with :class:`~packaging.metadata.RFC822Message`, so a value holding a bare
+  carriage return (or a form feed, a line separator, ...) no longer ends the
+  header and starts a new one. ``Summary`` is validated against the same set of
+  line boundaries.
 * Raise ``InvalidLicenseExpression`` for misplaced ``WITH`` clauses and empty
   ``LicenseRef-`` names. (:pull:`1266`)
 * Raise ``InvalidLicenseExpression`` instead of ``KeyError`` for a

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -87,10 +87,12 @@ Fixes for metadata and licenses:
 * Make ``InvalidMetadata`` and ``CyclicDependencyGroup`` picklable.
   (:pull:`1328`)
 * Fold every line boundary ``str.splitlines`` recognizes when writing a header
-  with :class:`~packaging.metadata.RFC822Message`, so a value holding a bare
-  carriage return (or a form feed, a line separator, ...) no longer ends the
-  header and starts a new one. ``Summary`` is validated against the same set of
-  line boundaries.
+  with :class:`~packaging.metadata.RFC822Message`. A value holding a bare
+  carriage return no longer makes the email generator raise
+  ``HeaderWriteError``, and on CPython releases without the CVE-2024-6923 fix
+  the other boundaries (form feed, line separator, ...) no longer end the
+  header and start a new one. ``Summary`` is validated against the same set of
+  line boundaries. (:pull:`1356`)
 * Raise ``InvalidLicenseExpression`` for misplaced ``WITH`` clauses and empty
   ``LicenseRef-`` names. (:pull:`1266`)
 * Raise ``InvalidLicenseExpression`` instead of ``KeyError`` for a

--- a/src/packaging/metadata.py
+++ b/src/packaging/metadata.py
@@ -6,6 +6,7 @@ import email.parser
 import email.policy
 import keyword
 import pathlib
+import re
 import typing
 from typing import (
     Any,
@@ -307,6 +308,12 @@ _EMAIL_TO_RAW_MAPPING = {
 _RAW_TO_EMAIL_MAPPING = {raw: email for email, raw in _EMAIL_TO_RAW_MAPPING.items()}
 
 
+# Every boundary ``str.splitlines`` knows about ends a header line once the
+# email package writes the message back out, so all of them have to be folded,
+# not just "\n".
+_LINE_BOUNDARY_RE = re.compile(r"\r\n|[\n\r\v\f\x1c\x1d\x1e\x85\u2028\u2029]")
+
+
 # This class is for writing RFC822 messages
 class RFC822Policy(email.policy.EmailPolicy):
     """
@@ -322,7 +329,7 @@ class RFC822Policy(email.policy.EmailPolicy):
 
     def header_store_parse(self, name: str, value: str) -> tuple[str, str]:
         size = len(name) + 2
-        value = value.replace("\n", "\n" + " " * size)
+        value = _LINE_BOUNDARY_RE.sub("\n" + " " * size, value)
         return (name, value)
 
 
@@ -642,8 +649,8 @@ class _Validator(Generic[T]):
             ) from exc
 
     def _process_summary(self, value: str) -> str:
-        """Check the field contains no newlines."""
-        if "\n" in value:
+        """Check the field contains no line breaks."""
+        if _LINE_BOUNDARY_RE.search(value):
             raise self._invalid_metadata(f"{self.raw_name!r} must be a single line")
         return value
 

--- a/src/packaging/metadata.py
+++ b/src/packaging/metadata.py
@@ -308,9 +308,9 @@ _EMAIL_TO_RAW_MAPPING = {
 _RAW_TO_EMAIL_MAPPING = {raw: email for email, raw in _EMAIL_TO_RAW_MAPPING.items()}
 
 
-# Every boundary ``str.splitlines`` knows about ends a header line once the
-# email package writes the message back out, so all of them have to be folded,
-# not just "\n".
+# A bare "\r" makes the email generator raise ``HeaderWriteError``, and on
+# CPython releases without the CVE-2024-6923 fix any ``str.splitlines``
+# boundary ends the header line, so fold all of them, not just "\n".
 _LINE_BOUNDARY_RE = re.compile(r"\r\n|[\n\r\v\f\x1c\x1d\x1e\x85\u2028\u2029]")
 
 

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -716,7 +716,9 @@ class TestMetadata:
 
         assert meta.summary == summary
 
-    @pytest.mark.parametrize("summary", ["Hello\n    Again", "Hello\rAgain"])
+    @pytest.mark.parametrize(
+        "summary", ["Hello\n    Again", "Hello\rAgain", "Hello\u2028Again"]
+    )
     def test_invalid_summary(self, summary: str) -> None:
         meta = metadata.Metadata.from_raw({"summary": summary}, validate=False)
 
@@ -1188,6 +1190,22 @@ class TestMetadataWriting:
             written_bytes
             == "metadata-version: 2.3\nname: Hello\n"
             "version: 1.2.3\n\nHello\n\nWorld👋".encode()
+        )
+
+    def test_write_metadata_with_carriage_return(self) -> None:
+        # A bare "\r" made the email generator raise HeaderWriteError.
+        meta = metadata.Metadata.from_raw(
+            {
+                "version": "1.2.3",
+                "name": "packaging",
+                "author": "Hello\rWorld",
+                "metadata_version": "2.3",
+            }
+        )
+        written = meta.as_rfc822().as_string()
+        assert (
+            written == "metadata-version: 2.3\nname: packaging\nversion: 1.2.3"
+            "\nauthor: Hello\n        World\n\n"
         )
 
     def test_multiline_license(self) -> None:

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -716,10 +716,9 @@ class TestMetadata:
 
         assert meta.summary == summary
 
-    def test_invalid_summary(self) -> None:
-        meta = metadata.Metadata.from_raw(
-            {"summary": "Hello\n    Again"}, validate=False
-        )
+    @pytest.mark.parametrize("summary", ["Hello\n    Again", "Hello\rAgain"])
+    def test_invalid_summary(self, summary: str) -> None:
+        meta = metadata.Metadata.from_raw({"summary": summary}, validate=False)
 
         with pytest.raises(metadata.InvalidMetadata) as exc_info:
             meta.summary  # noqa: B018
@@ -1474,6 +1473,19 @@ class TestMetadataWriting:
 
         assert email.message_from_string(str(message)).items() == [
             (a, "\n       ".join(b.splitlines())) for a, b in items if b is not None
+        ]
+
+    @pytest.mark.parametrize(
+        "boundary",
+        ["\r", "\r\n", "\v", "\f", "\x1c", "\x1d", "\x1e", "\x85", "\u2028", "\u2029"],
+    )
+    def test_headers_fold_every_line_boundary(self, boundary: str) -> None:
+        message = metadata.RFC822Message()
+        message["ItemA"] = f"ValueA{boundary}Requires-Dist: injected"
+
+        assert str(message) == "ItemA: ValueA\n       Requires-Dist: injected\n\n"
+        assert email.message_from_string(str(message)).items() == [
+            ("ItemA", "ValueA\n       Requires-Dist: injected")
         ]
 
     def test_body(self) -> None:


### PR DESCRIPTION
`header_store_parse` folds `\n` into a continuation line, but the email package ends a header line on every boundary `str.splitlines` recognizes. A value carrying a bare `\r`, `\v`, `\f`, `\x1c`-`\x1e`, `\x85`, U+2028 or U+2029 goes out unfolded, so `Metadata.from_raw({"author": "a\rRequires-Dist: evil"}).as_rfc822()` writes an `author` header and then a `Requires-Dist` header that was never on the metadata object. Values arriving from `pyproject.toml` or a JSON payload reach this path directly, since on the parse side those bytes are already line breaks.

Folding on the whole boundary set keeps this in one place instead of a per-field check across summary, author, keywords, classifier and project-url, and `\n` output stays byte for byte what it was. `Summary` still needs its own check to remain one line, so it now tests the same set.
