### PR TITLE
fix(markers): reject backslashes in marker values

### DIFF
--- a/src/packaging/_parser.py
+++ b/src/packaging/_parser.py
@@ -394,6 +394,8 @@ def process_env_var(env_var: str) -> Variable:
 
 
 def process_python_str(python_str: str) -> Value:
+    if "\\" in python_str:
+        raise ValueError("Backslashes are not allowed in marker values")
     value = ast.literal_eval(python_str)
     return Value(str(value))
 

--- a/tests/test_markers.py
+++ b/tests/test_markers.py
@@ -267,6 +267,21 @@ class TestMarker:
         assert ctx.exconly() == expected
 
     @pytest.mark.parametrize(
+        "marker_string",
+        [
+            r'sys_platform == "linu\x78"',
+            r'sys_platform == "linu\\x78"',
+            r"sys_platform == 'linu\x78'",
+            r"sys_platform == 'linu\\x78'",
+        ],
+    )
+    def test_parses_invalid_quoted_string_with_backslash(
+        self, marker_string: str
+    ) -> None:
+        with pytest.raises(InvalidMarker):
+            Marker(marker_string)
+
+    @pytest.mark.parametrize(
         ("marker_string", "expected"),
         [
             # Test the different quoting rules

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1170,6 +1170,21 @@ class TestMetadataWriting:
             written == "metadata-version: 2.6\nname: packaging\nversion: 2023.0.0\n\n"
         )
 
+    def test_write_metadata_rejects_marker_value_with_backslash(self) -> None:
+        meta = metadata.Metadata.from_email(
+            "Metadata-Version: 2.1\n"
+            "Name: demo\n"
+            "Version: 1.0\n"
+            'Requires-Dist: evil-dep; sys_platform == "linu\\\\x78"\n',
+            validate=False,
+        )
+
+        with pytest.raises(metadata.InvalidMetadata) as exc_info:
+            meta.as_rfc822()
+
+        assert exc_info.value.field == "requires-dist"
+        assert isinstance(exc_info.value.__cause__, requirements.InvalidRequirement)
+
     def test_write_metadata_with_description(self) -> None:
         # Intentionally out of order to make sure it is written in order
         meta = metadata.Metadata.from_raw(


### PR DESCRIPTION
Fixes #1399.

Backslashes are currently accepted in quoted marker values, but they are interpreted as Python string escapes during parsing and emitted without escaping during serialization. As a result, a marker can change meaning after `str(marker)` and reparsing.

Reject unsupported backslashes while parsing marker values, following the marker grammar and the guidance in #1399. This prevents invalid input from silently changing semantics during serialization while preserving the existing output for valid markers.

Tests:

- Added marker parsing regressions for single and double quotes with one and two backslashes.
- Added a metadata serialization regression for `Metadata.as_rfc822()`.
- The full test suite and property tests pass locally.
- Ruff, targeted mypy checks, build, and `twine check --strict` pass locally.