### PR TITLE
perf(tests): skip coverage on 3.13t

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import argparse
 import contextlib
 import datetime
 import difflib
@@ -48,6 +49,10 @@ PYTHON_VERSIONS = nox.project.python_versions(PYPROJECT)
 # binaries so uv/pip picks the newest version with a compatible wheel instead.
 HYPOTHESIS_BINARY_ONLY = ("--only-binary", "hypothesis")
 
+# Interpreters that run the tests without coverage, because tracing is too slow
+# there: PyPy, and free-threaded 3.13, which has no fast C tracer.
+NO_COVERAGE = {"pypy", "3.13t"}
+
 
 @nox.session(
     python=[
@@ -64,15 +69,24 @@ def tests(session: nox.Session) -> None:
     """
     Run the tests, with coverage.
     """
+    assert session.python is not None
+    assert not isinstance(session.python, bool)
+
+    parser = argparse.ArgumentParser(prog="nox -s tests --")
+    parser.add_argument(
+        "--coverage",
+        action=argparse.BooleanOptionalAction,
+        default=not any(x in session.python for x in NO_COVERAGE),
+        help="Run the tests under coverage.",
+    )
+    args, posargs = parser.parse_known_args(session.posargs)
+
     coverage = ["python", "-m", "coverage"]
 
     session.install(
         *HYPOTHESIS_BINARY_ONLY, *nox.project.dependency_groups(PYPROJECT, "test")
     )
     session.install("-e.")
-
-    assert session.python is not None
-    assert not isinstance(session.python, bool)
 
     # Give each session its own data file so parallel sessions don't fight over
     # the default ".coverage".
@@ -84,24 +98,23 @@ def tests(session: nox.Session) -> None:
     # via pyproject.toml. Run the regular test suite normally; property tests can be
     # run explicitly with `pytest -m property` or the `property_tests` nox session.
 
-    if "pypy" not in session.python:
+    if args.coverage:
         session.run(
             *coverage,
             "run",
             "-m",
             "pytest",
-            *session.posargs,
+            *posargs,
             env=env,
         )
         session.run(*coverage, "report", env=env)
     else:
-        # Don't do coverage tracking for PyPy, since it's SLOW.
         session.run(
             "python",
             "-m",
             "pytest",
             "--capture=no",
-            *session.posargs,
+            *posargs,
         )
 
 


### PR DESCRIPTION
Our 3.13t job is reallllly slow (8 mins on CI). This brings it in line with the others, under 2 mins. No need to check coverage on every job, they all report 100% (not combined later, in other words).

Also now support turning off (or on) coverage from nox.

```console
$ nox -s tests -j 12
...
nox > Ran 11 sessions in 41 seconds:
nox > * tests-3.10: success, took 40 seconds
nox > * tests-3.11: success, took 41 seconds
nox > * tests-3.12: success, took 31 seconds
nox > * tests-3.13: success, took 32 seconds
nox > * tests-3.14: success, took 19 seconds
nox > * tests-3.15: success, took 16 seconds
nox > * tests-3.13t: success, took 29 seconds
nox > * tests-3.14t: success, took 27 seconds
nox > * tests-3.15t: success, took 25 seconds
nox > * tests-pypy3.10: success, took 24 seconds
nox > * tests-pypy3.11: success, took 21 seconds

$ nox -s tests -j 12 -- --no-coverage
...
nox > Ran 11 sessions in 22 seconds:
nox > * tests-3.10: success, took 18 seconds
nox > * tests-3.11: success, took 15 seconds
nox > * tests-3.12: success, took 14 seconds
nox > * tests-3.13: success, took 15 seconds
nox > * tests-3.14: success, took 16 seconds
nox > * tests-3.15: success, took 15 seconds
nox > * tests-3.13t: success, took 21 seconds
nox > * tests-3.14t: success, took 16 seconds
nox > * tests-3.15t: success, took 16 seconds
nox > * tests-pypy3.10: success, took 14 seconds
nox > * tests-pypy3.11: success, took 13 seconds

$ nox -s tests -j 12 -- --coverage
...
nox > Ran 11 sessions in 2 minutes:
nox > * tests-3.10: success, took 35 seconds
nox > * tests-3.11: success, took 34 seconds
nox > * tests-3.12: success, took 30 seconds
nox > * tests-3.13: success, took 32 seconds
nox > * tests-3.14: success, took 17 seconds
nox > * tests-3.15: success, took 16 seconds
nox > * tests-3.13t: success, took 2 minutes
nox > * tests-3.14t: success, took 17 seconds
nox > * tests-3.15t: success, took 17 seconds
nox > * tests-pypy3.10: failed, took a minute
nox > * tests-pypy3.11: failed, took 2 minutes
```

(FWIW, here's the PyPy missing coverage:
```
src/packaging/tags.py                  397      0    220      4    99%   916->918, 918->920, 920->922, 922->924
```
)

:robot: _AI text below_ :robot:

Free-threaded 3.13 has no fast C tracer, so coverage tracking there is as slow as on PyPy.

The hardcoded PyPy check in the `tests` session becomes a `NO_COVERAGE` default (`pypy`, `3.13t`) plus a `--coverage`/`--no-coverage` flag, so any session can turn coverage on or off:

```
nox -s tests-3.13t -- --coverage
nox -s tests-3.13 -- --no-coverage
```