### PR TITLE
fix(parser): reject whitespace in the URL token

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,12 @@ Removals:
 
 * Drop support for EOL Python 3.9. (:pull:`1263`)
 
+Fixes for requirements and markers:
+
+* Reject embedded whitespace in the URL of a direct-reference requirement, so a
+  newline can no longer split one requirement into two when the parsed result is
+  serialized. (:pull:`1379`)
+
 26.3 - 2026-08-03
 ~~~~~~~~~~~~~~~~~
 

--- a/src/packaging/_tokenizer.py
+++ b/src/packaging/_tokenizer.py
@@ -82,7 +82,7 @@ DEFAULT_RULES: dict[str, re.Pattern[str]] = {
         re.VERBOSE | re.IGNORECASE,
     ),
     "AT": re.compile(r"\@"),
-    "URL": re.compile(r"[^ \t]+"),
+    "URL": re.compile(r"\S+"),
     "IDENTIFIER": re.compile(r"\b[a-zA-Z0-9][a-zA-Z0-9._-]*\b"),
     "VERSION_PREFIX_TRAIL": re.compile(r"\.\*"),
     "VERSION_LOCAL_LABEL_TRAIL": re.compile(r"\+[a-z0-9]+(?:[-_\.][a-z0-9]+)*"),

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -235,6 +235,7 @@ class TestRequirementParsing:
         [
             "name>=1",
             'name; python_version >= "3"',
+            "name @ https://example.com/name.whl",
         ],
     )
     def test_error_when_suffixed_with_line_break(

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -244,6 +244,14 @@ class TestRequirementParsing:
         with pytest.raises(InvalidRequirement):
             Requirement(requirement + line_break)
 
+    @pytest.mark.parametrize("line_break", ["\n", "\r", "\r\n"])
+    def test_error_when_url_embeds_line_break(self, line_break: str) -> None:
+        # A line break inside the URL must not let the remainder be
+        # absorbed into the URL and later serialized as a second
+        # requirement line.
+        with pytest.raises(InvalidRequirement):
+            Requirement(f"name @ https://example.com/name.whl{line_break}evil==1")
+
     @pytest.mark.parametrize("whitespace", [" ", "\t", " \t"])
     def test_trailing_horizontal_whitespace(self, whitespace: str) -> None:
         assert Requirement("name>=1" + whitespace) == Requirement("name>=1")


### PR DESCRIPTION
The URL token in the dependency-specifier tokenizer matches `[^ \t]+`, so it stops at spaces and tabs but keeps going through a newline. A direct-reference requirement like `foo @ https://host/foo.whl\nevil==1` parses without complaint, with the trailing newline and `evil==1` folded into `url`. Calling `str()` on that requirement then prints two lines, so any tool that writes parsed requirements one per line (a requirements file, a generated lockfile) picks up the injected second dependency.

Match the URL token with `\S+` instead, so it ends at any whitespace, in line with RFC 3986 having no whitespace in a URI. The name, extras, and specifier tokens already reject newlines, and marker values go through `ast.literal_eval`, so this just brings the URL branch up to the same footing. Valid URLs never carry whitespace, so parsing of real direct references is unchanged.