### PR TITLE
Restore packaging.version.NegativeInfinity compatibility

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,12 @@ Changelog
 *unreleased*
 ~~~~~~~~~~~~
 
+Fixes:
+
+* Restore ``packaging.version.NegativeInfinity`` as a compatibility alias.
+  New code should use public ``Version`` APIs instead of comparison sentinels.
+  (:issue:`1363`)
+
 Removals:
 
 * Drop support for EOL Python 3.9. (:pull:`1263`)

--- a/src/packaging/version.py
+++ b/src/packaging/version.py
@@ -21,6 +21,10 @@ from typing import (
     TypedDict,
 )
 
+from . import _structures
+
+NegativeInfinity = _structures.NegativeInfinity
+
 if typing.TYPE_CHECKING:
     from typing_extensions import Self, Unpack
 

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -13,6 +13,7 @@ import typing
 import pretend
 import pytest
 
+import packaging.version
 from packaging._structures import Infinity, NegativeInfinity
 from packaging.version import (
     InvalidVersion,
@@ -49,6 +50,11 @@ def test_parse() -> None:
 def test_parse_raises() -> None:
     with pytest.raises(InvalidVersion):
         parse("lolwat")
+
+
+def test_negative_infinity_compatibility_alias() -> None:
+    assert packaging.version.NegativeInfinity is NegativeInfinity
+    assert repr(packaging.version.NegativeInfinity) == "-Infinity"
 
 
 # This list must be in the correct sorting order


### PR DESCRIPTION
Restores `packaging.version.NegativeInfinity` as a module-level alias of the existing `packaging._structures.NegativeInfinity` sentinel, preserving its identity and `-Infinity` representation.

Adds a regression test asserting the alias identity and representation, and adds an unreleased changelog entry describing the compatibility restoration and guidance to use public `Version` APIs.

Verification: `python3 -m nox -s lint -- --show-diff-on-failure` passed, including Ruff, mypy, documentation checks, and package build/twine validation.

The focused `python3 -m pytest tests/test_version.py::test_negative_infinity_compatibility_alias` command did not execute the assertion because test collection raised an `ImportError` for `packaging.markers._cached_default_environment`; baseline and patched checkouts showed the same failure.

<!-- oss-autonomy-ba2b89dbfc310fd51398da969b4fe793a43a05bfc12e6683078200384abb1c99 -->