### PR TITLE
refactor: use dataclass slots=True instead of manual __slots__

### DIFF
--- a/src/packaging/_tokenizer.py
+++ b/src/packaging/_tokenizer.py
@@ -11,10 +11,8 @@ if TYPE_CHECKING:
     from collections.abc import Generator, Mapping
 
 
-@dataclass
+@dataclass(slots=True)
 class Token:
-    __slots__ = ("name", "position", "text")
-
     name: str
     text: str
     position: int

--- a/src/packaging/errors.py
+++ b/src/packaging/errors.py
@@ -34,7 +34,7 @@ else:  # pragma: no cover
             return f"{self.__class__.__name__}({self.message!r}, {self.exceptions!r})"
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(slots=True)
 class _ErrorCollector:
     """
     Collect errors into ExceptionGroups.


### PR DESCRIPTION
Some more `slots=True` usages.

Assisted-by: ClaudeCode:claude-fable-5
