### PR TITLE
ci(downstream): bump hatchling to 1.31.0 and fix hatchling's rootdir

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -186,7 +186,7 @@ PROJECTS = {
         pytest_args=("unit_test",),
     ),
     "hatchling": Project(
-        "https://github.com/pypa/hatch/archive/refs/tags/hatchling-v1.30.1.tar.gz",
+        "https://github.com/pypa/hatch/archive/refs/tags/hatchling-v1.31.0.tar.gz",
         # hatchling lives in the hatch monorepo; its backend tests rely on the
         # full hatch package and its fixtures.
         install=(
@@ -197,13 +197,16 @@ PROJECTS = {
             "filelock",
             "editables",
         ),
-        install_env={"SETUPTOOLS_SCM_PRETEND_VERSION": "1.30.1"},
+        install_env={"SETUPTOOLS_SCM_PRETEND_VERSION": "1.31.0"},
         # test_binary downloads a PyApp binary over the network.
         # See https://github.com/pypa/hatch/issues/2319.
+        # hatchling ships no pytest config, so from nox's tmp dir inside this
+        # checkout pytest makes packaging's own directory the rootdir. Node IDs
+        # then carry a .nox/... prefix, which silently breaks --deselect.
         pytest_args=(
             "tests/backend",
+            "--rootdir=.",
             "--ignore=tests/backend/builders/test_binary.py",
-            "--deselect=tests/backend/builders/test_wheel.py::TestBuildStandard::test_default_shared_scripts",
         ),
     ),
     "tox": Project(


### PR DESCRIPTION
hatchling 1.31.0 fixed the flaky test.

In investigating the CI flake, Claude found that we never applied our exclusion,
since hatchling has no pytest config, it walks up and find ours. Added a rootdir to pin the correct paths (our warnings and such still leak in).

Assisted-by: ClaudeCode:claude-opus-5
