### PR TITLE
pylock: validate default-groups

### DIFF
--- a/src/packaging/pylock.py
+++ b/src/packaging/pylock.py
@@ -584,6 +584,16 @@ class Pylock:
             _logger.warning(
                 "pylock minor version %s is not supported", pylock.lock_version
             )
+        if pylock.default_groups:
+            invalid_default_groups = set(pylock.default_groups) - set(
+                pylock.dependency_groups or []
+            )
+            if invalid_default_groups:
+                raise PylockValidationError(
+                    f"The following members of 'default-groups' "
+                    f"are not declared in 'dependency-groups': "
+                    f"{', '.join(sorted(invalid_default_groups))}"
+                )
         return pylock
 
     @classmethod

--- a/tests/test_pylock.py
+++ b/tests/test_pylock.py
@@ -901,3 +901,34 @@ def test_validate_attestation_identity_invalid_kind() -> None:
         "Unexpected type int (expected str) "
         "in 'packages[0].attestation-identities[0].kind'"
     )
+
+
+@pytest.mark.parametrize(
+    ("default_groups", "dependency_groups", "expected"),
+    [
+        (["g"], None, "g"),
+        (["f", "g"], None, "f, g"),
+        (["f", "g"], [], "f, g"),
+        (["f", "g"], ["h"], "f, g"),
+        (["f", "g"], ["f", "h"], "g"),
+        (["g"], ["h"], "g"),
+    ],
+)
+def test_invalid_default_groups(
+    default_groups: list[str] | None,
+    dependency_groups: list[str] | None,
+    expected: str,
+) -> None:
+    data = {
+        "lock-version": "1.0",
+        "created-by": "pip",
+        "default-groups": default_groups,
+        "dependency-groups": dependency_groups,
+        "packages": [],
+    }
+    with pytest.raises(PylockValidationError) as exc_info:
+        Pylock.from_dict(data)
+    assert str(exc_info.value) == (
+        f"The following members of 'default-groups' "
+        f"are not declared in 'dependency-groups': {expected}"
+    )


### PR DESCRIPTION
Validate that members of 'default-groups' are part of 'dependency-groups'.