### PR TITLE
fix(specifiers): scope ~= groups with (?a:...)

### DIFF
--- a/src/packaging/specifiers.py
+++ b/src/packaging/specifiers.py
@@ -292,16 +292,16 @@ class Specifier(BaseSpecifier):
                 v?
                 (?:[0-9]+!)?          # epoch
                 [0-9]+(?:\.[0-9]+)+   # release  (We have a + instead of a *)
-                (?:                   # pre release
+                (?a:                  # pre release
                     [-_\.]?
                     (alpha|beta|preview|pre|a|b|c|rc)
                     [-_\.]?
                     [0-9]*
                 )?
-                (?:                                   # post release
+                (?a:                                  # post release
                     (?:-[0-9]+)|(?:[-_\.]?(post|rev|r)[-_\.]?[0-9]*)
                 )?
-                (?:[-_\.]?dev[-_\.]?[0-9]*)?          # dev release
+                (?a:[-_\.]?dev[-_\.]?[0-9]*)?         # dev release
             )
             |
             (?:

--- a/tests/test_specifiers.py
+++ b/tests/test_specifiers.py
@@ -98,6 +98,9 @@ class TestSpecifier:
             # when re.IGNORECASE is in force and re.ASCII is not (issue #469)
             "==1.2+\u0130",
             "==1.2+\u0130\u0131\u017fK",
+            # Same for the pre/post-release words on the compatible operator
+            "~=1.2.3prev\u0131ew1",
+            "~=1.2.3po\u017ft1",
         ],
     )
     def test_specifiers_invalid(self, specifier: str) -> None:


### PR DESCRIPTION
The `~=` branch is the only one in `Specifier._regex_str` whose pre, post and dev groups are not scoped with `(?a:...)`. Under IGNORECASE without ASCII, ı matches "i", so `~=1.2.3prevıew1` is accepted while `==` and `>=` reject the same operand, and `contains()` then fails on an AssertionError trying to parse it.

Same class of issue as #469, which covered the local segment.
