### PR TITLE
refactor: add slots=True to frozen dataclasses

### DIFF
--- a/src/packaging/direct_url.py
+++ b/src/packaging/direct_url.py
@@ -152,7 +152,7 @@ class _DirectUrlRequiredKeyError(DirectUrlValidationError):
         super().__init__("Missing required value", context=key)
 
 
-@dataclasses.dataclass(frozen=True, init=False)
+@dataclasses.dataclass(frozen=True, init=False, slots=True)
 class VcsInfo:
     """The version control information of a :class:`DirectUrl`."""
 
@@ -181,7 +181,7 @@ class VcsInfo:
         )
 
 
-@dataclasses.dataclass(frozen=True, init=False)
+@dataclasses.dataclass(frozen=True, init=False, slots=True)
 class ArchiveInfo:
     """The archive information of a :class:`DirectUrl`."""
 
@@ -229,7 +229,7 @@ class ArchiveInfo:
         return cls(hashes=hashes)
 
 
-@dataclasses.dataclass(frozen=True, init=False)
+@dataclasses.dataclass(frozen=True, init=False, slots=True)
 class DirInfo:
     """The local directory information of a :class:`DirectUrl`."""
 
@@ -249,7 +249,7 @@ class DirInfo:
         )
 
 
-@dataclasses.dataclass(frozen=True, init=False)
+@dataclasses.dataclass(frozen=True, init=False, slots=True)
 class DirectUrl:
     """A class representing a direct URL.
 

--- a/src/packaging/pylock.py
+++ b/src/packaging/pylock.py
@@ -321,7 +321,7 @@ class PylockSelectError(Exception):
     """
 
 
-@dataclass(frozen=True, init=False)
+@dataclass(frozen=True, init=False, slots=True)
 class PackageVcs:
     type: str
     url: str | None = None
@@ -362,7 +362,7 @@ class PackageVcs:
         return package_vcs
 
 
-@dataclass(frozen=True, init=False)
+@dataclass(frozen=True, init=False, slots=True)
 class PackageDirectory:
     path: str
     editable: bool | None = None
@@ -389,7 +389,7 @@ class PackageDirectory:
         )
 
 
-@dataclass(frozen=True, init=False)
+@dataclass(frozen=True, init=False, slots=True)
 class PackageArchive:
     url: str | None = None
     path: str | None = None
@@ -430,7 +430,7 @@ class PackageArchive:
         return package_archive
 
 
-@dataclass(frozen=True, init=False)
+@dataclass(frozen=True, init=False, slots=True)
 class PackageSdist:
     name: str | None = None
     upload_time: datetime | None = None
@@ -482,7 +482,7 @@ class PackageSdist:
         return filename
 
 
-@dataclass(frozen=True, init=False)
+@dataclass(frozen=True, init=False, slots=True)
 class PackageWheel:
     name: str | None = None
     upload_time: datetime | None = None
@@ -531,7 +531,7 @@ class PackageWheel:
         return filename
 
 
-@dataclass(frozen=True, init=False)
+@dataclass(frozen=True, init=False, slots=True)
 class Package:
     name: NormalizedName
     version: Version | None = None
@@ -665,7 +665,7 @@ class Package:
         return not (self.sdist or self.wheels)
 
 
-@dataclass(frozen=True, init=False)
+@dataclass(frozen=True, init=False, slots=True)
 class Pylock:
     """A class representing a pylock file."""
 


### PR DESCRIPTION
This is also a followup to #1263 / #1354 (see #1365), slots can now be used on dataclasses.

Assisted-by: ClaudeCode:claude-fable-5
