### PR TITLE
perf(tests): freeze GC after collection

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import gc
 import sysconfig
 import typing
 
@@ -18,6 +19,14 @@ def _clear_default_environment_cache() -> Generator[None, None, None]:
     _cached_default_environment.cache_clear()
     yield
     _cached_default_environment.cache_clear()
+
+
+def pytest_collection_finish() -> None:
+    # Freeze the collected-item tree and imported modules into GC's permanent
+    # generation so per-test GC passes stop traversing them (~10% faster suite).
+    gc.collect()
+    if hasattr(gc, "freeze"):  # CPython-only; missing on PyPy
+        gc.freeze()
 
 
 def pytest_report_header() -> str:


### PR DESCRIPTION
I was exploring optimizations to pytest to speed our test suite up (already got a 10% one merged for next pytest release), and ran into this, which we can do here.

(3.14 isn't listed below, because I did that one elsewhere, but it's also around 10%).

:robot: _AI text below_ :robot:

Call `gc.freeze()` after pytest collection finishes. This moves the collected-item tree and the imported modules into the GC permanent generation, so the per-test collection passes no longer traverse them.

Timings for the full suite, median of 5 alternating runs on this machine:

| Python | before | after | change |
| --- | --- | --- | --- |
| 3.12 | 19.12 s | 17.36 s | -9.2% |
| 3.15 | 19.71 s | 17.44 s | -11.5% |

Every "after" run was faster than every "before" run on both interpreters. The `hasattr` guard keeps this a no-op on PyPy, which has no `gc.freeze`.