### PR TITLE
fix(pylock): respect explicitly empty environments in select()

### DIFF
--- a/src/packaging/pylock.py
+++ b/src/packaging/pylock.py
@@ -836,7 +836,7 @@ class Pylock:
         # #. If :ref:`pylock-environments` is specified, check that at least one of the
         #    environment marker expressions is satisfied; an error MUST be raised if no
         #    expression is satisfied.
-        if self.environments:
+        if self.environments is not None:
             for env_marker in self.environments:
                 if env_marker.evaluate(
                     cast("dict[str, str]", environment or {}), context="requirement"

--- a/tests/test_pylock_select.py
+++ b/tests/test_pylock_select.py
@@ -70,11 +70,15 @@ def test_smoke_test() -> None:
         assert isinstance(dist, PackageWheel)
 
 
-def test_lock_no_matching_env() -> None:
+@pytest.mark.parametrize(
+    "environments",
+    [[], [Marker('python_version == "3.14"')]],
+)
+def test_lock_no_matching_env(environments: list[Marker]) -> None:
     pylock = Pylock(
         lock_version=Version("1.0"),
         created_by="some_tool",
-        environments=[Marker('python_version == "3.14"')],
+        environments=environments,
         packages=[],
     )
     pylock.validate()
@@ -91,6 +95,22 @@ def test_lock_no_matching_env() -> None:
                 environment=_py312_linux.environment,
             )
         )
+
+
+def test_lock_without_environments() -> None:
+    pylock = Pylock(
+        lock_version=Version("1.0"),
+        created_by="some_tool",
+        environments=None,
+        packages=[],
+    )
+    pylock.validate()
+    assert not list(
+        pylock.select(
+            tags=_py312_linux.tags,
+            environment=_py312_linux.environment,
+        )
+    )
 
 
 def test_lock_require_python_mismatch() -> None:


### PR DESCRIPTION
`Pylock.select()` currently treats an explicitly empty `environments` sequence like an omitted one and skips environment validation. This lets selection continue even though the lock declares no supported environment.

This distinguishes `None` from an empty sequence. An empty sequence now reaches the existing loop `else` and raises `PylockSelectError`, while an omitted `environments` field remains unrestricted.

Tests: `PYTHONPATH=src pytest tests/test_pylock_select.py -q` (29 passed); full suite (62,424 passed, 1 skipped, 427 deselected).
