### PR TITLE
refactor(parser): replace the last typing.Union with PEP 604 syntax

### DIFF
--- a/src/packaging/_parser.py
+++ b/src/packaging/_parser.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import ast
 from collections.abc import Sequence
-from typing import Literal, NamedTuple, Union
+from typing import Literal, NamedTuple, TypeAlias
 
 from ._tokenizer import DEFAULT_RULES, ParserSyntaxError, Tokenizer
 
@@ -89,7 +89,7 @@ MarkerLogical = Literal["and", "or"]
 MarkerVar = Variable | Value
 MarkerItem = tuple[MarkerVar, Op, MarkerVar]
 MarkerAtom = MarkerItem | Sequence["MarkerAtom"]
-MarkerList = list[Union["MarkerList", MarkerAtom, MarkerLogical]]
+MarkerList: TypeAlias = 'list["MarkerList" | MarkerAtom | MarkerLogical]'
 
 
 class ParsedRequirement(NamedTuple):

--- a/src/packaging/markers.py
+++ b/src/packaging/markers.py
@@ -412,7 +412,7 @@ class Marker:
         try:
             self._markers = _normalize_extra_values(_parse_marker(marker))
             # The attribute `_markers` can be described in terms of a recursive type:
-            # MarkerList = List[Union[Tuple[Node, ...], str, MarkerList]]
+            # MarkerList = list[tuple[Node, ...] | str | MarkerList]
             #
             # For example, the following expression:
             # python_version > "3.6" or (python_version == "3.6" and os_name == "unix")


### PR DESCRIPTION
A few missed updates for TypeAlias.

Assisted-by: ClaudeCode:claude-fable-5
