### PR TITLE
refactor(tags): use match statement for platform dispatch

### DIFF
--- a/src/packaging/tags.py
+++ b/src/packaging/tags.py
@@ -913,18 +913,19 @@ def platform_tags() -> Iterator[str]:
 
     .. versionadded:: 21.1
     """
-    if platform.system() == "Darwin":
-        return mac_platforms()
-    elif platform.system() == "iOS":
-        return ios_platforms()
-    elif platform.system() == "Android":
-        return android_platforms()
-    elif platform.system() == "Linux":
-        return _linux_platforms()
-    elif platform.system() == "Emscripten":
-        return _emscripten_platforms()
-    else:
-        return _generic_platforms()
+    match platform.system():
+        case "Darwin":
+            return mac_platforms()
+        case "iOS":
+            return ios_platforms()
+        case "Android":
+            return android_platforms()
+        case "Linux":
+            return _linux_platforms()
+        case "Emscripten":
+            return _emscripten_platforms()
+        case _:
+            return _generic_platforms()
 
 
 def interpreter_name() -> str:


### PR DESCRIPTION
I did a drop with Fable to compare with #1354 (#1263), and it found this modernization, which also potentially drops the number of calls to `platform.system()` (~~an expensive function~~, edit, it's cached, but this is still conceptually cleaner), now it's always one call.

Assisted-by: ClaudeCode:claude-fable-5
