### PR TITLE
fix(ranges): stop unbounded bounds sorting above each other

### DIFF
--- a/src/packaging/_ranges.py
+++ b/src/packaging/_ranges.py
@@ -178,7 +178,8 @@ if TYPE_CHECKING:
 class LowerBound:
     """Lower bound of a version range.
 
-    A version *v* of ``None`` means unbounded below (-inf).
+    A version *v* of ``None`` means unbounded below (-inf), with
+    ``inclusive`` forced to ``False``.
     At equal versions, ``[v`` sorts before ``(v`` because an inclusive
     bound starts earlier.
     """
@@ -186,6 +187,10 @@ class LowerBound:
     __slots__ = ("_above", "inclusive", "version")
 
     def __init__(self, version: _VersionOrBoundary, inclusive: bool) -> None:
+        # Two spellings of -inf would sort above each other under total_ordering.
+        if version is None:
+            inclusive = False
+
         self.version = version
         self.inclusive = inclusive
         # Pre-bind a predicate "is parsed at or above this lower
@@ -235,7 +240,8 @@ class LowerBound:
 class UpperBound:
     """Upper bound of a version range.
 
-    A version *v* of ``None`` means unbounded above (+inf).
+    A version *v* of ``None`` means unbounded above (+inf), with
+    ``inclusive`` forced to ``False``.
     At equal versions, ``v)`` sorts before ``v]`` because an exclusive
     bound ends earlier.
     """
@@ -243,6 +249,10 @@ class UpperBound:
     __slots__ = ("_below", "inclusive", "version")
 
     def __init__(self, version: _VersionOrBoundary, inclusive: bool) -> None:
+        # Two spellings of +inf would sort above each other under total_ordering.
+        if version is None:
+            inclusive = False
+
         self.version = version
         self.inclusive = inclusive
         # Pre-bind a predicate "is parsed at or below this upper

--- a/tests/test_ranges.py
+++ b/tests/test_ranges.py
@@ -6,7 +6,14 @@ from __future__ import annotations
 
 import pytest
 
-from packaging._ranges import BoundaryKind, BoundaryVersion
+from packaging._ranges import (
+    NEG_INF,
+    POS_INF,
+    BoundaryKind,
+    BoundaryVersion,
+    LowerBound,
+    UpperBound,
+)
 from packaging.ranges import _MAX_EXCLUSION_RUN, VersionRange
 from packaging.specifiers import Specifier, SpecifierSet
 from packaging.version import InvalidVersion, Version
@@ -1822,6 +1829,36 @@ class TestBoundaryCanonicalization:
         # ``1.0a2`` is not a boundary successor, so ``>=1.0a2`` stays plain.
         assert "1.0a2" in repr(vr(">=1.0a2"))
         assert "AFTER" not in repr(vr(">=1.0a2"))
+
+
+class TestUnboundedEnds:
+    """An unbounded end has one spelling: ``inclusive`` is not part of it."""
+
+    def test_lower_spellings_are_one_bound(self) -> None:
+        bound = LowerBound(None, True)
+        assert bound.inclusive is False
+
+        assert bound == LowerBound(None, False) == NEG_INF
+        assert hash(bound) == hash(NEG_INF)
+        assert len({bound, NEG_INF}) == 1
+
+    def test_upper_spellings_are_one_bound(self) -> None:
+        bound = UpperBound(None, True)
+        assert bound.inclusive is False
+
+        assert bound == UpperBound(None, False) == POS_INF
+        assert hash(bound) == hash(POS_INF)
+        assert len({bound, POS_INF}) == 1
+
+    def test_lower_ends_order_as_one_value(self) -> None:
+        a, b = LowerBound(None, True), LowerBound(None, False)
+        assert (a < b, a > b, a <= b, a >= b) == (False, False, True, True)
+        assert (b < a, b > a, b <= a, b >= a) == (False, False, True, True)
+
+    def test_upper_ends_order_as_one_value(self) -> None:
+        a, b = UpperBound(None, True), UpperBound(None, False)
+        assert (a < b, a > b, a <= b, a >= b) == (False, False, True, True)
+        assert (b < a, b > a, b <= a, b >= a) == (False, False, True, True)
 
 
 class TestEmptyMatchesUnsatisfiable:


### PR DESCRIPTION
Minor bug in private `LowerBound` and `UpperBound`, not exposed to end user.