### PR TITLE
fix(tags): preserve explicitly empty platform iterables

### DIFF
--- a/src/packaging/tags.py
+++ b/src/packaging/tags.py
@@ -448,7 +448,7 @@ def cpython_tags(
         except ValueError:  # noqa: PERF203
             pass
 
-    platforms = list(platforms or platform_tags())
+    platforms = list(platform_tags() if platforms is None else platforms)
     for abi in abis:
         for platform_ in platforms:
             yield Tag(interpreter, abi, platform_)
@@ -555,7 +555,7 @@ def generic_tags(
         interp_version = interpreter_version(warn=warn)
         interpreter = f"{interp_name}{interp_version}"
     abis = _generic_abi() if abis is None else list(abis)
-    platforms = list(platforms or platform_tags())
+    platforms = list(platform_tags() if platforms is None else platforms)
     if "none" not in abis:
         abis.append("none")
     for abi in abis:
@@ -629,7 +629,7 @@ def compatible_tags(
     """
     if not python_version:
         python_version = sys.version_info[:2]
-    platforms = list(platforms or platform_tags())
+    platforms = list(platform_tags() if platforms is None else platforms)
     for version in _py_interpreter_range(python_version):
         for platform_ in platforms:
             yield Tag(version, "none", platform_)

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -1298,6 +1298,9 @@ class TestCPythonTags:
         result = list(tags.cpython_tags((3, 11), abis=["whatever"]))
         assert tags.Tag("cp311", "whatever", "plat1") in result
 
+    def test_empty_platforms(self) -> None:
+        assert list(tags.cpython_tags((3, 11), abis=["whatever"], platforms=[])) == []
+
     def test_platform_name_space_normalization(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -1508,6 +1511,10 @@ class TestGenericTags:
         result = list(tags.generic_tags(interpreter="sillywalk", abis=["none"]))
         assert result == [tags.Tag("sillywalk", "none", "plat")]
 
+    def test_empty_platforms(self) -> None:
+        result = list(tags.generic_tags("sillywalk", ["abi"], []))
+        assert result == []
+
 
 class TestPurePythonTags:
     def test_python_version(self) -> None:
@@ -1564,6 +1571,13 @@ class TestCompatibleTags:
             tags.Tag("py32", "none", "any"),
             tags.Tag("py31", "none", "any"),
             tags.Tag("py30", "none", "any"),
+        ]
+
+    def test_empty_platforms(self) -> None:
+        result = list(tags.compatible_tags((3,), "cp3", []))
+        assert result == [
+            tags.Tag("cp3", "none", "any"),
+            tags.Tag("py3", "none", "any"),
         ]
 
     def test_all_args_needs_underscore(self) -> None:


### PR DESCRIPTION
Passing `platforms=[]` currently falls through `platforms or platform_tags()` in the three public tag generators. That silently substitutes the running host's platform tags, while an equivalent empty iterator remains empty.

Distinguish an omitted `None` from an explicitly empty iterable in `cpython_tags()`, `generic_tags()`, and `compatible_tags()`. Focused regressions cover each generator, including the universal `*-none-any` tags that `compatible_tags()` should still return.

Tests: `PYTHONPATH=src uv run --no-project --with 'pytest>=6.2' --with pretend --with hypothesis python -m pytest -q tests/test_tags.py` (237 passed).
