### PR TITLE
Escape backslashes when serializing marker values

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,11 @@ Removals:
 
 * Drop support for EOL Python 3.9. (:pull:`1263`)
 
+Fixes:
+
+* Escape backslashes when serializing a marker value so a value containing one
+  survives a ``str()`` round trip. (:pull:`1374`)
+
 26.3 - 2026-08-03
 ~~~~~~~~~~~~~~~~~
 

--- a/src/packaging/_parser.py
+++ b/src/packaging/_parser.py
@@ -69,10 +69,15 @@ class Value(Node):
 
     def serialize(self) -> str:
         value = str(self)
+        # ``process_python_str`` reads a value back with ``ast.literal_eval``,
+        # which decodes backslash escapes. Double the backslashes so a value
+        # that contains one survives the round trip instead of being re-decoded
+        # (e.g. ``C:\temp`` would otherwise reparse to ``C:<TAB>emp``).
+        escaped = value.replace("\\", "\\\\")
         if '"' not in value:
-            return f'"{value}"'
+            return f'"{escaped}"'
         if "'" not in value:
-            return f"'{value}'"
+            return f"'{escaped}'"
         raise ValueError(
             "Cannot serialize marker value containing both quote characters"
         )

--- a/tests/test_markers.py
+++ b/tests/test_markers.py
@@ -99,6 +99,36 @@ class TestNode:
         ):
             Value("a\"b'c").serialize()
 
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            ("a\\b", '"a\\\\b"'),
+            ("C:\\temp", '"C:\\\\temp"'),
+            ('a"b\\c', "'a\"b\\\\c'"),
+        ],
+    )
+    def test_value_serialize_escapes_backslash(self, value: str, expected: str) -> None:
+        # process_python_str reads values back with ast.literal_eval, so a
+        # backslash must be doubled on the way out or it gets re-decoded.
+        assert Value(value).serialize() == expected
+
+
+@pytest.mark.parametrize(
+    ("marker_str", "value"),
+    [
+        (r'os_name == "a\\b"', "a\\b"),
+        (r'os_name == "C:\\temp"', "C:\\temp"),
+        (r'os_name == "\\\\host\\share"', "\\\\host\\share"),
+    ],
+)
+def test_marker_with_backslash_value_round_trips(marker_str: str, value: str) -> None:
+    marker = Marker(marker_str)
+    # the value keeps its literal backslash(es) after parsing
+    assert marker._markers[0][2].value == value  # type: ignore[union-attr]
+    # str(marker) must reparse to an equal marker rather than re-decoding the
+    # backslash (e.g. "C:\\temp" -> str -> "C:<TAB>emp").
+    assert Marker(str(marker)) == marker
+
 
 class TestOperatorEvaluation:
     def test_prefers_pep440(self) -> None:

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -191,6 +191,14 @@ def test_requirement_marker_with_embedded_double_quote_round_trips() -> None:
     assert round_tripped_marker.evaluate() is False
 
 
+def test_requirement_marker_with_backslash_value_round_trips() -> None:
+    # A marker value with a backslash must survive serialization; otherwise
+    # str() re-decodes it (e.g. "C:\\temp" -> "C:<TAB>emp") and the requirement
+    # compares unequal to itself after a round trip.
+    req = Requirement(r'demo; os_name == "C:\\temp"')
+    assert Requirement(str(req)) == req
+
+
 class TestRequirementParsing:
     @pytest.mark.parametrize(
         "marker",


### PR DESCRIPTION
Marker and requirement values are read back with `ast.literal_eval` (in `_parser.process_python_str`), which decodes backslash escapes. `Value.serialize` re-wraps the decoded value in quotes but doesn't re-escape it, so a value containing a backslash doesn't survive a `str()` round trip:

```pycon
>>> from packaging.markers import Marker
>>> m = Marker(r'os_name == "C:\\temp"')   # value is C:\temp
>>> str(m)
'os_name == "C:\\temp"'                     # single, unescaped backslash
>>> Marker(str(m)) == m
False                                        # reparses \t as a tab -> C:<TAB>emp
```

Same for `Requirement`:

```pycon
>>> from packaging.requirements import Requirement
>>> r = Requirement(r'demo; os_name == "C:\\temp"')
>>> Requirement(str(r)) == r
False
```

`serialize` is the inverse of the `ast.literal_eval` parser, so it has to escape everything the parser decodes. This is the backslash counterpart of the quote round trip fixed in #1213; the fix doubles backslashes before quoting and leaves the quote-delimiter selection alone.

Added regression tests for `Value.serialize` and for the `Marker`/`Requirement` round trip. Both fail before this change and pass after.
