### PR TITLE
pylock.select: fail on unknown extras and dependency groups

### DIFF
--- a/src/packaging/pylock.py
+++ b/src/packaging/pylock.py
@@ -653,34 +653,29 @@ class Pylock:
             Raise :class:`PylockSelectError` if passed extras or dependency groups
             that are not declared in the corresponding pylock fields.
         """
-        if extras:
-            unknown_extras = {canonicalize_name(extra) for extra in extras} - set(
-                self.extras or []
+        canonical_extras = {canonicalize_name(extra) for extra in extras or ()}
+        unknown_extras = canonical_extras - set(self.extras or ())
+        if unknown_extras:
+            raise PylockSelectError(
+                f"Undeclared extras: {', '.join(sorted(unknown_extras))}"
             )
-            if unknown_extras:
-                raise PylockSelectError(
-                    f"Undeclared extras: {', '.join(sorted(unknown_extras))}"
-                )
 
-        if dependency_groups:
-            unknown_dependency_groups = {
-                canonicalize_name(dependency_group)
-                for dependency_group in dependency_groups
-            } - (
-                {
-                    canonicalize_name(dependency_group)
-                    for dependency_group in self.dependency_groups or []
-                }
-                | {
-                    canonicalize_name(dependency_group)
-                    for dependency_group in self.default_groups or []
-                }
+        canonical_dependency_groups = {
+            canonicalize_name(dependency_group)
+            for dependency_group in dependency_groups or ()
+        }
+        unknown_dependency_groups = canonical_dependency_groups - {
+            canonicalize_name(dependency_group)
+            for dependency_group in [
+                *(self.dependency_groups or ()),
+                *(self.default_groups or ()),
+            ]
+        }
+        if unknown_dependency_groups:
+            raise PylockSelectError(
+                f"Undeclared dependency groups: "
+                f"{', '.join(sorted(unknown_dependency_groups))}"
             )
-            if unknown_dependency_groups:
-                raise PylockSelectError(
-                    f"Undeclared dependency groups: "
-                    f"{', '.join(sorted(unknown_dependency_groups))}"
-                )
 
         compatible_tags_selector = create_compatible_tags_selector(
             tags if tags is not None else sys_tags()
@@ -696,11 +691,11 @@ class Pylock:
             "dict[str, str | frozenset[str]]",
             dict(
                 environment or {},  # Marker.evaluate will fill-up
-                extras=frozenset(extras or []),
+                extras=frozenset(canonical_extras),
                 dependency_groups=frozenset(
                     (self.default_groups or [])
                     if dependency_groups is None  # to allow selecting no group
-                    else dependency_groups
+                    else canonical_dependency_groups
                 ),
             ),
         )

--- a/src/packaging/pylock.py
+++ b/src/packaging/pylock.py
@@ -25,6 +25,7 @@ from .specifiers import SpecifierSet
 from .tags import create_compatible_tags_selector, sys_tags
 from .utils import (
     NormalizedName,
+    canonicalize_name,
     is_normalized_name,
     parse_sdist_filename,
     parse_wheel_filename,
@@ -647,7 +648,34 @@ class Pylock:
 
         .. versionchanged:: 26.3
             Added the *prefer_sdist_predicate* parameter.
+
+        .. versionchanged:: 26.4
+            Raise :class:`PylockSelectError` if passed extras or dependency groups
+            that are not declared in the corresponding pylock fields.
         """
+        if extras:
+            unknown_extras = {canonicalize_name(extra) for extra in extras} - set(
+                self.extras or []
+            )
+            if unknown_extras:
+                raise PylockSelectError(
+                    f"Undeclared extras: {', '.join(sorted(unknown_extras))}"
+                )
+
+        if dependency_groups:
+            unknown_dependency_groups = {
+                canonicalize_name(dependency_group)
+                for dependency_group in dependency_groups
+            } - {
+                canonicalize_name(dependency_group)
+                for dependency_group in self.dependency_groups or []
+            }
+            if unknown_dependency_groups:
+                raise PylockSelectError(
+                    f"Undeclared dependency groups: "
+                    f"{', '.join(sorted(unknown_dependency_groups))}"
+                )
+
         compatible_tags_selector = create_compatible_tags_selector(
             tags if tags is not None else sys_tags()
         )

--- a/src/packaging/pylock.py
+++ b/src/packaging/pylock.py
@@ -666,10 +666,16 @@ class Pylock:
             unknown_dependency_groups = {
                 canonicalize_name(dependency_group)
                 for dependency_group in dependency_groups
-            } - {
-                canonicalize_name(dependency_group)
-                for dependency_group in self.dependency_groups or []
-            }
+            } - (
+                {
+                    canonicalize_name(dependency_group)
+                    for dependency_group in self.dependency_groups or []
+                }
+                | {
+                    canonicalize_name(dependency_group)
+                    for dependency_group in self.default_groups or []
+                }
+            )
             if unknown_dependency_groups:
                 raise PylockSelectError(
                     f"Undeclared dependency groups: "

--- a/tests/test_pylock_select.py
+++ b/tests/test_pylock_select.py
@@ -518,3 +518,29 @@ def test_python_prerelease() -> None:
     env = default_environment()
     env["python_full_version"] = "3.15.0a8+"
     list(pylock.select(environment=env))
+
+
+def test_unknown_extras() -> None:
+    pylock = Pylock(
+        lock_version=Version("1.0"),
+        created_by="some_tool",
+        extras=cast("list[NormalizedName]", ["x1", "x2"]),
+        packages=[],
+    )
+    pylock.validate()
+    with pytest.raises(PylockSelectError, match=r"Undeclared extras: x3, x4"):
+        list(pylock.select(extras=["X1", "x3", "x4"]))
+
+
+def test_unknown_groups() -> None:
+    pylock = Pylock(
+        lock_version=Version("1.0"),
+        created_by="some_tool",
+        dependency_groups=["g1", "g2"],
+        packages=[],
+    )
+    pylock.validate()
+    with pytest.raises(
+        PylockSelectError, match=r"Undeclared dependency groups: g3, g4"
+    ):
+        list(pylock.select(dependency_groups=["G1", "g3", "g4"]))

--- a/tests/test_pylock_select.py
+++ b/tests/test_pylock_select.py
@@ -544,3 +544,18 @@ def test_unknown_groups() -> None:
         PylockSelectError, match=r"Undeclared dependency groups: g3, g4"
     ):
         list(pylock.select(dependency_groups=["G1", "g3", "g4"]))
+
+
+def test_unknown_groups_default_groups() -> None:
+    pylock = Pylock(
+        lock_version=Version("1.0"),
+        created_by="some_tool",
+        dependency_groups=["g1", "g2"],
+        default_groups=["dg1", "dg2"],
+        packages=[],
+    )
+    pylock.validate()
+    with pytest.raises(
+        PylockSelectError, match=r"Undeclared dependency groups: g3, g4"
+    ):
+        list(pylock.select(dependency_groups=["G1", "DG1", "g3", "g4"]))


### PR DESCRIPTION
With this PR, `Pylock.select()` now fails when provided `extras` or `dependency_groups` that are not declared in the lock file.

Strictly speaking this is a breaking change, since before it would silently skip packages.
However the API is young, and I feel that the current behaviour is surprising, so I propose this change.

Consumers that wish to ignore instead of failing can easily pre-filter (and likely warn their users in such cases).

Alternatives are enabling this new check with a flag, or doing nothing and leave such validation to consumers.