### PR TITLE
reject drive-relative license-file paths in metadata validation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,12 @@ Removals:
 
 * Drop support for EOL Python 3.9. (:pull:`1263`)
 
+Fixes for metadata and licenses:
+
+* Reject Windows drive-relative ``License-File`` paths (e.g. ``C:LICENSE``),
+  which are neither absolute nor contain ``..`` yet resolve outside the
+  project root when joined on Windows. (:pull:`1382`)
+
 26.3 - 2026-08-03
 ~~~~~~~~~~~~~~~~~
 

--- a/src/packaging/metadata.py
+++ b/src/packaging/metadata.py
@@ -775,6 +775,7 @@ class _Validator(Generic[T]):
             if (
                 pathlib.PurePosixPath(path).is_absolute()
                 or pathlib.PureWindowsPath(path).is_absolute()
+                or pathlib.PureWindowsPath(path).drive
             ):
                 raise self._invalid_metadata(
                     f"{path!r} is invalid for {self.raw_name!r}, paths must be relative"

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1117,6 +1117,9 @@ class TestMetadata:
             ["licenses/../LICENSE"],
             # Absolute paths are not allowed.
             ["/licenses/LICENSE"],
+            # Windows drive-relative paths escape the project root on join.
+            ["C:LICENSE"],
+            ["d:secrets/key.txt"],
             # Paths must be valid
             # (i.e. glob pattern didn't escape out of pyproject.toml.)
             ["licenses/*"],


### PR DESCRIPTION
`_process_license_files` blocks absolute paths, backslashes, globs, and `..`, but a Windows drive-relative path like `C:LICENSE` or `D:secrets/key.txt` slips through since it has none of those and `pathlib` does not report it as absolute, yet `ntpath.join(project_root, "D:evil.txt")` resolves outside the project root, so reject any path carrying a drive at the same layer that rejects the other escapes.