### PR TITLE
perf(tests): disable the logging plugin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,8 @@ exclude_also = [
 [tool.pytest.ini_options]
 minversion = "6.2"
 # --capture=sys avoids per-test fd dup2/lseek syscalls (~20% of the runtime);
-# no test writes to raw file descriptors.
+# no test writes to raw file descriptors. The logging plugin is disabled since
+# no test uses caplog and its per-test setup is measurable at this test count.
 addopts = [
     "-ra",
     "--showlocals",
@@ -107,10 +108,11 @@ addopts = [
     "-m",
     "not property",
     "--capture=sys",
+    "-p",
+    "no:logging",
 ]
 xfail_strict = true
 filterwarnings = ["error"]
-log_level = "INFO"
 testpaths = ["tests"]
 markers = ["property: property-based tests (opt-in)"]
 


### PR DESCRIPTION
We don't have much logging in packaging, so turning this off saves a nice bit of time on every test run for very little added inconvenience.

:robot: _AI text below_ :robot:

No test uses `caplog`, so the logging plugin's per-test `catching_logs` setup/teardown is pure overhead at 62k tests. `log_level` is removed because it becomes an unknown option under `--strict-config` once the plugin is off. Trade-off: failure reports lose their "captured log" section (`tags.py`/`pylock.py` do emit debug logs).

Local run: 16.5s -> 15.0s.

One of four independent test-suite speedup PRs from the same profiling session (Python 3.15 sampling profiler). Conflicts trivially with the `--capture=sys` PR (#1386, same `addopts` line); whichever merges second needs a rebase.