### PR TITLE
perf(tests): disable GC while collecting tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,9 +21,16 @@ def _clear_default_environment_cache() -> Generator[None, None, None]:
     _cached_default_environment.cache_clear()
 
 
+def pytest_collection() -> None:
+    # Collection allocates millions of long-lived objects; skip GC passes until
+    # the collect-and-freeze below.
+    gc.disable()
+
+
 def pytest_collection_finish() -> None:
     # Freeze the collected-item tree and imported modules into GC's permanent
     # generation so per-test GC passes stop traversing them (~10% faster suite).
+    gc.enable()
     gc.collect()
     if hasattr(gc, "freeze"):  # CPython-only; missing on PyPy
         gc.freeze()


### PR DESCRIPTION
Last of this series. Smallest speedup, but a trivial change.

Here's the :robot: summary when the changes were stacked:

| Commit    | Change                                                   | Time after |
| --------- | -------------------------------------------------------- | ---------- |
| `f4fd59f` | `--capture=sys` — skip per-test fd dup2/lseek syscalls   | 13.15s     |
| `b86fbea` | Disable the logging plugin, drop `log_level`             | 11.63s     |
| `5cdb087` | Hook-based cache clearing instead of the autouse fixture | 11.02s     |
| `b3ccbe3` | GC disabled during collection, re-enabled at the freeze  | 10.92s     |

Baseline was 16.5s, so the stack lands at **10.92s (−34%)**



:robot: _AI text below_ :robot:

GC passes during collection of 62k items are ~3.5% of the runtime in the sampling profile, and nearly everything allocated there is long-lived and about to be frozen by the existing `pytest_collection_finish` hook anyway. Disable GC when collection starts and re-enable it just before the collect-and-freeze.

Local run: 16.5s -> 16.2s.

One of four independent test-suite speedup PRs from the same profiling session (Python 3.15 sampling profiler). Extends #1385.