### PR TITLE
perf(tests): disable more unused pytest plugins

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -316,7 +316,10 @@ def downstream(session: nox.Session, project: str) -> None:
         data = resp.read()
     with tarfile.open(fileobj=io.BytesIO(data), mode="r:gz") as tf:
         tf.extractall(project)
-    (inner_dir,) = Path(project).iterdir()
+    project_path = Path(project)
+    (inner_dir,) = project_path.iterdir()
+    # Make sure pytest doesn't keep searching upwards for config
+    project_path.joinpath("pytest.ini").touch()
     session.chdir(inner_dir)
 
     pip_cmd = ["uv", "pip"] if session.venv_backend == "uv" else ["pip"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,29 +97,22 @@ exclude_also = [
 
 [tool.pytest.ini_options]
 minversion = "6.2"
-# --capture=sys avoids per-test fd dup2/lseek syscalls (~20% of the runtime);
-# no test writes to raw file descriptors. The logging plugin is disabled since
-# no test uses caplog and its per-test setup is measurable at this test count.
-# threadexception wraps every test phase in catch contexts and forces several
-# gc.collect() passes at shutdown; the suite spawns no threads. tmpdir and
-# legacypath are unused (no test uses tmp_path or tmpdir) and only add
-# per-hook dispatch cost.
 addopts = [
     "-ra",
     "--showlocals",
     "--strict-markers",
     "--strict-config",
     "-m",
-    "not property",
-    "--capture=sys",
+    "not property",        # property based tests opt-in only
+    "--capture=sys",       # avoids per-test fd dup2/lseek syscalls (~20% of the runtime)
     "-p",
-    "no:logging",
+    "no:logging",          # no test uses caplog and its per-test setup is measurable
     "-p",
-    "no:threadexception",
+    "no:threadexception",  # no threads, avoids extra gc
     "-p",
-    "no:tmpdir",
+    "no:tmpdir",           # no usage of tempdir (mostly sans IO)
     "-p",
-    "no:legacypath",
+    "no:legacypath",       # no legacy paths
 ]
 xfail_strict = true
 filterwarnings = ["error"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,11 @@ minversion = "6.2"
 # --capture=sys avoids per-test fd dup2/lseek syscalls (~20% of the runtime);
 # no test writes to raw file descriptors. The logging plugin is disabled since
 # no test uses caplog and its per-test setup is measurable at this test count.
+# threadexception wraps every test phase in catch contexts and forces several
+# gc.collect() passes at shutdown; the suite spawns no threads. tmpdir and
+# legacypath are unused (no test uses tmp_path or tmpdir) and only add
+# per-hook dispatch cost. unraisableexception stays enabled to catch
+# __del__/finalizer bugs.
 addopts = [
     "-ra",
     "--showlocals",
@@ -110,6 +115,12 @@ addopts = [
     "--capture=sys",
     "-p",
     "no:logging",
+    "-p",
+    "no:threadexception",
+    "-p",
+    "no:tmpdir",
+    "-p",
+    "no:legacypath",
 ]
 xfail_strict = true
 filterwarnings = ["error"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,8 +103,7 @@ minversion = "6.2"
 # threadexception wraps every test phase in catch contexts and forces several
 # gc.collect() passes at shutdown; the suite spawns no threads. tmpdir and
 # legacypath are unused (no test uses tmp_path or tmpdir) and only add
-# per-hook dispatch cost. unraisableexception stays enabled to catch
-# __del__/finalizer bugs.
+# per-hook dispatch cost.
 addopts = [
     "-ra",
     "--showlocals",


### PR DESCRIPTION
Also fixes leaks of pytest configuration into the downstream tests by dropping a pytest.ini one level above the repo.

We could also drop unraisableexception, but that one's pretty easy to trigger by mistake, so best to keep it, I think.


This drops:

* `threadexception`: we should not be making threads anyway
* `tmpdir`: no IO means no reason to make tmpdir's
* `legacypath`: I'd forgotten we can opt out, that's great even if it didn't also save time.

This saves about 0.5s or so out of 11s or so. For the full parallel no coverage run, it's 22s -> 21s.

:robot: _AI text below_ :robot:

Disable three more builtin pytest plugins that this suite does not use:

- `threadexception` wraps every test phase in catch contexts and forces several `gc.collect()` passes at shutdown; the suite spawns no threads.
- `tmpdir` and `legacypath` back fixtures no test uses (`tmp_path`/`tmpdir`) and only add per-hook dispatch cost.

The `unraisableexception` plugin stays enabled to catch `__del__`/finalizer bugs. This saves approximately 3% of the suite runtime (measured with a sampling profiler; test bodies are a small fraction of total wall time at this test count).