### PR TITLE
Warn when python_version markers aren't valid PEP 440 versions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,12 @@ Removals:
 
 * Drop support for EOL Python 3.9. (:pull:`1263`)
 
+Fixes for requirements and markers:
+
+* Warn when ``python_version`` / ``python_full_version`` marker comparisons
+  fall back to string comparison because the right-hand side is not a valid
+  PEP 440 version (for example ``"3.9."``). (:issue:`633`)
+
 26.3 - 2026-08-03
 ~~~~~~~~~~~~~~~~~
 

--- a/src/packaging/markers.py
+++ b/src/packaging/markers.py
@@ -9,6 +9,7 @@ import operator
 import os
 import platform
 import sys
+import warnings
 from collections.abc import Callable
 from collections.abc import Set as AbstractSet
 from typing import TYPE_CHECKING, Literal, TypedDict, cast
@@ -248,7 +249,15 @@ def _eval_op(lhs: str, op: Op, rhs: str | AbstractSet[str], *, key: str) -> bool
         try:
             spec = Specifier(f"{op_str}{rhs}")
         except InvalidSpecifier:
-            pass
+            if (
+                key in {"python_version", "python_full_version"}
+                and op_str in {"<", "<=", "==", "!=", ">=", ">"}
+            ):
+                warnings.warn(
+                    f"marker {key} {op_str} {rhs!r} is not a valid PEP 440 "
+                    "version; falling back to string comparison",
+                    stacklevel=3,
+                )
         else:
             return spec.contains(lhs, prereleases=True)
 

--- a/src/packaging/markers.py
+++ b/src/packaging/markers.py
@@ -251,7 +251,16 @@ def _eval_op(lhs: str, op: Op, rhs: str | AbstractSet[str], *, key: str) -> bool
         except InvalidSpecifier:
             if (
                 key in {"python_version", "python_full_version"}
-                and op_str in {"<", "<=", "==", "!=", ">=", ">"}
+                and op_str
+                in {
+                    "<",
+                    "<=",
+                    "==",
+                    "!=",
+                    ">=",
+                    ">",
+                }
+                and any(ch.isdigit() for ch in str(rhs))
             ):
                 warnings.warn(
                     f"marker {key} {op_str} {rhs!r} is not a valid PEP 440 "

--- a/tests/test_markers.py
+++ b/tests/test_markers.py
@@ -537,6 +537,12 @@ class TestMarker:
             {"python_full_version": "3.11.1+"}
         )
 
+    def test_invalid_python_version_marker_warns(self) -> None:
+        marker = Marker('python_version >= "3.9."')
+        with pytest.warns(UserWarning, match="not a valid PEP 440"):
+            result = marker.evaluate({"python_version": "3.10"})
+        assert result is False
+
     def test_python_full_version_untagged(self) -> None:
         with mock.patch("platform.python_version", return_value="3.11.1+"):
             assert Marker("python_full_version < '3.12'").evaluate()


### PR DESCRIPTION
`python_version >= "3.9."` isn't a PEP 440 version, so the comparison currently falls back to string compare with no indication (and `"3.10" >= "3.9."` is False).

Warn for `< <= == != >= >` on `python_version` / `python_full_version` when that happens. `in` / `not in` and `platform_release` are unchanged.

Fixes #633