### PR TITLE
perf(tests): capture output at the sys level

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,17 @@ exclude_also = [
 
 [tool.pytest.ini_options]
 minversion = "6.2"
-addopts = ["-ra", "--showlocals", "--strict-markers", "--strict-config", "-m", "not property"]
+# --capture=sys avoids per-test fd dup2/lseek syscalls (~20% of the runtime);
+# no test writes to raw file descriptors.
+addopts = [
+    "-ra",
+    "--showlocals",
+    "--strict-markers",
+    "--strict-config",
+    "-m",
+    "not property",
+    "--capture=sys",
+]
 xfail_strict = true
 filterwarnings = ["error"]
 log_level = "INFO"


### PR DESCRIPTION
This does actually side-step the optimization I made to fd capture in pytest, so we don't get a future 10%, but we get more than that right now. :)

We don't take advantage of fd capture anywhere that I know of, or could find.

:robot: _AI text below_ :robot:

Python 3.15's sampling profiler shows pytest's fd-level capture (`FDCapture.snap` and suspend/resume, i.e. per-test `dup2`/`lseek`/`truncate` syscalls) is ~31% of the suite's runtime. `--capture=sys` swaps `sys.stdout`/`sys.stderr` instead, so failure reports still show captured output; only raw file-descriptor writes escape, and no test does those.

Local run: 16.5s -> 13.2s.

One of four independent test-suite speedup PRs from the same profiling session. This one conflicts trivially with the `no:logging` PR (same `addopts` line); whichever merges second needs a rebase.