### PR TITLE
Have interfaces for platform_tag(), abi_tag(), and python_tag() for the host python

### DIFF
--- a/docs/tags.rst
+++ b/docs/tags.rst
@@ -46,6 +46,12 @@ items that applications should need to reference, in order to parse and check ta
 
 .. autofunction:: sys_tags
 
+.. autofunction:: python_tag
+
+.. autofunction:: abi_tag
+
+.. autofunction:: platform_tag
+
 .. autofunction:: create_compatible_tags_selector
 
 .. autoexception:: TooManyTagsError

--- a/src/packaging/tags.py
+++ b/src/packaging/tags.py
@@ -35,6 +35,7 @@ __all__ = [
     "Tag",
     "TooManyTagsError",
     "UnsortedTagsError",
+    "abi_tag",
     "android_platforms",
     "compatible_tags",
     "cpython_tags",
@@ -46,8 +47,10 @@ __all__ = [
     "ios_platforms",
     "mac_platforms",
     "parse_tag",
+    "platform_tag",
     "platform_tags",
     "pure_python_tags",
+    "python_tag",
     "sys_tags",
 ]
 
@@ -971,6 +974,33 @@ def interpreter_abi() -> str:
     if interpreter_name() == "cp":
         return next(iter(_cpython_abis(sys.version_info[:2])))
     return next(iter(_generic_abi()))
+
+
+def platform_tag() -> str:
+    """
+    Returns the first platform tag for the running interpreter.
+
+    .. versionadded:: 26.4
+    """
+    return next(iter(platform_tags()))
+
+
+def abi_tag() -> str:
+    """
+    Returns the ABI tag for the running interpreter.
+
+    .. versionadded:: 26.4
+    """
+    return interpreter_abi()
+
+
+def python_tag() -> str:
+    """
+    Returns the interpreter tag for the running interpreter.
+
+    .. versionadded:: 26.4
+    """
+    return interpreter_name() + interpreter_version()
 
 
 def sys_tags(*, warn: bool = False) -> Iterator[Tag]:

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -2202,3 +2202,17 @@ def test_interpreter_abi(monkeypatch: pytest.MonkeyPatch) -> None:
     assert (
         tags.interpreter_abi() == f"cp{sys.version_info.major}{sys.version_info.minor}"
     )
+
+
+def test_host_tag_accessors(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(tags, "interpreter_name", lambda: "zz")
+    monkeypatch.setattr(tags, "interpreter_version", lambda: "123")
+    monkeypatch.setattr(tags, "interpreter_abi", lambda: "zzabi")
+    monkeypatch.setattr(
+        tags, "platform_tags", lambda: iter(["first_platform", "second_platform"])
+    )
+
+    assert tags.python_tag() == "zz123"
+    assert tags.abi_tag() == "zzabi"
+    assert tags.platform_tag() == "first_platform"
+    assert {"python_tag", "abi_tag", "platform_tag"} <= set(tags.__all__)


### PR DESCRIPTION
Adds public `platform_tag()`, `abi_tag()`, and `python_tag()` accessors to `packaging.tags`, delegating to existing canonical computations and exporting all three through `__all__`.

Adds deterministic delegation tests in `tests/test_tags.py` and API autodoc entries in `docs/tags.rst`.

Verification: the focused tags runs reported 239 tests passed on each CPython version exercised and 237 passed with 1 skipped on PyPy 3.10; the patched `tags.py` reached 100% coverage. `nox -s lint` and `nox -s docs` completed successfully. The multi-version focused nox command timed out while the repository-wide 100% coverage threshold was applied, so that result is inconclusive rather than a passing full-suite result.

<!-- oss-autonomy-0662e0746a91f9ab5cb20ee4be6f37feae908108c6ba8c69148937744bd6c9ee -->