### PR TITLE
Handle empty import_namespaces like import_names in metadata round-trip

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,11 @@ Changelog
 *unreleased*
 ~~~~~~~~~~~~
 
+Fixes:
+
+* Preserve an empty ``import_namespaces`` list through the metadata
+  serialize/parse round-trip, matching ``import_names``. (:pull:`1373`)
+
 Removals:
 
 * Drop support for EOL Python 3.9. (:pull:`1263`)

--- a/src/packaging/metadata.py
+++ b/src/packaging/metadata.py
@@ -472,10 +472,10 @@ def parse_email(data: bytes | str) -> tuple[RawMetadata, dict[str, list[str]]]:
         # of unparsed stuff.
         if raw_name in _STRING_FIELDS and len(value) == 1:
             raw[raw_name] = value[0]
-        # If this is import_names, we need to special case the empty field
-        # case, which converts to an empty list instead of None. We can't let
-        # the empty case slip through, as it will fail validation.
-        elif raw_name == "import_names" and value == [""]:
+        # If this is import_names or import_namespaces, we need to special case
+        # the empty field, which converts to an empty list instead of None. We
+        # can't let the empty case slip through, as it will fail validation.
+        elif raw_name in {"import_names", "import_namespaces"} and value == [""]:
             raw[raw_name] = []
         # If this is one of our list of string fields, then we can just assign
         # the value, since email *only* has strings, and our get_all() call
@@ -1042,7 +1042,10 @@ class Metadata:
                             message[email_name] = f"{label}, {url}"
                     elif email_name == "keywords":
                         message[email_name] = ",".join(value)
-                    elif email_name == "import-name" and value == []:
+                    elif (
+                        email_name in {"import-name", "import-namespace"}
+                        and value == []
+                    ):
                         message[email_name] = ""
                     elif isinstance(value, list):
                         for item in value:

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1374,6 +1374,39 @@ class TestMetadataWriting:
         assert core_metadata.get_payload() is None
 
     @pytest.mark.parametrize(
+        ("raw_field", "email_field"),
+        [
+            ("import_names", "import-name"),
+            ("import_namespaces", "import-namespace"),
+        ],
+    )
+    def test_empty_import_field_round_trip(
+        self, raw_field: str, email_field: str
+    ) -> None:
+        meta = metadata.Metadata.from_raw(
+            {
+                "metadata_version": "2.6",
+                "name": "full_metadata",
+                "version": "3.2.1",
+                raw_field: [],
+            }
+        )
+
+        core_metadata = meta.as_rfc822()
+        assert core_metadata.items() == [
+            ("metadata-version", "2.6"),
+            ("name", "full_metadata"),
+            ("version", "3.2.1"),
+            (email_field, ""),
+        ]
+
+        # The empty list must survive a serialize/parse round-trip rather than
+        # silently becoming ``None``.
+        raw, unparsed = metadata.parse_email(core_metadata.as_string())
+        assert not unparsed
+        assert raw[raw_field] == []
+
+    @pytest.mark.parametrize(
         ("items", "data"),
         [
             pytest.param(


### PR DESCRIPTION
`import_names` and `import_namespaces` (both added in Metadata 2.5 / PEP 794) share a processor and are validated the same way, but only `import_names` special-cases the empty-list value. `import_namespaces` does not, so on 26.3:

- `Metadata.from_raw({..., "import_namespaces": []})` is accepted, but `as_rfc822()` drops the field entirely, and parsing the output back gives `None` instead of `[]`.
- A bare `Import-Namespace:` header raises `invalid or unparsed metadata` on parse: the value `[""]` reaches `_process_import_names`, where `"".isidentifier()` is false. A bare `Import-Name:` parses to `[]`.

Both special cases (`[""]` -> `[]` on parse, `[]` -> `""` on write) were added for `import_names` in e83801f (#948), the commit that introduced both fields, and weren't mirrored to `import_namespaces`. This extends both branches to cover it and adds a round-trip test parametrized over the two fields.

Reproduced on 26.3:

```pycon
>>> from packaging.metadata import Metadata, parse_email
>>> m = Metadata.from_raw({"metadata_version": "2.5", "name": "x", "version": "1", "import_namespaces": []}, validate=False)
>>> print(parse_email(m.as_rfc822().as_string())[0].get("import_namespaces"))
None
>>> # the same input with import_names gives []
```
