### PR TITLE
Add candidate-extra evaluation to Marker.evaluate

### DIFF
--- a/docs/markers.rst
+++ b/docs/markers.rst
@@ -24,6 +24,9 @@ Usage
     >>> env = {'python_version': '1.5'}
     >>> marker.evaluate(environment=env)
     False
+    >>> # Check whether a marker applies to any of several candidate extras
+    >>> Marker('extra == "docs"').evaluate(extras={'docs', 'tests'})
+    True
     >>> # Multiple markers can be ANDed
     >>> and_marker = Marker("os_name=='a' and os_name=='b'")
     >>> and_marker
@@ -42,6 +45,26 @@ Usage
     >>> markers1 = {Marker("python_version > '3.6'"), Marker('os_name == "unix"')}
     >>> markers2 = {Marker('os_name == "unix"'), Marker("python_version > '3.6'")}
     >>> markers1 == markers2
+    True
+
+When evaluating a marker for a set of candidate extras, pass the set with the
+keyword-only ``extras`` argument. The complete marker expression is evaluated
+independently for each candidate, and the result is ``True`` if any candidate
+matches. Extra names are normalized according to PEP 685; an empty set
+returns ``False``. When both ``extras`` and ``environment['extra']`` are
+provided, the candidate set takes precedence over the scalar environment value.
+This argument is separate from the set-valued ``extras`` and
+``dependency_groups`` marker names used with membership operators.
+
+This is useful when checking a dependency marker against the extras requested
+by a :class:`~packaging.requirements.Requirement`:
+
+.. doctest::
+
+    >>> from packaging.requirements import Requirement
+    >>> requested = Requirement("a[b,c]")
+    >>> dependency = Requirement("foo; extra == 'b'")
+    >>> dependency.marker.evaluate(extras=requested.extras)
     True
 
 Combining markers programmatically

--- a/src/packaging/markers.py
+++ b/src/packaging/markers.py
@@ -506,6 +506,8 @@ class Marker:
         self,
         environment: Mapping[str, str | AbstractSet[str]] | None = None,
         context: EvaluateContext = "metadata",
+        *,
+        extras: AbstractSet[str] | None = None,
     ) -> bool:
         """Evaluate a marker.
 
@@ -519,6 +521,11 @@ class Marker:
             evaluated, which influences what marker names are considered valid.
             Accepted values are ``"metadata"`` (for core metadata; default),
             ``"lock_file"``, and ``"requirement"`` (i.e. all other situations).
+        :param extras: Candidate extra names to use when evaluating the marker.
+            The complete marker is evaluated independently for each candidate,
+            and the result is ``True`` if any candidate matches. Candidate names
+            are normalized according to PEP 685. When supplied, this takes
+            precedence over the scalar ``"extra"`` value in ``environment``.
         :raises UndefinedComparison: If the marker uses a comparison on values
             that are not valid versions per the :ref:`specification of version
             specifiers <pypug:version-specifiers>`.
@@ -543,6 +550,7 @@ class Marker:
 
         if environment is not None:
             current_environment |= environment
+        if extras is None:
             if "extra" in current_environment:
                 # The API used to allow setting extra to None. We need to handle
                 # this case for backwards compatibility. Also skip running
@@ -550,8 +558,18 @@ class Marker:
                 extra = cast("str | None", current_environment["extra"])
                 current_environment["extra"] = canonicalize_name(extra) if extra else ""
 
-        return _evaluate_markers(
-            self._markers, _repair_python_full_version(current_environment)
+            return _evaluate_markers(
+                self._markers, _repair_python_full_version(current_environment)
+            )
+
+        normalized_extras = {canonicalize_name(extra) for extra in extras}
+        if not normalized_extras:
+            return False
+
+        repaired_environment = _repair_python_full_version(current_environment)
+        return any(
+            _evaluate_markers(self._markers, repaired_environment | {"extra": extra})
+            for extra in normalized_extras
         )
 
 

--- a/tests/test_markers.py
+++ b/tests/test_markers.py
@@ -24,6 +24,7 @@ from packaging.markers import (
     _format_full_version,
     default_environment,
 )
+from packaging.requirements import Requirement
 
 VARIABLES = [
     "extra",
@@ -376,6 +377,25 @@ class TestMarker:
         marker = Marker("os_name == 'foo'")
         assert marker.evaluate({"os_name": "foo"}, context="requirement")
         assert not marker.evaluate({"os_name": "bar"}, context="requirement")
+
+    def test_evaluate_against_candidate_extras(self) -> None:
+        requirement = Requirement("a[b,c]")
+        dependency = Requirement("foo; extra == 'b'")
+        assert dependency.marker is not None
+
+        assert dependency.marker.evaluate(extras=requirement.extras)
+        assert not dependency.marker.evaluate(extras={"d"})
+        assert not dependency.marker.evaluate(extras=set())
+
+    def test_candidate_extras_are_normalized_and_use_whole_expression(self) -> None:
+        marker = Marker(
+            'extra == "Foo_Bar" and python_version >= "3" and extra != "baz"'
+        )
+
+        assert marker.evaluate(
+            {"python_version": "3.12", "extra": "ignored"}, extras={"FOO.BAR"}
+        )
+        assert not Marker('extra == "a" and extra == "b"').evaluate(extras={"a", "b"})
 
     @pytest.mark.parametrize(
         ("marker_string", "environment", "expected"),


### PR DESCRIPTION
Adds a keyword-only `extras` parameter to `Marker.evaluate` for evaluating a marker against candidate extras. The complete marker expression is evaluated independently for each candidate, names are normalized with existing PEP 685 rules, an empty set returns `False`, and the candidate set takes precedence over `environment['extra']`; existing scalar evaluation and `extras`/`dependency_groups` membership behavior remain unchanged.

Adds focused tests for the issue's `Requirement("a[b,c]")` / `extra == 'b'` example, normalization, empty and nonmatching sets, and whole-expression conjunctions, plus documentation in `docs/markers.rst`.

`git diff --check` and the repository `lint` session passed. The focused candidate-extra assertions passed in completed test sessions, but the broader `tests` nox command exceeded its runtime budget and did not complete; its selective coverage report also failed the repository's 100% threshold, so the full suite result is inconclusive.

<!-- oss-autonomy-83a5312995df04110d09d9071d068fe9d85f96915ba809c9a23356c3e0ad0537 -->