### PR TITLE
perf(tests): clear the environment cache with hooks, not a fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,22 +2,19 @@ from __future__ import annotations
 
 import gc
 import sysconfig
-import typing
-
-import pytest
 
 from packaging.markers import _cached_default_environment
 
-if typing.TYPE_CHECKING:
-    from collections.abc import Generator
 
-
-@pytest.fixture(autouse=True)
-def _clear_default_environment_cache() -> Generator[None, None, None]:
-    # default_environment() is cached, so tests that patch platform/sys must run
-    # against a fresh cache and must not leak their patched values to later tests.
+# default_environment() is cached, so tests that patch platform/sys must run
+# against a fresh cache and must not leak their patched values to later tests.
+# Plain hooks are used instead of an autouse fixture because instantiating a
+# fixture 62k times costs several percent of the suite's runtime.
+def pytest_runtest_setup() -> None:
     _cached_default_environment.cache_clear()
-    yield
+
+
+def pytest_runtest_teardown() -> None:
     _cached_default_environment.cache_clear()
 
 


### PR DESCRIPTION
Autouse fixtures have a bit of cost associated with them; since we have so many tests, that cost added up.

:robot: _AI text below_ :robot:

The autouse `_clear_default_environment_cache` generator fixture runs through pytest's full fixture instantiation machinery on every one of 62k tests, while its body is two `cache_clear()` calls. Plain `pytest_runtest_setup`/`pytest_runtest_teardown` hooks keep the clear-before-and-after semantics at a fraction of the cost.

Local run: 16.5s -> 15.8s.

One of four independent test-suite speedup PRs from the same profiling session (Python 3.15 sampling profiler).