### PR TITLE
feat(requirements): add Requirement.__replace__

### DIFF
--- a/docs/requirements.rst
+++ b/docs/requirements.rst
@@ -109,6 +109,10 @@ Reference
         string representation still preserves the parsed name and extras
         spelling.
 
+    .. versionchanged:: 26.4
+
+        Added ``__replace__``, enabling :func:`copy.replace` on Python 3.13+.
+
     :param str requirement_string: The string representation of a requirement.
     :raises InvalidRequirement: If the given ``requirement_string`` is not parseable,
                                 then this exception will be raised.
@@ -132,6 +136,19 @@ Reference
     .. attribute:: marker
 
       A :class:`~.Marker` of the marker for the requirement. Can be None.
+
+    .. method:: __replace__(*, name=..., url=..., extras=..., specifier=..., marker=...)
+
+      Return a copy of the requirement with the given fields replaced. The
+      result is validated and normalized by re-parsing its string form, so an
+      invalid replacement raises :exc:`InvalidRequirement`.
+      This also enables :func:`copy.replace` on Python 3.13+::
+
+          >>> import copy
+          >>> copy.replace(Requirement("requests>=2.0"), name="flask")
+          <Requirement('flask>=2.0')>
+
+      .. versionadded:: 26.4
 
 .. exception:: InvalidRequirement
 

--- a/src/packaging/requirements.py
+++ b/src/packaging/requirements.py
@@ -3,7 +3,9 @@
 # for complete details.
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import builtins
+import sys
+from typing import TYPE_CHECKING, Any
 
 from ._parser import parse_requirement as _parse_requirement
 from ._tokenizer import ParserSyntaxError
@@ -22,6 +24,11 @@ __all__ = [
 
 def __dir__() -> list[str]:
     return __all__
+
+
+# Sentinel for __replace__, typed as Any so it can be the default for any field.
+# mypy is missing sentinel currently
+_UNSET: Any = object() if sys.version_info < (3, 15) else builtins.sentinel("_UNSET")  # type: ignore[attr-defined]
 
 
 class InvalidRequirement(ValueError):
@@ -70,6 +77,10 @@ class Requirement:
         Equality and hashing normalize requirement names, extras, and
         equivalent specifiers. The string representation still preserves the
         parsed name and extras spelling.
+
+    .. versionchanged:: 26.4
+
+        Added ``__replace__``, enabling :func:`copy.replace` on Python 3.13+.
     """
 
     # TODO: Can we test whether something is contained within a requirement?
@@ -96,6 +107,44 @@ class Requirement:
         if parsed.marker is not None:
             self.marker = Marker.__new__(Marker)
             self.marker._markers = _normalize_extra_values(parsed.marker)
+
+    def __replace__(
+        self,
+        *,
+        name: str = _UNSET,
+        url: str | None = _UNSET,
+        extras: set[str] = _UNSET,
+        specifier: SpecifierSet = _UNSET,
+        marker: Marker | None = _UNSET,
+    ) -> Requirement:
+        """Return a copy with the given fields replaced.
+
+        This also enables :func:`copy.replace` on Python 3.13+. The result is
+        validated and normalized by re-parsing its string form, so invalid
+        replacements raise :exc:`InvalidRequirement`.
+
+        .. versionadded:: 26.4
+        """
+        tmp = Requirement.__new__(Requirement)
+        tmp.name = self.name if name is _UNSET else name
+        tmp.url = self.url if url is _UNSET else url or None
+        tmp.extras = self.extras if extras is _UNSET else extras
+        tmp.specifier = self.specifier if specifier is _UNSET else specifier
+        tmp.marker = self.marker if marker is _UNSET else marker
+
+        result = Requirement(str(tmp))
+        # A field that parses as something more than itself (for example
+        # ``name="foo[bar]"``) would silently change other fields; reject it.
+        if (
+            result.name != tmp.name
+            or result.url != tmp.url
+            or result.extras != tmp.extras
+        ):
+            raise InvalidRequirement(
+                f"Replacement fields do not round-trip: {str(tmp)!r}"
+            )
+        result.specifier._prereleases = tmp.specifier._prereleases
+        return result
 
     def _iter_parts(self, name: str) -> Iterator[str]:
         yield name

--- a/src/packaging/requirements.py
+++ b/src/packaging/requirements.py
@@ -16,6 +16,8 @@ from .utils import canonicalize_name
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
+    from typing_extensions import Self
+
 __all__ = [
     "InvalidRequirement",
     "Requirement",
@@ -116,7 +118,7 @@ class Requirement:
         extras: set[str] = _UNSET,
         specifier: SpecifierSet = _UNSET,
         marker: Marker | None = _UNSET,
-    ) -> Requirement:
+    ) -> Self:
         """Return a copy with the given fields replaced.
 
         This also enables :func:`copy.replace` on Python 3.13+. The result is
@@ -125,14 +127,14 @@ class Requirement:
 
         .. versionadded:: 26.4
         """
-        tmp = Requirement.__new__(Requirement)
+        tmp = self.__class__.__new__(self.__class__)
         tmp.name = self.name if name is _UNSET else name
         tmp.url = self.url if url is _UNSET else url or None
         tmp.extras = self.extras if extras is _UNSET else extras
         tmp.specifier = self.specifier if specifier is _UNSET else specifier
         tmp.marker = self.marker if marker is _UNSET else marker
 
-        result = Requirement(str(tmp))
+        result = self.__class__(str(tmp))
         # A field that parses as something more than itself (for example
         # ``name="foo[bar]"``) would silently change other fields; reject it.
         if (

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -4,7 +4,9 @@
 
 from __future__ import annotations
 
+import copy
 import pickle
+import sys
 
 import pytest
 
@@ -1051,3 +1053,52 @@ def test_pickle_requirement_25_0_format_loads() -> None:
     assert str(r.specifier) == ">=2.0"
     assert r.marker is None
     assert r == Requirement("requests>=2.0")
+
+
+def test_replace() -> None:
+    r = Requirement('requests[security]>=2.0; python_version >= "3"')
+    r2 = r.__replace__(name="flask")
+    assert r2.name == "flask"
+    assert r2.extras == r.extras
+    assert r2.specifier == r.specifier
+    assert r2.marker == r.marker
+    # The original is untouched.
+    assert r.name == "requests"
+    # A URL requirement may not keep a version specifier, so clear it.
+    r_url = r.__replace__(url="https://example.com/flask.zip", specifier=SpecifierSet())
+    assert r_url.url == "https://example.com/flask.zip"
+    assert not r_url.specifier
+    # No changes gives an equal but distinct instance.
+    r3 = r.__replace__()
+    assert r3 == r
+    assert r3 is not r
+    with pytest.raises(TypeError):
+        r.__replace__(nonexistent=1)  # type: ignore[call-arg]
+
+
+def test_replace_validates_and_normalizes() -> None:
+    r = Requirement("requests>=2.0")
+    # Invalid fields are rejected by the parser round-trip.
+    with pytest.raises(InvalidRequirement):
+        r.__replace__(name="not a name!")
+    # A field that would smuggle in extra syntax is rejected too.
+    with pytest.raises(InvalidRequirement):
+        r.__replace__(name="foo[bar]")
+    with pytest.raises(InvalidRequirement):
+        r.__replace__(extras={"a,b"})
+    # Marker extras are normalized like they are when parsing.
+    r2 = r.__replace__(marker=Marker('extra == "Foo_Bar"'))
+    assert str(r2.marker) == 'extra == "foo-bar"'
+    # An explicit prereleases override on the specifier is preserved.
+    r3 = r.__replace__(specifier=SpecifierSet(">=2.0", prereleases=True))
+    assert r3.specifier.prereleases is True
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 13), reason="copy.replace() requires Python 3.13"
+)
+def test_copy_replace() -> None:
+    r = Requirement("requests>=2.0")
+    r2 = copy.replace(r, specifier=SpecifierSet(">=3.0"))  # type: ignore[attr-defined]
+    assert str(r2) == "requests>=3.0"
+    assert str(r) == "requests>=2.0"

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -1094,6 +1094,14 @@ def test_replace_validates_and_normalizes() -> None:
     assert r3.specifier.prereleases is True
 
 
+def test_replace_keeps_subclass() -> None:
+    class MyRequirement(Requirement):
+        pass
+
+    r = MyRequirement("requests>=2.0").__replace__(name="flask")
+    assert type(r) is MyRequirement
+
+
 @pytest.mark.skipif(
     sys.version_info < (3, 13), reason="copy.replace() requires Python 3.13"
 )


### PR DESCRIPTION
Let's start by providing a nice way to do this, then we can (maybe) deprecate in the future. Quite a few projects are mutating this.

---


<details><summary>Previous (available on a branch requirement-replace-and-deprecate in my fork for the future):</summary>
<p>
 
This was proposed in #1252. This assumes we want a deprecation period.

This enables caching `__hash__`, and `__hash__` was always broken if you mutated this class
while it was in a set or similar.

Added support for `__replace__` as an alternative if anyone was trying to mutate these.

Mutating the `extras` set inside doesn't warn. We should swap it for a frozenset when making this immutable.

</p>
</details> 

Assisted-by: ClaudeCode:claude-fable-5
