### PR TITLE
Reject non-normalized names in filename parsers

### DIFF
--- a/src/packaging/utils.py
+++ b/src/packaging/utils.py
@@ -270,6 +270,8 @@ def parse_wheel_filename(
     if "__" in name_part or _wheel_name_regex.match(name_part) is None:
         raise InvalidWheelFilename(f"Invalid project name: {filename!r}")
     name = canonicalize_name(name_part)
+    if not is_normalized_name(name):
+        raise InvalidWheelFilename(f"Invalid project name: {filename!r}")
 
     try:
         version = Version(parts[1])
@@ -359,6 +361,10 @@ def parse_sdist_filename(filename: str) -> tuple[NormalizedName, Version]:
         )
 
     name = canonicalize_name(name_part)
+    if not is_normalized_name(name):
+        raise InvalidSdistFilename(
+            f"Invalid sdist filename (invalid project name): {filename!r}"
+        )
 
     try:
         version = Version(version_part)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -161,20 +161,6 @@ def test_canonicalize_version_no_strip_trailing_zero(version: str) -> None:
                 Tag("py3", "none", "manylinux2014_x86_64"),
             },
         ),
-        (
-            "foo_bár-1.0-py3-none-any.whl",
-            "foo-bár",
-            Version("1.0"),
-            (),
-            {Tag("py3", "none", "any")},
-        ),
-        (
-            "foo_bár-1.0-1000-py3-none-any.whl",
-            "foo-bár",
-            Version("1.0"),
-            (1000, ""),
-            {Tag("py3", "none", "any")},
-        ),
     ],
 )
 def test_parse_wheel_filename(
@@ -189,6 +175,8 @@ def test_parse_wheel_filename(
         ("foo-1.0.whl"),  # Missing tags
         ("foo-1.0-py3-none-any.wheel"),  # Incorrect file extension (`.wheel`)
         ("foo__bar-1.0-py3-none-any.whl"),  # Invalid name (`__`)
+        ("foo_bár-1.0-py3-none-any.whl"),  # Invalid name (not normalized)
+        ("foo_bár-1.0-1000-py3-none-any.whl"),  # Invalid name with build number
         ("foo\n-1.0-py3-none-any.whl"),  # Invalid name (`\n`)
         ("foo#bar-1.0-py3-none-any.whl"),  # Invalid name (`#`)
         ("-1.0-py3-none-any.whl"),  # Empty project name
@@ -245,6 +233,8 @@ def test_parse_sdist_filename(filename: str, name: str, version: Version) -> Non
     [
         ("foo-1.0.xz"),  # Incorrect extension
         ("foo1.0.tar.gz"),  # Missing separator
+        ("foo_bár-1.0.tar.gz"),  # Invalid name (not normalized)
+        ("foo_bár-1.0.zip"),  # Invalid name (not normalized)
         ("foo-1.x.tar.gz"),  # Invalid version
         ("-1.0.tar.gz"),  # Empty project name
         ("-1.0.zip"),  # Empty project name (zip)


### PR DESCRIPTION
## Summary
- Preserve the `NormalizedName` invariant for parsed wheel and sdist filenames.
- Reject filename project names whose canonicalized value is not accepted by `is_normalized_name`.
- Move the non-ASCII filename cases from accepted wheel examples to invalid filename coverage and add matching sdist coverage.

Closes #1350.

## Verification
RED:
- `python3 -m pytest tests/test_utils.py::test_parse_wheel_filename_rejects_names_that_are_not_normalized -q` failed before the fix with `Failed: DID NOT RAISE <class 'packaging.utils.InvalidWheelFilename'>`.

GREEN:
- `python3 -m pytest tests/test_utils.py -q` → 79 passed
- `python3 -m pytest -q` → 62425 passed, 427 deselected
- `python3 -m ruff check src/packaging/utils.py tests/test_utils.py` → All checks passed
- `python3 -m ruff format --check src/packaging/utils.py tests/test_utils.py` → 2 files already formatted
- `python3 -m py_compile src/packaging/utils.py tests/test_utils.py`
- `git diff --check`

## Duplicate preflight
- Issue #1350 is open and unassigned.
- Checked open PRs for #1350, non-ASCII/unicode names, `parse_wheel_filename`, `parse_sdist_filename`, and `is_normalized_name`.
- Existing PR #1309 is scoped to opt-in strict wheel validation for #873 and explicitly does not change default parsing or sdist parsing, so this remains a focused #1350 fix.
